### PR TITLE
e2e-tests: Avoid updating all packages

### DIFF
--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -214,9 +214,8 @@ Cancel Operation
     Match Text    @ubuntu    15
 
 
-Update And Upgrade Packages
-    SSH.Execute    apt-get update
-    SSH.Execute    apt-get upgrade -y    timeout=1200
+Update Authd
+    SSH.Execute    apt-get install -y authd    timeout=120
 
 
 Sync System Time

--- a/e2e-tests/tests/migration_authd.robot
+++ b/e2e-tests/tests/migration_authd.robot
@@ -38,7 +38,7 @@ Test login after updating authd to edge version
 
     # Switch to the edge PPA for authd
     Enable Edge Repository For Authd
-    Update And Upgrade Packages
+    Update Authd
 
     # Log in with remote user with local password after upgrading
     Open Terminal In Sudo Mode

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -39,7 +39,7 @@ Test login after upgrading authd and broker to edge channel
     # Switch to the edge channel for the broker snap and the edge PPA for authd
     Enable Edge Repository For Authd
     Enable Edge Broker
-    Update And Upgrade Packages
+    Update Authd
 
     # Log in with remote user with local password after upgrading
     Open Terminal In Sudo Mode

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -38,7 +38,6 @@ Test login with broker on edge channel
 
     # Switch to edge channel for the broker snap
     Enable Edge Broker
-    Update And Upgrade Packages
 
     # Log in with remote user with local password after upgrading
     Open Terminal In Sudo Mode


### PR DESCRIPTION
We only need to update authd.
    
This fixes that the test fails when openssh-server is updated and ssh.service restarted afterwards.

UDENG-10685