### PR TITLE
docs: update config for authd docs URL migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
 
         **Troubleshooting**
 
-        Please read our [Troubleshooting wiki page](https://documentation.ubuntu.com/authd/stable-docs/reference/troubleshooting/#common-issues-and-limitations)
+        Please read our [Troubleshooting wiki page](https://ubuntu.com/docs/authd/stable-docs/reference/troubleshooting/#common-issues-and-limitations)
         and see if you can find a solution to your problem there.
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
 
         **Troubleshooting**
 
-        Please read our [Troubleshooting wiki page](https://ubuntu.com/docs/authd/stable-docs/reference/troubleshooting/#common-issues-and-limitations)
+        Please read our [Troubleshooting page](https://ubuntu.com/docs/authd/stable-docs/reference/troubleshooting/#common-issues-and-limitations)
         and see if you can find a solution to your problem there.
   - type: checkboxes
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ PRs to our project are always welcome and can be a quick way to get your fix or 
 * Only fix/add the functionality in question **OR** address wide-spread whitespace/style issues, not both.
 * Add unit or integration tests for fixed or changed functionality.
 * Address a single concern in the least possible number of changed lines.
-* Include documentation in the repo or on our [docs site](https://documentation.ubuntu.com/authd/stable/).
+* Include documentation in the repo or on our [docs site](https://ubuntu.com/docs/authd/stable-docs/).
 * Be accompanied by a complete Pull Request template (loaded automatically when a PR is created).
 
 For changes that address core functionality or that would require breaking changes (e.g. a major release), it's best to open an Issue to discuss your proposal first. This is not required but can save time when creating and reviewing changes.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 [goreport-url]: https://goreportcard.com/report/github.com/canonical/authd
 
 [docs-image]: https://readthedocs.com/projects/canonical-authd/badge/?version=edge-docs
-[docs-url-stable]: https://documentation.ubuntu.com/authd/stable-docs/
-[docs-url-edge]: https://documentation.ubuntu.com/authd/edge-docs/
+[docs-url-stable]: https://ubuntu.com/docs/authd/stable-docs/
+[docs-url-edge]: https://ubuntu.com/docs/authd/edge-docs/
 
 [![Code quality][actions-image]][actions-url]
 [![License][license-image]](COPYING)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ We provide security updates for the latest version of `authd` on each supported 
 
 **Ubuntu 24.04 LTS and earlier supported LTS releases**: `authd` is not in the Ubuntu archive and must be installed using the stable PPA.
 
-See [Install authd](https://documentation.ubuntu.com/authd/stable-docs/howto/install-authd/) for installation instructions.
+See [Install authd](https://ubuntu.com/docs/authd/stable-docs/howto/install-authd/) for installation instructions.
 
 An [edge PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge) provides the latest development builds, but is not recommended for production use and does not receive security support.
 
@@ -44,6 +44,6 @@ The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/
 - [Canonical's Security Site](https://ubuntu.com/security)
 - [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
 - [Ubuntu Security Notices](https://ubuntu.com/security/notices)
-- [authd Documentation](https://documentation.ubuntu.com/authd/stable-docs/)
+- [authd Documentation](https://ubuntu.com/docs/authd/stable-docs/)
 
 If you have any questions regarding security vulnerabilities, please reach out to the maintainers via the aforementioned channels.

--- a/cmd/authctl/internal/docgen/manpage.go
+++ b/cmd/authctl/internal/docgen/manpage.go
@@ -72,7 +72,7 @@ func genManPage(cmd *cobra.Command, path string) error {
 	fmt.Fprintf(buf, ".IP \" 1.\" 4\n")
 	fmt.Fprintf(buf, "authd documentation\n")
 	fmt.Fprintf(buf, ".RS 4\n")
-	fmt.Fprintf(buf, "\\%%https://documentation.ubuntu.com/authd\n")
+	fmt.Fprintf(buf, "\\%%https://ubuntu.com/docs/authd\n")
 	fmt.Fprintf(buf, ".RE\n")
 
 	if !shouldWriteManPage(path, buf.Bytes()) {

--- a/docs/.sphinx/_templates/version-warning.html
+++ b/docs/.sphinx/_templates/version-warning.html
@@ -9,7 +9,7 @@
         <div class="version-warning">
           <p class="version-warning-content">
           This is the <strong>edge</strong> version. Some features may not be available in the stable release.
-          Read the <a href="{{ ogp_site_url }}/{{ clean_pagename }}"><strong>stable</strong></a> version of the documentation.
+          Read the <a href="https://ubuntu.com/docs/authd/stable-docs/{{ clean_pagename }}"><strong>stable</strong></a> version of the documentation.
           </p>
         </div>
         {% else %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import yaml
 project = "authd"
 author = "Canonical Ltd."
 
-version = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
+version = os.environ.get('READTHEDOCS_VERSION', 'local')
 
 # Sidebar documentation title; best kept reasonably short
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ import yaml
 project = "authd"
 author = "Canonical Ltd."
 
+version = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
 
 # Sidebar documentation title; best kept reasonably short
 #
@@ -70,7 +71,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://documentation.ubuntu.com/authd/stable-docs"
+ogp_site_url = f"https://ubuntu.com/docs/authd/{version}/"
 
 
 # Preview name of the documentation website
@@ -96,8 +97,6 @@ ogp_image = "https://assets.ubuntu.com/v1/cc828679-docs_illustration.svg"
 
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
-
-version = os.getenv("READTHEDOCS_VERSION", "")
 
 html_context = {
     # Used for rendering version information and links in authd documentation
@@ -180,7 +179,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-slug = "authd"
+slug = "docs/authd"
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -188,7 +187,7 @@ slug = "authd"
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = f"https://ubuntu.com/docs/authd/{version}/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -138,7 +138,7 @@ Replace `@example.com` with the domain of your identity provider.
 
 When a new user logs in for the first time, or when a user is added to a new
 group in the identity provider (for providers that support group management, see
-[Group management](https://documentation.ubuntu.com/authd/stable-docs/reference/group-management/)),
+[Group management](https://ubuntu.com/docs/authd/stable-docs/reference/group-management/)),
 authd automatically assigns a unique user ID (UID) and group ID (GID).
 
 Before assigning a UID or GID, authd checks that there are no collisions with

--- a/docs/howto/changing-versions.md
+++ b/docs/howto/changing-versions.md
@@ -99,5 +99,5 @@ sudo snap refresh authd-msentraid
 
 ```{note}
 If using an edge release, you can read the
-[edge version of the documentation](https://documentation.ubuntu.com/authd/edge-docs/)
+[edge version of the documentation](https://ubuntu.com/docs/authd/edge-docs/)
 ```

--- a/man/authctl.1
+++ b/man/authctl.1
@@ -93,5 +93,5 @@ For more information, please refer to the \m[blue]\fBauthd documentation\fP\m[][
 .IP " 1." 4
 authd documentation
 .RS 4
-\%https://documentation.ubuntu.com/authd
+\%https://ubuntu.com/docs/authd
 .RE

--- a/snap/variants/google/snapcraft.yaml
+++ b/snap/variants/google/snapcraft.yaml
@@ -17,7 +17,7 @@ description: |
     Explore the official documentation for installation and configuration steps, or visit the GitHub repository to
     contribute or provide feedback.
 icon: snap/variants/google/icon.svg
-website: https://documentation.ubuntu.com/authd
+website: https://ubuntu.com/docs/authd
 issues: https://github.com/canonical/authd/issues
 source-code: https://github.com/canonical/authd/tree/main/authd-oidc-brokers
 adopt-info: version

--- a/snap/variants/msentraid/snapcraft.yaml
+++ b/snap/variants/msentraid/snapcraft.yaml
@@ -17,7 +17,7 @@ description: |
     Explore the official documentation for installation and configuration steps, or visit the GitHub repository to
     contribute or provide feedback.
 icon: snap/variants/msentraid/icon.svg
-website: https://documentation.ubuntu.com/authd
+website: https://ubuntu.com/docs/authd
 issues: https://github.com/canonical/authd/issues
 source-code: https://github.com/canonical/authd/tree/main/authd-oidc-brokers
 adopt-info: version

--- a/snap/variants/oidc/snapcraft.yaml
+++ b/snap/variants/oidc/snapcraft.yaml
@@ -17,7 +17,7 @@ description: |
     Explore the official documentation for installation and configuration steps, or visit the GitHub repository to
     contribute or provide feedback.
 icon: snap/variants/oidc/icon.svg
-website: https://documentation.ubuntu.com/authd
+website: https://ubuntu.com/docs/authd
 issues: https://github.com/canonical/authd/issues
 source-code: https://github.com/canonical/authd/tree/main/authd-oidc-brokers
 adopt-info: version


### PR DESCRIPTION
This config change is necessary for completion of the migration of the docs to a new URL at `ubuntu.com/docs/authd`.

Currently the `edge` docs are using this PR branch, which has been tested prior to proposing this merge to main.

We will also need to apply the config change to the `stable-docs` branch.

UDENG-10611