### PR TITLE
Fix selection menu shown briefly before auto-selection

### DIFF
--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -154,11 +154,13 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		}
 
 		firstAuthModeID := m.availableAuthModes[0].Id
+		selectedID := firstAuthModeID
+		if validAuthModeID(m.autoSelectedAuthModeID, m.availableAuthModes) {
+			selectedID = m.autoSelectedAuthModeID
+		}
+
 		if m.clientType != InteractiveTerminal && !m.Focused() {
-			// Preserve a deferred external selection (set before modes arrived).
-			if m.autoSelectedAuthModeID == "" {
-				m.autoSelectedAuthModeID = firstAuthModeID
-			}
+			m.autoSelectedAuthModeID = selectedID
 			return m, cmd
 		}
 
@@ -166,10 +168,6 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		// arrived (e.g. GDM client sent AuthModeSelected while stage change
 		// arrived before the mode list was fetched). Fall back to the first
 		// available mode.
-		selectedID := firstAuthModeID
-		if m.autoSelectedAuthModeID != "" && validAuthModeID(m.autoSelectedAuthModeID, m.availableAuthModes) {
-			selectedID = m.autoSelectedAuthModeID
-		}
 		m.autoSelectedAuthModeID = ""
 
 		return m, tea.Sequence(cmd, selectAuthMode(selectedID))

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -143,13 +143,18 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 
 		cmd := m.SetItems(allAuthModes)
 
-		// Autoselect first auth mode if any, as soon as we've the focus.
+		// Auto-select the first auth mode when available.
+		// For InteractiveTerminal, always select immediately because the
+		// authModeSelection stage is skipped entirely (see model.go).
+		// For GDM/Native, defer the selection until the auth mode selection
+		// stage is active (list is focused), so the stage transition completes
+		// before we request the corresponding UI layout.
 		if len(m.availableAuthModes) == 0 {
 			return m, cmd
 		}
 
 		firstAuthModeID := m.availableAuthModes[0].Id
-		if !m.Focused() {
+		if m.clientType != InteractiveTerminal && !m.Focused() {
 			m.autoSelectedAuthModeID = firstAuthModeID
 			return m, cmd
 		}

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -155,11 +155,24 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 
 		firstAuthModeID := m.availableAuthModes[0].Id
 		if m.clientType != InteractiveTerminal && !m.Focused() {
-			m.autoSelectedAuthModeID = firstAuthModeID
+			// Preserve a deferred external selection (set before modes arrived).
+			if m.autoSelectedAuthModeID == "" {
+				m.autoSelectedAuthModeID = firstAuthModeID
+			}
 			return m, cmd
 		}
 
-		return m, tea.Sequence(cmd, selectAuthMode(firstAuthModeID))
+		// When already focused, honor a pending selection from before modes
+		// arrived (e.g. GDM client sent AuthModeSelected while stage change
+		// arrived before the mode list was fetched). Fall back to the first
+		// available mode.
+		selectedID := firstAuthModeID
+		if m.autoSelectedAuthModeID != "" && validAuthModeID(m.autoSelectedAuthModeID, m.availableAuthModes) {
+			selectedID = m.autoSelectedAuthModeID
+		}
+		m.autoSelectedAuthModeID = ""
+
+		return m, tea.Sequence(cmd, selectAuthMode(selectedID))
 
 	case listItemSelected:
 		if !m.Focused() {
@@ -175,6 +188,14 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		safeMessageDebug(msg)
 		// Ensure auth mode id is valid
 		if !validAuthModeID(msg.id, m.availableAuthModes) {
+			if len(m.availableAuthModes) == 0 {
+				// Modes not yet available; the stage change arrived before the
+				// mode list was fetched (e.g. GDM/Native MFA path in model.go
+				// where changeStageCmd runs before getModesCmd). Defer this
+				// selection; it will be applied when authModesReceived fires.
+				m.autoSelectedAuthModeID = msg.id
+				return m, nil
+			}
 			log.Infof(context.TODO(), "authentication mode %q is not part of currently available authentication mode", msg.id)
 			return m, nil
 		}

--- a/pam/internal/adapter/authmodeselection_test.go
+++ b/pam/internal/adapter/authmodeselection_test.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/canonical/authd/internal/proto/authd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthModeSelectionDeferredSelectionUsesAvailableMode(t *testing.T) {
+	t.Parallel()
+
+	authModes := []*authd.GAMResponse_AuthenticationMode{
+		{Id: "first", Label: "First"},
+		{Id: "second", Label: "Second"},
+	}
+
+	tests := map[string]struct {
+		pendingID string
+		wantID    string
+	}{
+		"Falls_back_from_invalid_pending_mode": {
+			pendingID: "invalid",
+			wantID:    "first",
+		},
+		"Preserves_valid_pending_mode": {
+			pendingID: "second",
+			wantID:    "second",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := newAuthModeSelectionModel(Gdm)
+			m.autoSelectedAuthModeID = tc.pendingID
+
+			m, cmd := m.Update(authModesReceived{authModes: authModes})
+			require.Equal(t, tc.wantID, m.autoSelectedAuthModeID)
+			require.Nil(t, cmd)
+		})
+	}
+}

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -345,10 +345,33 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		return m, tea.Sequence(
-			getAuthenticationModes(m.client, m.currentSession.sessionID, m.authModeSelectionModel.SupportedUILayouts()),
-			sendEvent(ChangeStage{proto.Stage_authModeSelection}),
-		)
+		getModesCmd := getAuthenticationModes(m.client, m.currentSession.sessionID, m.authModeSelectionModel.SupportedUILayouts())
+
+		// For InteractiveTerminal, skip the authModeSelection stage entirely.
+		// The first auth mode is auto-selected immediately when modes arrive
+		// (see authModesReceived), so transitioning to the authModeSelection
+		// stage would only cause the auth mode list to flash briefly on screen
+		// before the auto-selected challenge view replaces it.
+		if m.clientType == InteractiveTerminal {
+			return m, getModesCmd
+		}
+
+		changeStageCmd := sendEvent(ChangeStage{proto.Stage_authModeSelection})
+
+		// For native/SSH mode during MFA (auth.Next), the stage is still
+		// "challenge". We need to transition through authModeSelection so
+		// that the subsequent auto-selection properly triggers a new challenge
+		// via the normal stage change path (Compose → ChangeStage{challenge}
+		// → StageChanged → nativeChallengeRequested).
+		// Stage change must happen BEFORE fetching modes, so that when
+		// authModesReceived fires the list is already focused and the
+		// immediate auto-selection is safe (no risk of the deferred
+		// ChangeStage{authModeSelection} pulling us back after challenge starts).
+		if m.clientType == Native && m.currentStage() == proto.Stage_challenge {
+			return m, tea.Sequence(changeStageCmd, getModesCmd)
+		}
+
+		return m, tea.Sequence(getModesCmd, changeStageCmd)
 
 	case AuthModeSelected:
 		safeMessageDebug(msg)


### PR DESCRIPTION
When authenticating via an interactive terminal (e.g. sudo), the auth mode selection list was often briefly visible before the first mode was auto-selected and the challenge view appeared.

Fix this by skipping the transition to the authModeSelection stage entirely for InteractiveTerminal clients: fetch auth modes and immediately auto-select the first one.

For GDM and Native clients the existing behaviour is preserved:

GDM fetches modes then transitions to authModeSelection, deferring the auto-selection until the list is focused. Native MFA (auth.Next) transitions to authModeSelection first so that when modes arrive the list is already focused and the immediate auto-selection safely drives the next challenge.

Closes #1523 
UDENG-10960