### PR TITLE
conf: Add comments for issuer and client_id settings

### DIFF
--- a/authd-oidc-brokers/conf/variants/google/broker.conf
+++ b/authd-oidc-brokers/conf/variants/google/broker.conf
@@ -1,6 +1,11 @@
 [oidc]
+## The issuer URL for Google's OIDC service.
 issuer = https://accounts.google.com
+
+## The client ID of the application registered with Google.
 client_id = <CLIENT_ID>
+
+## The client secret of the application registered with Google.
 client_secret = <CLIENT_SECRET>
 
 ## Force verification with the identity provider during login.

--- a/authd-oidc-brokers/conf/variants/msentraid/broker.conf
+++ b/authd-oidc-brokers/conf/variants/msentraid/broker.conf
@@ -1,5 +1,9 @@
 [oidc]
+## The OIDC issuer URL for your Entra ID tenant.
+## Replace <ISSUER_ID> with your tenant ID.
 issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0
+
+## The client ID of the application registered in Entra ID.
 client_id = <CLIENT_ID>
 
 ## Force verification with the identity provider during login.

--- a/authd-oidc-brokers/conf/variants/oidc/broker.conf
+++ b/authd-oidc-brokers/conf/variants/oidc/broker.conf
@@ -1,5 +1,8 @@
 [oidc]
+## The OIDC issuer URL for your identity provider.
 issuer = <ISSUER_URL>
+
+## The client ID of the application registered with your identity provider.
 client_id = <CLIENT_ID>
 
 ## Depending on the identity provider, you may need to provide a


### PR DESCRIPTION
These were the only settings which did not have comments in the broker config file. Add comments which briefly explain the settings.