### PR TITLE
Reject control characters in owner username to prevent INI injection

### DIFF
--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"unicode"
 
 	"github.com/canonical/authd/log"
 	"gopkg.in/ini.v1"
@@ -382,6 +383,14 @@ func (uc *userConfig) registerOwner(cfgPath, userName string) error {
 	// considered the owner.
 	uc.ownerMutex.Lock()
 	defer uc.ownerMutex.Unlock()
+
+	// Reject any non-graphic characters in the username before writing it to
+	// the INI drop-in config. Control characters allow INI key injection, and
+	// other non-graphic runes are not valid content for a generated config
+	// value.
+	if strings.ContainsFunc(userName, func(r rune) bool { return !unicode.IsGraphic(r) }) {
+		return fmt.Errorf("username %q contains invalid characters and cannot be used for owner registration", userName)
+	}
 
 	if cfgPath == "" {
 		uc.owner = uc.provider.NormalizeUsername(userName)

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -418,6 +418,39 @@ func TestRegisterOwner(t *testing.T) {
 	}
 }
 
+func TestRegisterOwnerRejectsInvalidChars(t *testing.T) {
+	t.Parallel()
+
+	p := &testutils.MockProvider{}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "broker.conf")
+	require.NoError(t, os.WriteFile(cfgPath,
+		[]byte("[oidc]\nissuer = https://issuer.url.com\nclient_id = client_id\n"), 0600))
+
+	uc := userConfig{provider: p, ownerMutex: &sync.RWMutex{}}
+
+	tests := map[string]struct {
+		username string
+	}{
+		"newline_injection": {username: "attacker@evil.test\nallowed_users = ALL\nowner_extra_groups = sudo"},
+		"carriage_return":   {username: "user@x.com\ralert"},
+		"nul_byte":          {username: "user@x.com\x00evil"},
+		"bell_char":         {username: "user@x.com\x07evil"},
+		"escape_char":       {username: "user@x.com\x1bevil"},
+		"line_separator":    {username: "user@x.com\u2028evil"},
+		"zero_width_space":  {username: "user\u200bname"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := uc.registerOwner(cfgPath, tc.username)
+			require.ErrorContains(t, err, "invalid characters")
+		})
+	}
+}
+
 func TestParseConfigUnknownSettings(t *testing.T) {
 	// This test is NOT parallel because it modifies the global log handler.
 	p := &testutils.MockProvider{}


### PR DESCRIPTION
An IdP-supplied username containing newlines gets written verbatim into
the INI config drop-in via Go template without escaping. Injected keys
like 'allowed_users = ALL' become effective on reload.

Reject any non-graphic characters before templating so owner
auto-registration only writes usernames made of graphic runes. This
blocks the newline injection vector and avoids writing other
non-graphic runes into generated config values.

UDENG-10692