### PR TITLE
r2-worker: paginate R2 directory listings

### DIFF
--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -250,7 +250,13 @@ jobs:
         if: always() && (steps.run-tests.outputs.output-dir != '')
         run: |
           set -euo pipefail
-          TARGET_DIR="pr-${{ github.event.pull_request.number }}/run-${{ github.run_id }}-${{ github.run_attempt }}/${{ inputs.ubuntu-version }}-${{ inputs.broker }}"
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            EVENT_DIR="pr-${{ github.event.pull_request.number }}"
+          else
+            EVENT_DIR="${{ github.event_name }}-${{ github.run_id }}"
+          fi
+
+          TARGET_DIR="${EVENT_DIR}/run-${{ github.run_id }}-${{ github.run_attempt }}/${{ inputs.ubuntu-version }}-${{ inputs.broker }}"
           PAGES_DIR="$(pwd)/pages/${TARGET_DIR}"
           mkdir -p "${PAGES_DIR}"
 

--- a/e2e-tests/r2-worker/deploy.sh
+++ b/e2e-tests/r2-worker/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+if command -v wrangler >/dev/null 2>&1; then
+  wrangler deploy "$@"
+else
+  npx --yes wrangler deploy "$@"
+fi

--- a/e2e-tests/r2-worker/src/index.js
+++ b/e2e-tests/r2-worker/src/index.js
@@ -14,11 +14,20 @@ export default {
       }
     }
 
-    // List the directory
+    // List the directory, following pagination so entries don't disappear.
     const prefix = path ? path.replace(/\/?$/, "/") : "";
-    const listing = await env.BUCKET.list({ prefix, delimiter: "/" });
+    const objects = [];
+    const delimitedPrefixes = [];
+    let cursor;
 
-    if (!listing.objects.length && !listing.delimitedPrefixes.length) {
+    do {
+      const listing = await env.BUCKET.list({ prefix, delimiter: "/", cursor });
+      objects.push(...listing.objects);
+      delimitedPrefixes.push(...listing.delimitedPrefixes);
+      cursor = listing.truncated ? listing.cursor : undefined;
+    } while (cursor);
+
+    if (!objects.length && !delimitedPrefixes.length) {
       return new Response("Not found", { status: 404 });
     }
 
@@ -33,11 +42,11 @@ export default {
     const rows = [
       // Add '..' row if not at root
       ...(parent !== null ? [`<li><a href="/${parent}">..</a></li>`] : []),
-      ...listing.delimitedPrefixes.map(p => {
+      ...[...new Set(delimitedPrefixes)].sort().map(p => {
         const name = p.replace(prefix, "");
         return `<li><a href="/${p}">${name}</a></li>`;
       }),
-      ...listing.objects.map(o => {
+      ...objects.map(o => {
         const name = o.key.replace(prefix, "");
         return `<li><a href="/${o.key}">${name}</a></li>`;
       }),

--- a/e2e-tests/r2-worker/src/index.js
+++ b/e2e-tests/r2-worker/src/index.js
@@ -2,13 +2,16 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     const path = decodeURIComponent(url.pathname.replace(/^\//, ""));
+    const wantsDirectory = url.pathname.endsWith("/");
 
-    // Try to serve the file directly
-    const object = await env.BUCKET.get(path);
-    if (object) {
-      const headers = new Headers();
-      object.writeHttpMetadata(headers);
-      return new Response(object.body, { headers });
+    // Serve file objects only for non-directory paths.
+    if (!wantsDirectory && path) {
+      const object = await env.BUCKET.get(path);
+      if (object) {
+        const headers = new Headers();
+        object.writeHttpMetadata(headers);
+        return new Response(object.body, { headers });
+      }
     }
 
     // List the directory


### PR DESCRIPTION
Fix that only the first page of directory list entries are shown.

Also fix that non-PR runs are stored under `pr-` and store them under `<event>-<id>` instead, where `<event>` is e.g. `push`.

UDENG-10637