### PR TITLE
e2e-tests: Drop unnecessary sleeps

### DIFF
--- a/e2e-tests/resources/authd.resource
+++ b/e2e-tests/resources/authd.resource
@@ -37,17 +37,14 @@ Change Password
     Hid.Keys Combo    Return
 
     Match Text    Enter your local password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
 
     Match Text    New password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${new_password}
     Hid.Keys Combo    Return
 
     Match Text    Confirm password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${new_password}
     Hid.Keys Combo    Return
 
@@ -83,12 +80,9 @@ Check That Remote User Can Run Sudo Commands
     [Arguments]    ${local_password}
     Hid.Type String    sudo touch sudo-test.txt
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Match Text    Enter your local password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Hid.Type String    ls -l
     Hid.Keys Combo    Return
     Match Text    sudo-test.txt    15

--- a/e2e-tests/resources/authd.resource
+++ b/e2e-tests/resources/authd.resource
@@ -25,17 +25,14 @@ Change Password
     Hid.Keys Combo    Return
 
     Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
 
     Match Text    New password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${new_password}
     Hid.Keys Combo    Return
 
     Match Text    Confirm password:    15
-    Builtin.Sleep    2
     Hid.Type String    ${new_password}
     Hid.Keys Combo    Return
 

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -48,7 +48,6 @@ Select Provider
     Match Text    2. ${PROVIDER_DISPLAY_NAME}
 
     Hid.Type String    2
-    Builtin.Sleep    2
 
 
 Regenerate QR Code
@@ -100,11 +99,9 @@ Log In With Remote User Through CLI: Local Password
     Try machinectl login Prompt
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Match Text    Enter your local password:    120
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Match Text    ${username}@ubuntu:~$    120
 
 

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -63,7 +63,6 @@ Select Provider
     Match Text    2. ${PROVIDER_DISPLAY_NAME}
 
     Hid.Type String    2
-    Builtin.Sleep    2
 
 
 Regenerate QR Code


### PR DESCRIPTION
Avoid sleeps during tests when to wait for work to finish - they cause flakiness when the work takes longer than expected and make the tests take longer than necessary. The sleeps that are dropped here should not be necessary in the first place.

UDENG-10849