### PR TITLE
himmelblau: make broker HTTP timeout configurable

### DIFF
--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/generate.sh
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/generate.sh
@@ -24,7 +24,7 @@ set -x
 
 "${CARGO_HOME:-$HOME/.cargo}"/bin/cbindgen --config ./cbindgen.toml > himmelblau/himmelblau.h
 
-FEATURES="broker,changepassword,on_behalf_of"
+FEATURES="broker,changepassword,on_behalf_of,set_timeout"
 # Enable custom_oidc_discovery_url feature when not building a release,
 # which is the case when building inside snapcraft or when the RELEASE env
 # var is set (the latter can be used during development).

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/himmelblau_c.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/himmelblau_c.go
@@ -9,6 +9,15 @@ package himmelblau
 // Add the current directory to the library search path if we're building for testing,
 // because libhimmelblau is not installed in the standard search directories.
 #cgo !release LDFLAGS: -Wl,-rpath,${SRCDIR}
+// libhimmelblau is built with the set_timeout feature, which makes cbindgen emit the
+// timeout-aware, 6-argument broker_init under #if defined(SET_TIMEOUT) and the old
+// 5-argument one under #if !defined(SET_TIMEOUT). Since initBroker calls the
+// 6-argument variant, we must define SET_TIMEOUT so the header exposes it.
+//
+// The other features we enable (changepassword, on_behalf_of) don't need this:
+// their guarded declarations are never referenced from cgo, so the header compiles
+// fine whether or not their macros are defined.
+#cgo CFLAGS: -DSET_TIMEOUT
 #include "himmelblau.h"
 */
 import "C"
@@ -62,6 +71,10 @@ func initTPM(tctiName string) (tpm *boxedDynTPM, err error) {
 	return tpm, nil
 }
 
+// brokerHTTPTimeoutSecs extends libhimmelblau's 3-second default, which is too
+// short for Entra device enrollment.
+const brokerHTTPTimeoutSecs = 15
+
 func initBroker(authority, clientID string, transportKeyBytes, certKeyBytes []byte) (broker *brokerClientApplication, err error) {
 	cAuthority := C.CString(authority)
 	defer C.free(unsafe.Pointer(cAuthority))
@@ -98,11 +111,14 @@ func initBroker(authority, clientID string, transportKeyBytes, certKeyBytes []by
 		defer C.loadable_ms_device_enrollment_key_free(cCertKey)
 	}
 
+	cTimeoutSecs := C.uint64_t(brokerHTTPTimeoutSecs)
+
 	msalErr := C.broker_init(
 		cAuthority,
 		cClientID,
 		cTransportKey,
 		cCertKey,
+		&cTimeoutSecs,
 		(**C.BrokerClientApplication)(unsafe.Pointer(&broker)),
 	)
 	if msalErr != nil {

--- a/snap/variants/msentraid/snapcraft.yaml
+++ b/snap/variants/msentraid/snapcraft.yaml
@@ -56,7 +56,7 @@ parts:
       cp "$SNAPCRAFT_PROJECT_DIR/authd-oidc-brokers/rust-toolchain.toml" "$SNAPCRAFT_PART_SRC/"
     override-build: |
       cargo install cargo-c
-      cargo cbuild --release --lib --features=broker,changepassword,on_behalf_of
+      cargo cbuild --release --lib --features=broker,changepassword,on_behalf_of,set_timeout
       echo "Installing libhimmelblau.so and himmelblau.h"
       TARGET_TRIPLE=$(rustc -vV | awk '/host:/ {print $2}')
       install -D target/${TARGET_TRIPLE}/release/libhimmelblau.so ${CRAFT_PART_INSTALL}/lib/libhimmelblau.so.0


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on this MR https://gitlab.com/samba-team/libhimmelblau/-/merge_requests/160, which should be reviewed and merged first.

Device registration broke due to a hardcoded 3-second timeout introduced in the libhimmelblau C API: https://gitlab.com/samba-team/libhimmelblau/-/commit/8a10e64be10c5862f897027be77dbe7705934ed8

This PR (and the upstream MR) makes the timeout caller-configurable, falling back to 3 seconds if unset.

UDENG-10724