### PR TITLE
Ensure GDM sees managed users after reboot

### DIFF
--- a/debian/authd.service.in
+++ b/debian/authd.service.in
@@ -3,6 +3,8 @@ Description=authd daemon service
 After=authd.socket
 Requires=authd.socket
 PartOf=authd.socket
+# AccountsService starts after this target to populate the GDM user list.
+Before=nss-user-lookup.target
 
 [Service]
 Type=notify

--- a/debian/authd.socket
+++ b/debian/authd.socket
@@ -6,6 +6,8 @@ Wants=dbus.service
 After=dbus.service
 Before=nss-user-lookup.target
 Wants=nss-user-lookup.target
+# Start the daemon before AccountsService queries NSS for its cached users.
+Wants=authd.service
 
 [Socket]
 ListenStream=/run/authd.sock

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -83,6 +83,11 @@ Wait Until GDM Login Screen Ready
     BuiltIn.Sleep    2
 
 
+Wait Until System Is Running Or Degraded
+    Wait Until Keyword Succeeds    3 min    1 sec
+    ...    SSH.Execute    output=$(systemctl is-system-running --wait) || [ "$output" = degraded ]
+
+
 Wait Until Desktop Ready
     Wait Until Keyword Succeeds    1 min    1 sec
     ...    Try Desktop Ready

--- a/e2e-tests/tests/gdm_managed_user_after_reboot.robot
+++ b/e2e-tests/tests/gdm_managed_user_after_reboot.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+Test Setup       utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown    utils.Test Teardown
+
+
+*** Variables ***
+${username}        %{E2E_USER}
+${local_password}  qwer1234
+
+
+*** Test Cases ***
+Managed user is listed by GDM after reboot
+    [Documentation]    Verify that GDM discovers an existing managed user during boot.
+    ...
+    ...                Do not query NSS after the reboot: that would activate authd and
+    ...                hide the startup-ordering regression this test covers.
+    Log In With Remote User Through GDM: QR Code    ${username}    ${local_password}
+    Log Out
+    ${display_name} =    SSH.Execute    getent passwd ${username} | cut -d: -f5 | cut -d, -f1
+
+    Run Keyword And Ignore Error    SSH.Execute    systemctl reboot
+    Wait Until Keyword Succeeds    3 min    1 sec
+    ...    SSH.Execute    systemctl is-system-running --wait
+
+    Wait Until GDM Login Screen Ready
+    Match Text    ${display_name}    30

--- a/e2e-tests/tests/gdm_managed_user_after_reboot.robot
+++ b/e2e-tests/tests/gdm_managed_user_after_reboot.robot
@@ -23,8 +23,7 @@ Managed user is listed by GDM after reboot
     ${display_name} =    SSH.Execute    getent passwd ${username} | cut -d: -f5 | cut -d, -f1
 
     Run Keyword And Ignore Error    SSH.Execute    systemctl reboot
-    Wait Until Keyword Succeeds    3 min    1 sec
-    ...    SSH.Execute    systemctl is-system-running --wait
+    Wait Until System Is Running Or Degraded
 
     Wait Until GDM Login Screen Ready
     Match Text    ${display_name}    30

--- a/e2e-tests/tests/gdm_managed_user_after_reboot.robot
+++ b/e2e-tests/tests/gdm_managed_user_after_reboot.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+Test Setup       utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown    utils.Test Teardown
+
+
+*** Variables ***
+${username}        %{E2E_USER}
+${local_password}  qwer1234
+
+
+*** Test Cases ***
+Managed user is listed by GDM after reboot
+    [Documentation]    Verify that GDM discovers an existing managed user during boot.
+    ...
+    ...                Do not query NSS after the reboot: that would activate authd and
+    ...                hide the startup-ordering regression this test covers.
+    Log In With Remote User Through GDM: QR Code    ${username}    ${local_password}
+    Log Out
+    ${display_name} =    SSH.Execute    getent passwd ${username} | cut -d: -f5 | cut -d, -f1
+    Should Not Be Empty    ${display_name}
+    Run Keyword And Ignore Error    SSH.Execute    systemctl reboot
+    Wait Until GDM Login Screen Ready
+    Match Text    ${display_name}    30

--- a/e2e-tests/vm/lib/libprovision.sh
+++ b/e2e-tests/vm/lib/libprovision.sh
@@ -62,10 +62,16 @@ function force_create_snapshot() {
 
     if virsh domstate "${VM_NAME}" | grep -q '^running'; then
         # If the VM is running, we have to use --memspec to create the snapshot
-        local memfile="${IMAGE%.qcow2}-${snapshot_name}.mem"
+        # Libvirt's default disk filename is derived from the snapshot name.
+        # A failed or metadata-only-deleted snapshot can leave that file behind.
+        local snapshot_id
+        snapshot_id="$(date +%s%N)"
+        local diskfile="${IMAGE%.qcow2}.${snapshot_name}.${snapshot_id}"
+        local memfile="${IMAGE%.qcow2}-${snapshot_name}.${snapshot_id}.mem"
         time virsh snapshot-create-as \
           --domain "${VM_NAME}" \
           --name "${snapshot_name}" \
+          --diskspec "vda,file=${diskfile},snapshot=external" \
           --memspec "${memfile},snapshot=external"
         return
     fi

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1522,6 +1522,10 @@ func TestGdmModel(t *testing.T) {
 			wantPAMReturnValue: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_regenerated_after_wait_started_at_auth_selection_stage_from_client_after_client_side_broker_and_auth_mode_selection": {
+			// This test has one more event cycle than its sibling test above,
+			// so it needs at least as much time to avoid flaking on loaded CI
+			// runners.
+			timeout: 30 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(pam_test.WithWait(true)),
 				pam_test.QrCodeUILayout(),


### PR DESCRIPTION
AccountsService can enumerate NSS users before authd has completed its socket-activated startup, leaving the GDM user cache without managed accounts until they log in once. Start authd as part of the NSS lookup target and make that target wait for the daemon to become ready.

Also adds an e2e-test to test that the authd user shows up in GDM after a reboot.

Closes #1743 
UDENG-11043