### PR TITLE
e2e-tests: fix device code regex capturing label instead of code

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -73,11 +73,11 @@ Regenerate QR Code
 
 
 Continue Log In With Remote User: Authenticate In External Browser
-    # Wait until the verification URL and login code are displayed
+    # Wait until the verification URL is displayed.
     Match Text    ${DEVICE_URL}
-    # Read the user code.
-    ${text} =    Read Text
-    ${user_code} =    StringUtils.First Match    ${DEVICE_URL_REGEX}    ${text}
+    # The code can be rendered separately from its label, so wait until the
+    # actual code is available before starting the browser login.
+    ${user_code} =    Wait Until Keyword Succeeds    30s    1s    Extract Device Code
     # The OCR sometimes reads spaces in the user code, even though there are none,
     # so remove any spaces.
     ${user_code} =    Remove String    ${user_code}    ${SPACE}
@@ -86,6 +86,12 @@ Continue Log In With Remote User: Authenticate In External Browser
     ${user_code} =    String.Convert To Upper Case    ${user_code}
 
     Browser.Login    ${user_code}    ${SUITE_OUTPUT_DIR}
+
+
+Extract Device Code
+    ${text} =    Read Text
+    ${user_code} =    StringUtils.First Match    ${DEVICE_URL_REGEX}    ${text}
+    RETURN    ${user_code}
 
 
 Continue Log In With Remote User Through CLI: Define Local Password

--- a/e2e-tests/resources/broker_vars.py
+++ b/e2e-tests/resources/broker_vars.py
@@ -30,7 +30,12 @@ _BROKER_CONFIGS = {
         "PROVIDER_DISPLAY_NAME": "Google",
         "DEVICE_URL": "google.com/device",
         # TODO: Same as above — simplify once stable ships the new format.
-        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https:\/\/)?google.com\/device\n(?:(?:Code|Login code):\s*|\s*)([A-Za-z\- ]+)",
+        # The colon is optional (:?) and the code may appear on the next line
+        # because GDM renders the label and value as separate widgets in its dialog.
+        # The capture group permits OCR-inserted whitespace and accepts code
+        # segments of three or four letters. Requiring at least one hyphen keeps
+        # adjacent GDM UI text from being captured with the code.
+        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https:\/\/)?google.com\/device\n(?:(?:Code|Login code):?\s*\n?|\s*)([A-Za-z](?:\s*[A-Za-z]){2,3}(?:\s*-\s*[A-Za-z](?:\s*[A-Za-z]){2,3})+(?![A-Za-z]))",
         "remote_group": "",
     },
 }

--- a/e2e-tests/resources/broker_vars.py
+++ b/e2e-tests/resources/broker_vars.py
@@ -16,13 +16,14 @@ _BROKER_CONFIGS = {
         "PROVIDER_DISPLAY_NAME": "Microsoft Entra ID",
         "DEVICE_URL": "login.microsoft.com/device",
         # TODO: Once the stable channel ships the new URL:/Code: format, drop the
-        # optional-prefix fallbacks and simplify to r"URL:\s*(https://)?...\nCode:\s*([A-Za-z0-9]+)".
+        # optional-prefix fallbacks and simplify to r"URL:\s*(https://)?...\nCode[:\uFF1A]\s*([A-Za-z0-9]+)".
         # They exist only for migration_broker.robot, which logs in before upgrading
         # from stable (old bare format) to edge (new labeled format).
         # The label can be rendered separately from the code, and OCR can drop
-        # its colon or change its case. Require the value to end its OCR line
-        # so a label-only frame cannot capture adjacent dialog text.
-        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https://)?login.microsoft.com/device\n(?:(?i:Code|Login[ \t]*code)(?=:[ \t]*|[ \t]+|\n):?[ \t]*\n?|(?!(?i:CODE|LOGIN[ \t]*CODE)(?:[ \t]*:|[ \t]+|\n|$))\s*)([A-Za-z0-9]+)(?=[ \t]*(?:\n|$))",
+        # its colon, render it full-width, or change its case. Require the
+        # value to end its OCR line so a label-only frame cannot capture
+        # adjacent dialog text.
+        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https://)?login.microsoft.com/device\n(?:(?i:Code|Login[ \t]*code)(?=[:\uFF1A][ \t]*|[ \t]+|\n)[:\uFF1A]?[ \t]*\n?|(?!(?i:CODE|LOGIN[ \t]*CODE)(?:[ \t]*[:\uFF1A]|[ \t]+|\n|$))\s*)([A-Za-z0-9]+)(?=[ \t]*(?:\n|$))",
         "remote_group": "e2e-test-group",
     },
     "authd-google": {
@@ -33,12 +34,13 @@ _BROKER_CONFIGS = {
         "PROVIDER_DISPLAY_NAME": "Google",
         "DEVICE_URL": "google.com/device",
         # TODO: Same as above — simplify once stable ships the new format.
-        # The colon is optional (:?) and the code may appear on the next line
-        # because GDM renders the label and value as separate widgets in its dialog.
+        # The colon is optional and may be rendered as a full-width colon. The
+        # code may appear on the next line because GDM renders the label and
+        # value as separate widgets in its dialog.
         # The capture group permits OCR-inserted whitespace and accepts code
         # segments of three or four letters. Requiring at least one hyphen keeps
         # adjacent GDM UI text from being captured with the code.
-        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https:\/\/)?google.com\/device\n(?:(?i:Code|Login[ \t]*code):?[ \t]*\n?|\s*)([A-Za-z](?:\s*[A-Za-z]){2,3}(?:\s*-\s*[A-Za-z](?:\s*[A-Za-z]){2,3})+(?![A-Za-z]))",
+        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https:\/\/)?google.com\/device\n(?:(?i:Code|Login[ \t]*code)[:\uFF1A]?[ \t]*\n?|\s*)([A-Za-z](?:\s*[A-Za-z]){2,3}(?:\s*-\s*[A-Za-z](?:\s*[A-Za-z]){2,3})+(?![A-Za-z]))",
         "remote_group": "",
     },
 }

--- a/e2e-tests/resources/broker_vars.py
+++ b/e2e-tests/resources/broker_vars.py
@@ -19,7 +19,10 @@ _BROKER_CONFIGS = {
         # optional-prefix fallbacks and simplify to r"URL:\s*(https://)?...\nCode:\s*([A-Za-z0-9]+)".
         # They exist only for migration_broker.robot, which logs in before upgrading
         # from stable (old bare format) to edge (new labeled format).
-        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https://)?login.microsoft.com/device\n(?:(?:Code|Login code):\s*|\s*)([A-Za-z0-9]+)",
+        # The label can be rendered separately from the code, and OCR can drop
+        # its colon or change its case. Require the value to end its OCR line
+        # so a label-only frame cannot capture adjacent dialog text.
+        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https://)?login.microsoft.com/device\n(?:(?i:Code|Login[ \t]*code)(?=:[ \t]*|[ \t]+|\n):?[ \t]*\n?|(?!(?i:CODE|LOGIN[ \t]*CODE)(?:[ \t]*:|[ \t]+|\n|$))\s*)([A-Za-z0-9]+)(?=[ \t]*(?:\n|$))",
         "remote_group": "e2e-test-group",
     },
     "authd-google": {
@@ -30,7 +33,12 @@ _BROKER_CONFIGS = {
         "PROVIDER_DISPLAY_NAME": "Google",
         "DEVICE_URL": "google.com/device",
         # TODO: Same as above — simplify once stable ships the new format.
-        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https:\/\/)?google.com\/device\n(?:(?:Code|Login code):\s*|\s*)([A-Za-z\- ]+)",
+        # The colon is optional (:?) and the code may appear on the next line
+        # because GDM renders the label and value as separate widgets in its dialog.
+        # The capture group permits OCR-inserted whitespace and accepts code
+        # segments of three or four letters. Requiring at least one hyphen keeps
+        # adjacent GDM UI text from being captured with the code.
+        "DEVICE_URL_REGEX": r"(?:URL:\s*)?(https:\/\/)?google.com\/device\n(?:(?i:Code|Login[ \t]*code):?[ \t]*\n?|\s*)([A-Za-z](?:\s*[A-Za-z]){2,3}(?:\s*-\s*[A-Za-z](?:\s*[A-Za-z]){2,3})+(?![A-Za-z]))",
         "remote_group": "",
     },
 }


### PR DESCRIPTION
When GDM renders the qrcode layout it displays the 'Login code:' label and the actual code as separate UI widgets, so they appear on separate lines in the GDM dialog.  When OCR of the GDM screen also drops the colon (a common OCR failure), the alternation in DEVICE_URL_REGEX falls through to the \s* branch, and the capture group — which included a literal space — greedily matched the two-word label 'Login code', producing 'LOGINCODE' instead of the real code.

Two changes close the gap:
1. Make the colon optional (:?) and allow a newline (\n?) between the label and the code, so 'Login code\nWXYZ-ABCD' is handled correctly.
2. Remove the space from the capture group ([A-Za-z\-]+ instead of [A-Za-z\- ]+), so that even if the \s* fallback is taken the multi-word label cannot be swallowed as the device code.

Closes #1719 
UDENG-10984