### PR TITLE
Explicitly define our Rust MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["nss/"]
 exclude = ["vendor_rust/", "authd-oidc-brokers/third_party/libhimmelblau/", "parts/libhimmelblau/build"]
-resolver = "2"
+resolver = "3"
 
 [profile.release]
 lto = "thin"

--- a/debian/rules
+++ b/debian/rules
@@ -66,7 +66,20 @@ export BUILT_PAM_LIBS_PATH := obj-$(DEB_HOST_GNU_TYPE)/src/$(AUTHD_GO_PACKAGE)/p
 
 override_dh_auto_clean:
 	dh_auto_clean
-	dh_auto_clean --buildsystem=cargo
+
+	# 'dh_auto_clean --buildsystem=cargo' calls /usr/share/cargo/bin/cargo.
+	# If the cargo in $PATH is the one from /usr/share/cargo/bin/cargo,
+	# then we can just call 'dh_auto_clean --buildsystem=cargo'.
+	# Otherwise, we need to do what 'dh_auto_clean --buildsystem=cargo' does
+	# ourselves, but using the cargo in $PATH.
+	if [ "$$(command -v cargo)" = "/usr/share/cargo/bin/cargo" ]; then \
+		dh_auto_clean --buildsystem=cargo; \
+	else \
+		touch --no-create --date='@$(SOURCE_DATE_EPOCH)' .cargo_vcs_info.json; \
+		cargo clean --verbose --verbose; \
+		rm -f .cargo-checksum.json; \
+		rm -rf debian/cargo_registry; \
+	fi
 
 	# Vendor Go dependencies when building the source package
 	[ -d vendor/ ] || go mod vendor

--- a/debian/tests/run-tests.sh
+++ b/debian/tests/run-tests.sh
@@ -2,6 +2,8 @@
 
 set -exuo pipefail
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
 # Skip tests which depend on vhs which is not available in the build environment.
 export AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS=1
 
@@ -12,7 +14,7 @@ export AUTHD_SKIP_FLAKY_TESTS=1
 export GOPROXY=off
 export GOTOOLCHAIN=local
 
-PATH=$PATH:$("$(dirname "$0")"/../get-depends-go-bin-path.sh)
+PATH=$("${SCRIPT_DIR}/../get-depends-cargo-bin-paths.sh"):$("${SCRIPT_DIR}/../get-depends-go-bin-path.sh"):$PATH
 export PATH
 
 go test ./...

--- a/nss/Cargo.toml
+++ b/nss/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nss"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.91.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/nss/src/logs/mod.rs
+++ b/nss/src/logs/mod.rs
@@ -52,11 +52,12 @@ fn init_sys_logger(log_level: LevelFilter) {
         pid: std::process::id(),
     };
 
-    let logger = if let Ok(l) = syslog::unix(formatter) {
-        l
-    } else {
-        eprintln!("failed to create syslog logger");
-        return;
+    let logger = match syslog::unix(formatter) {
+        Ok(l) => l,
+        _ => {
+            eprintln!("failed to create syslog logger");
+            return;
+        }
     };
 
     if let Err(err) = log::set_boxed_logger(Box::new(BasicLogger::new(logger))) {


### PR DESCRIPTION
Supporting multiple Ubuntu versions means (possibly) supporting multiple rustc versions. Explicitly defining a MSRV helps us control how far we can bump our dependencies.


UDENG-9430