### PR TITLE
Fix disabled-user bypass after online-to-offline transition

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -806,16 +806,6 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		return AuthNext, nil
 	}
 
-	if authInfo.UserIsDisabled && session.isOffline {
-		log.Errorf(context.Background(), "Login denied: user %q is disabled in %s and session is offline", session.username, b.provider.DisplayName())
-		return AuthDenied, errorMessage{Message: fmt.Sprintf("Your user account is disabled in %s. Please contact your administrator or try again with a working network connection.", b.provider.DisplayName())}
-	}
-
-	if authInfo.DeviceIsDisabled && session.isOffline {
-		log.Errorf(context.Background(), "Login denied: device %q is disabled in %s and session is offline", session.username, b.provider.DisplayName())
-		return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s. Please contact your administrator or try again with a working network connection.", b.provider.DisplayName())}
-	}
-
 	// Refresh the token if we're online even if the token has not expired
 	if b.cfg.forceAccessCheckWithProvider || !session.isOffline {
 		// Check if we have a refresh token before attempting to refresh
@@ -863,6 +853,19 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 				return AuthDenied, errorMessage{Message: "Failed to refresh token"}
 			}
 		}
+	}
+
+	// Check disabled status. We have to do this after trying to refresh the token,
+	// because if token refresh fails with a network error, the session falls back
+	// to offline mode.
+	if authInfo.UserIsDisabled && session.isOffline {
+		log.Errorf(context.Background(), "Login denied: user %q is disabled in %s and session is offline", session.username, b.provider.DisplayName())
+		return AuthDenied, errorMessage{Message: fmt.Sprintf("Your user account is disabled in %s. Please contact your administrator or try again with a working network connection.", b.provider.DisplayName())}
+	}
+
+	if authInfo.DeviceIsDisabled && session.isOffline {
+		log.Errorf(context.Background(), "Login denied: device %q is disabled in %s and session is offline", session.username, b.provider.DisplayName())
+		return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s. Please contact your administrator or try again with a working network connection.", b.provider.DisplayName())}
 	}
 
 	// If device registration is enabled, ensure that the device is registered.

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -906,6 +906,21 @@ func TestIsAuthenticated(t *testing.T) {
 			token:          &tokenOptions{deviceIsDisabled: true},
 			sessionOffline: true,
 		},
+		// disabled user/device must be denied even when the session transitions from online to offline mid-auth (network error during token refresh).
+		"Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error": {
+			firstMode: authmodes.Password,
+			token:     &tokenOptions{userIsDisabled: true},
+			customHandlers: map[string]testutils.EndpointHandler{
+				"/token": testutils.HangingHandler(broker.MaxRequestDuration + 1),
+			},
+		},
+		"Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error": {
+			firstMode: authmodes.Password,
+			token:     &tokenOptions{deviceIsDisabled: true},
+			customHandlers: map[string]testutils.EndpointHandler{
+				"/token": testutils.HangingHandler(broker.MaxRequestDuration + 1),
+			},
+		},
 		"Error_when_mode_is_invalid": {firstMode: "invalid"},
 		"Error_when_thin_id_token_and_userinfo_endpoint_is_unavailable": {
 			firstSecret:    "-",

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_transitions_to_offline_due_to_network_error/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"This device is disabled in the identity provider. Please contact your administrator or try again with a working network connection."}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_transitions_to_offline_due_to_network_error/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"Your user account is disabled in the identity provider. Please contact your administrator or try again with a working network connection."}'
+err: <nil>


### PR DESCRIPTION
Disabled-account checks were applied only at session start. When token
refresh fails with a network error, the session falls back to offline
without re-evaluating the cached disabled flags, allowing a disabled user
to log in if the network drops mid-auth.

Consolidate checks to the post-refresh block where all authentication paths
converge. This catches both offline-at-start and online→offline-fallback
cases. Removes duplicate logic and establishes a single canonical gate
before access grant.


UDENG-10645