### PR TITLE
e2e-tests: Connect to VM without SSH key

### DIFF
--- a/e2e-tests/vm/cloud-init-template-noble.yaml
+++ b/e2e-tests/vm/cloud-init-template-noble.yaml
@@ -9,12 +9,10 @@ users:
     groups: sudo
     homedir: /home/ubuntu
     shell: /bin/bash
-    ssh_authorized_keys:
-      - ${SSH_PUBLIC_KEY}
 chpasswd:
   expire: false
   users:
-    - {name: ubuntu, password: ubuntu, type: text}
+    - {name: ubuntu, password: '', type: text}
 
 package_update: true
 package_upgrade: true
@@ -67,6 +65,11 @@ write_files:
       UsePAM yes
       Match User *@*
           KbdInteractiveAuthentication yes
+
+  - path: /etc/ssh/sshd_config.d/password-auth.conf
+    content: |
+      PermitEmptyPasswords yes
+      PasswordAuthentication yes
 
   # Bind sshd to VSOCK socket
   - path: /etc/systemd/system/sshd-vsock.service

--- a/e2e-tests/vm/cloud-init-template-questing.yaml
+++ b/e2e-tests/vm/cloud-init-template-questing.yaml
@@ -9,12 +9,10 @@ users:
     groups: sudo
     homedir: /home/ubuntu
     shell: /bin/bash
-    ssh_authorized_keys:
-      - ${SSH_PUBLIC_KEY}
 chpasswd:
   expire: false
   users:
-    - {name: ubuntu, password: ubuntu, type: text}
+    - {name: ubuntu, password: '', type: text}
 
 package_update: true
 package_upgrade: true

--- a/e2e-tests/vm/config.sh.template
+++ b/e2e-tests/vm/config.sh.template
@@ -1,7 +1,6 @@
 # Provisioning configuration file for authd end-to-end tests
 # Copy this template to config.sh and customize the values for your environment.
 
-export SSH_PUBLIC_KEY_FILE="${HOME}/.ssh/id_rsa.pub"
 export VM_NAME_BASE=e2e-runner
 export RELEASE=questing
 export BROKERS=authd-msentraid,authd-google

--- a/e2e-tests/vm/provision-ubuntu.sh
+++ b/e2e-tests/vm/provision-ubuntu.sh
@@ -71,18 +71,7 @@ fi
 # shellcheck source=lib/libprovision.sh
 source "${LIB_DIR}/libprovision.sh"
 
-assert_env_vars RELEASE VM_NAME_BASE SSH_PUBLIC_KEY_FILE
-
-# Validate SSH public key file
-if [ ! -f "${SSH_PUBLIC_KEY_FILE}" ]; then
-    echo "SSH public key file not found: ${SSH_PUBLIC_KEY_FILE}"
-    exit 1
-fi
-
-if [[ "${SSH_PUBLIC_KEY_FILE}" != *.pub ]]; then
-    echo "SSH public key file must have a .pub extension"
-    exit 1
-fi
+assert_env_vars RELEASE VM_NAME_BASE
 
 # Cache sudo password early
 sudo -v
@@ -163,7 +152,7 @@ if [ ! -f "${CLOUD_INIT_ISO}" ]; then
         SOCAT_ADDRESS="TCP-LISTEN:55000,bind=0.0.0.0,reuseaddr"
     fi
 
-    SSH_PUBLIC_KEY=$(cat "${SSH_PUBLIC_KEY_FILE}") \
+    env \
       SOCAT_ADDRESS="${SOCAT_ADDRESS}" \
       envsubst < "${CLOUD_INIT_TEMPLATE}" > "${CLOUD_INIT_DIR}/user-data"
 

--- a/e2e-tests/vm/ssh.sh
+++ b/e2e-tests/vm/ssh.sh
@@ -4,20 +4,19 @@ set -euo pipefail
 
 usage(){
     cat << EOF
+Usage: $0 --release <release> [ssh options]
 
-    Usage: $0 --release <release> [ssh options]
+SSH into the e2e-test VM for the specified Ubuntu release.
 
-    SSH into the e2e-test VM for the specified Ubuntu release.
-
-    Example:
-      $0 --release questing
+Example:
+    $0 --release questing
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         -h|--help)
-            print_usage
+            usage
             exit 0
             ;;
         --release|-r)


### PR DESCRIPTION
The SSH public key setup made things complex and caused the tests to fail on Dependabot PRs because the CI secrets are not available there.

Let's simplify things and just allow SSH connections to the VM without an SSH key or password.
