### PR TITLE
ci: Run e2e-tests on Stonking

### DIFF
--- a/.github/workflows/debian-build-test-and-sync.yaml
+++ b/.github/workflows/debian-build-test-and-sync.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           lxd-image: ubuntu:${{ inputs.ubuntu-version }}
           source-changes: ${{ needs.build-deb.outputs.pkg-src-changes }}
-          autopkgtest-args: --add-apt-source=ppa:ubuntu-enterprise-desktop/golang
+          autopkgtest-args: ${{ (inputs.ubuntu-version == 'noble') && '--add-apt-source=ppa:ubuntu-enterprise-desktop/golang' || '' }}
 
   synchronize-packaging-branches:
     name: Update packaging branch

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -102,7 +102,7 @@ jobs:
       statuses: write
     strategy:
       matrix:
-        ubuntu-version: ['noble', 'resolute']
+        ubuntu-version: ['noble', 'resolute', 'devel']
       fail-fast: false
     uses: ./.github/workflows/e2e-tests-provision-and-run.yaml
     with:

--- a/e2e-tests/vm/cloud-init-template-stonking.yaml
+++ b/e2e-tests/vm/cloud-init-template-stonking.yaml
@@ -1,0 +1,133 @@
+#cloud-config
+password: ubuntu
+ssh_pwauth: true
+users:
+  - name: root
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+  - name: ubuntu
+    sudo: [ 'ALL=(ALL) NOPASSWD:ALL' ]
+    lock_passwd: false
+    gecos: Ubuntu
+    groups: sudo
+    homedir: /home/ubuntu
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+chpasswd:
+  expire: false
+  users:
+    - { name: ubuntu, password: ubuntu, type: text }
+
+package_update: true
+package_upgrade: true
+packages:
+  - fonts-ubuntu
+  - gdm3
+  - gnome-shell
+  - gnome-shell-ubuntu-extensions
+  - gsettings-ubuntu-schemas
+  - libpam-pwquality
+  - openssh-server
+  - policykit-desktop-privileges
+  # Required to get the VM's IP address
+  - qemu-guest-agent
+  # Default terminal on questing
+  - ptyxis
+  # Required to forward the journal to the host
+  - socat
+  - spice-vdagent
+  # Required for add-apt-repository
+  - software-properties-common
+  - systemd-container
+  - systemd-timesyncd
+  - ubuntu-settings
+  - yaru-theme-gtk
+  - yaru-theme-icon
+
+write_files:
+  - path: /etc/dconf/profile/user
+    content: |
+      user-db:user
+      system-db:local
+
+  # Configure dconf
+  - path: /etc/dconf/db/local.d/00-e2e-tests-requirements
+    content: |
+      # Disable automatic suspend when plugged in
+      [org/gnome/settings-daemon/plugins/power]
+      sleep-inactive-ac-type='nothing'
+      sleep-inactive-ac-timeout=0
+
+      # Disable screen blanking
+      [org/gnome/desktop/session]
+      idle-delay=uint32 0
+
+      # Use larger text for better OCR results
+      [org/gnome/desktop/interface]
+      text-scaling-factor=1.25
+
+  - path: /etc/ssh/sshd_config.d/root.conf
+    content: |
+      ${CI_ROOT_SSHD_CONFIG}
+
+  - path: /etc/ssh/sshd_config.d/authd.conf
+    content: |
+      UsePAM yes
+      Match User *@*
+          KbdInteractiveAuthentication yes
+
+  # Export the journal to the host
+  - path: /etc/systemd/system/journal-export.service
+    content: |
+      [Unit]
+      Description=Exports the journal to the host
+      After=systemd-journald.service
+      After=network.target
+      Requires=network.target
+      # Disable rate limiting
+      StartLimitIntervalSec=0
+
+      [Service]
+      Type=simple
+      ExecStart=/bin/bash -o pipefail -c 'journalctl -b --lines=all -o export -f | socat - ${SOCAT_ADDRESS}'
+      OOMScoreAdjust=-1000
+      Restart=always
+      RestartSec=1
+
+      [Install]
+      WantedBy=basic.target
+
+  # Hide login banner to avoid cluttering the terminal with messages that make
+  # OCR results less predictable.
+  - path: /etc/skel/.hushlogin
+    content: ""
+
+runcmd:
+  ${CI_ROOT_PASSWD_CMD}
+  # Disable apport
+  - sed -i 's/enabled=1/enabled=0/' /etc/default/apport
+  - systemctl mask --now apport.service
+  # Increase the default login timeout
+  - sed -i 's/^\(LOGIN_TIMEOUT\t\t\)[0-9]\+/\1360/' /etc/login.defs
+  # Update dconf database
+  - dconf update
+  # Disable systemd-networkd-wait-online to speed up boot time
+  - systemctl mask systemd-networkd-wait-online.service
+  # Enable our systemd services
+  - systemctl enable journal-export.service
+  # Avoid APT downloads and upgrades during the tests
+  - systemctl mask apt-daily.service
+  - systemctl mask apt-daily.timer
+  - systemctl mask apt-daily-upgrade.service
+  - systemctl mask apt-daily-upgrade.timer
+  - systemctl mask unattended-upgrades.service
+  - rm -f /etc/apt/apt.conf.d/20auto-upgrades /etc/apt/apt.conf.d/50unattended-upgrades
+
+final_message: "Provisioning finished after $UPTIME seconds"
+
+power_state:
+  mode: poweroff
+  message: Shutting down instance after initial setup
+  condition: True
+  timeout: 30

--- a/internal/testutils/bubblewrap.go
+++ b/internal/testutils/bubblewrap.go
@@ -92,7 +92,9 @@ func RunTestInBubbleWrap(t *testing.T, args ...string) {
 		"--ro-bind", "/etc/localtime", "/etc/localtime",
 		"--ro-bind", "/etc/login.defs", "/etc/login.defs",
 		"--ro-bind", "/etc/nsswitch.conf", "/etc/nsswitch.conf",
-		"--ro-bind", "/etc/sudo.conf", "/etc/sudo.conf",
+		// sudo.conf is optional and absent on recent releases (sudo falls back
+		// to built-in defaults), so bind it only if it exists.
+		"--ro-bind-try", "/etc/sudo.conf", "/etc/sudo.conf",
 		"--ro-bind", "/etc/sudoers", "/etc/sudoers",
 		"--ro-bind-try", "/etc/timezone", "/etc/timezone",
 		"--ro-bind", "/etc/pam.d", "/etc/pam.d",

--- a/internal/users/localentries/localgroups_test.go
+++ b/internal/users/localentries/localgroups_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sync"
 	"testing"
 
 	"github.com/canonical/authd/internal/fileutils"
@@ -365,67 +364,60 @@ func TestGetAndSaveLocalGroups(t *testing.T) {
 	}
 }
 
-//nolint:tparallel // This can't be parallel, but subtests can.
 func TestRacingGroupsLockingActions(t *testing.T) {
 	const nIterations = 50
 
 	testFilePath := filepath.Join("testdata", "no_users_in_our_groups.group")
 	testUserDBLocked := &localentries.UserDBLocked{}
 
-	wg := sync.WaitGroup{}
-	wg.Add(nIterations)
+	// Lock and get the values in parallel. The iterations are grouped under a
+	// dedicated subtest so that t.Run only returns once all of them are done.
+	// This avoids relying on a WaitGroup from a sibling parallel subtest, which
+	// deadlocks when the test parallelism is constrained (e.g. a single-CPU
+	// autopkgtest testbed) and the waiting subtest holds the only run slot.
+	t.Run("parallel_iterations", func(t *testing.T) {
+		for idx := range nIterations {
+			t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+				t.Parallel()
 
-	// Lock and get the values in parallel.
-	for idx := range nIterations {
-		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
-			t.Parallel()
+				var opts []localentries.Option
+				wantGroup := types.GroupEntry{Name: "root", GID: 0, Passwd: "x"}
+				useTestGroupFile := idx%3 == 0
 
-			t.Cleanup(wg.Done)
+				if useTestGroupFile {
+					// Mix the requests with test-only code paths...
+					opts = append(opts,
+						localentries.WithGroupPath(testFilePath),
+						localentries.WithUserDBLockedInstance(testUserDBLocked),
+						localentries.WithMockUserDBLocking(),
+					)
+					wantGroup = types.GroupEntry{Name: "localgroup1", GID: 41, Passwd: "x"}
+				}
 
-			var opts []localentries.Option
-			wantGroup := types.GroupEntry{Name: "root", GID: 0, Passwd: "x"}
-			useTestGroupFile := idx%3 == 0
+				entries, entriesUnlock, err := localentries.WithUserDBLock(opts...)
+				require.NoError(t, err, "Failed to lock the local entries")
+				t.Cleanup(func() {
+					err := entriesUnlock()
+					require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
+				})
 
-			if useTestGroupFile {
-				// Mix the requests with test-only code paths...
-				opts = append(opts,
-					localentries.WithGroupPath(testFilePath),
-					localentries.WithUserDBLockedInstance(testUserDBLocked),
-					localentries.WithMockUserDBLocking(),
-				)
-				wantGroup = types.GroupEntry{Name: "localgroup1", GID: 41, Passwd: "x"}
-			}
-
-			entries, entriesUnlock, err := localentries.WithUserDBLock(opts...)
-			require.NoError(t, err, "Failed to lock the local entries")
-			t.Cleanup(func() {
-				err := entriesUnlock()
-				require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
+				groups, err := localentries.GetGroupEntries(entries)
+				require.NoError(t, err, "GetEntries should not return an error, but did")
+				require.NotEmpty(t, groups, "Got empty groups (test groups: %v)", useTestGroupFile)
+				require.Contains(t, groups, wantGroup, "Expected group was not found  (test groups: %v)", useTestGroupFile)
 			})
-
-			groups, err := localentries.GetGroupEntries(entries)
-			require.NoError(t, err, "GetEntries should not return an error, but did")
-			require.NotEmpty(t, groups, "Got empty groups (test groups: %v)", useTestGroupFile)
-			require.Contains(t, groups, wantGroup, "Expected group was not found  (test groups: %v)", useTestGroupFile)
-		})
-	}
-
-	t.Run("final_check", func(t *testing.T) {
-		t.Parallel()
-		wg.Wait()
-
-		// Get a last unlock function, to see if we're all good...
-		entries, entriesUnlock, err := localentries.WithUserDBLock()
-		require.NoError(t, err, "Failed to lock the local entries")
-
-		require.NoError(t, err, "Unlock should not fail to lock the users group")
-
-		err = entriesUnlock()
-		require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
-
-		// Ensure that we had cleaned up all the locks correctly!
-		require.Panics(t, func() { _, _ = localentries.GetGroupEntries(entries) })
+		}
 	})
+
+	// Get a last unlock function, to see if we're all good...
+	entries, entriesUnlock, err := localentries.WithUserDBLock()
+	require.NoError(t, err, "Failed to lock the local entries")
+
+	err = entriesUnlock()
+	require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
+
+	// Ensure that we had cleaned up all the locks correctly!
+	require.Panics(t, func() { _, _ = localentries.GetGroupEntries(entries) })
 }
 
 func TestLockedInvalidActions(t *testing.T) {

--- a/internal/users/locking/locking_bwrap_test.go
+++ b/internal/users/locking/locking_bwrap_test.go
@@ -36,8 +36,10 @@ func TestLockAndWriteUnlock(t *testing.T) {
 
 	groupFile := filepath.Join("/etc", "group")
 	newGroupContents := "testgroup:x:1001:testuser"
+	// The group file must end with a trailing newline, otherwise newer
+	// shadow-utils (e.g. gpasswd) refuse to open it.
 	//nolint:gosec // G306 The group file is expected to have permissions 0644
-	err := os.WriteFile(groupFile, []byte("root:x:0:\n"+newGroupContents), 0644)
+	err := os.WriteFile(groupFile, []byte("root:x:0:\n"+newGroupContents+"\n"), 0644)
 	require.NoError(t, err, "Writing group file")
 
 	// Try using gpasswd to modify the group file. This should succeed, because
@@ -92,8 +94,10 @@ func TestReadWhileLocked(t *testing.T) {
 	groupContents := `root:x:0:
 testgroup:x:1001:testuser`
 
+	// The group file must end with a trailing newline, otherwise newer
+	// shadow-utils refuse to open it.
 	//nolint:gosec // G306 The group file is expected to have permissions 0644
-	err := os.WriteFile(groupFile, []byte(groupContents), 0644)
+	err := os.WriteFile(groupFile, []byte(groupContents+"\n"), 0644)
 	require.NoError(t, err, "Writing group file")
 
 	err = userslocking.WriteLock()
@@ -137,8 +141,10 @@ func TestLockAndLockAgainGroupFileOverridden(t *testing.T) {
 	groupFile := filepath.Join("/etc", "group")
 	groupContents := "testgroup:x:1001:testuser"
 
+	// The group file must end with a trailing newline, otherwise newer
+	// shadow-utils (e.g. gpasswd) refuse to open it.
 	//nolint:gosec // G306 The group file is expected to have permissions 0644
-	err = os.WriteFile(groupFile, []byte(groupContents), 0644)
+	err = os.WriteFile(groupFile, []byte(groupContents+"\n"), 0644)
 	require.NoError(t, err, "Writing group file")
 
 	err = userslocking.WriteLock()
@@ -234,8 +240,10 @@ func TestLockingLockedDatabase(t *testing.T) {
 	groupFile := filepath.Join("/etc", "group")
 	groupContents := "testgroup:x:1001:testuser"
 
+	// The group file must end with a trailing newline, otherwise newer
+	// shadow-utils (e.g. gpasswd) refuse to open it.
 	//nolint:gosec // G306 The group file is expected to have permissions 0644
-	err := os.WriteFile(groupFile, []byte(groupContents), 0644)
+	err := os.WriteFile(groupFile, []byte(groupContents+"\n"), 0644)
 	require.NoError(t, err, "Writing group file")
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Now that `devel` is resolving to `Stonking`, we need to start covering that release with our CI and E2E tests.

UDENG-10698