### PR TITLE
Mark TestCLIAuthenticate and TestNativeChangeAuthTok as not flaky 

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -28,11 +28,6 @@ func TestCLIAuthenticate(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	// This test is flaky, see https://github.com/canonical/authd/issues/1329
-	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
-		t.Skip("skipping flaky test")
-	}
-
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -791,11 +790,6 @@ func TestNativeChangeAuthTok(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
-	}
-
-	// This test is flaky, see https://github.com/canonical/authd/issues/1330
-	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
-		t.Skip("skipping flaky test")
 	}
 
 	clientPath := t.TempDir()


### PR DESCRIPTION
The flakiness was presumably fixed by #1529.

Closes #1329, #1330