### PR TITLE
tests: allow group fetch in TestConcurrentIsAuthenticated

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -1280,12 +1280,13 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 			username2 := "user2@example.com"
 
 			b := newBrokerForTests(t, &brokerForTestConfig{
-				Config:                broker.Config{DataDir: dataDir},
-				allUsersAllowed:       tc.allUsersAllowed,
-				ownerAllowed:          tc.ownerAllowed,
-				firstUserBecomesOwner: tc.firstUserBecomesOwner,
-				firstCallDelay:        tc.firstCallDelay,
-				secondCallDelay:       tc.secondCallDelay,
+				Config:                 broker.Config{DataDir: dataDir},
+				allUsersAllowed:        tc.allUsersAllowed,
+				ownerAllowed:           tc.ownerAllowed,
+				firstUserBecomesOwner:  tc.firstUserBecomesOwner,
+				firstCallDelay:         tc.firstCallDelay,
+				secondCallDelay:        tc.secondCallDelay,
+				supportsFetchingGroups: true,
 				tokenHandlerOptions: &testutils.TokenHandlerOptions{
 					IDTokenClaims: []map[string]interface{}{
 						{"sub": "user1", "name": "user1", "email": username1},


### PR DESCRIPTION
We used to fetch groups when running the tests with the withmsentraid tag. After #1550, the logic was changed and we forgot to update the test setup to account for this.

This is a no-op for broker that do not support groups, but will allow msentraid tests to work as intended.