### PR TITLE
docs: explanation of user management, local files, NSS, and authctl

### DIFF
--- a/docs/explanation/authd-architecture.md
+++ b/docs/explanation/authd-architecture.md
@@ -5,6 +5,7 @@ myst:
       "authd has a modular architecture, consisting of an authentication daemon and an identity broker."
 ---
 
+(explanation::authd-architecture)=
 # authd architecture
 
 authd can help organizations ensure secure identity and access management by enabling seamless cloud-based authentication of Ubuntu machines.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -33,6 +33,17 @@ that affect the security of authd.
 authd security overview <security>
 ```
 
+## User management
+
+Learn how authd manages users and groups, and how this differs from
+traditional local Linux accounts.
+
+```{toctree}
+:titlesonly:
+
+User management <user-management>
+```
+
 ## Documentation
 
 Information about the authd documentation itself.

--- a/docs/explanation/user-management.md
+++ b/docs/explanation/user-management.md
@@ -43,7 +43,7 @@ reference](reference::group-management) for details.
 ## authd provides an NSS module to get user information
 
 Linux systems can resolve user and group information through NSS.
-This enables administrators to specify which files to query for information,
+This enables administrators to specify which sources to query for information,
 such as user account details.
 
 authd's NSS module gets information from its local cache of the identity

--- a/docs/explanation/user-management.md
+++ b/docs/explanation/user-management.md
@@ -1,0 +1,68 @@
+---
+myst:
+    html_meta:
+        "description lang=en":
+            "The recommended way to manage users with authd is with the dedicated authctl tool."
+---
+
+(explanation::user-management)=
+# User management with authd
+
+authd is packaged with a Name Service Switch (NSS) module, which it uses
+internally for querying authd-managed users and groups. For administrators
+managing users and groups, authd provides the `authctl` tool.
+
+Other tools for managing Linux users, which rely on local files, may be
+incompatible with authd. This page provides a brief explanation of how user
+management works on authd and why `authctl` is the recommended tool for managing
+users.
+
+## Tools that modify `/etc/passwd` or `/etc/group` may not work
+
+In Linux systems, `/etc/passwd` stores user account information required during
+login, while `/etc/group` defines groups to which users belong.
+
+Information about users managed by authd, and their remote groups, never need
+to be written to `/etc/passwd` or `/etc/group`. For this reason, common tools
+like `usermod`, `userdel`, and `groupmod`, which modify these files directly,
+may not work consistently for authd-managed users.
+
+Similarly, scripts or software that query `/etc/passwd` to get the home
+directory of `<user>` by their ID will fail for authd-managed users. This also
+applies to `/etc/group` for remote groups (groups from the identity provider
+that aren't mapped to a local group).
+
+```{admonition} Local and remote groups
+:class: note
+Groups from the identity provider can be mapped into local Linux groups for the
+user. See the [group and privilege management
+reference](reference::group-management) for details.
+```
+
+## authd uses an NSS module to get user information
+
+Linux systems can resolve user and group information through NSS.
+This enables administrators to specify which files to query for information,
+such as user account details.
+
+authd's NSS module gets information from its local cache of the identity
+provider's users and groups. This is discussed in the [overview of authd's
+architecture](explanation::authd-architecture).
+
+## authd users should be managed using authctl
+
+For authd-managed users and groups, use [`authctl`](reference::cli),
+a dedicated command-line tool for user management.
+
+`authctl` supports operations including locking users, deleting users, and
+modifying user home directories.
+
+Group membership and privileges are managed through the identity provider, as
+described in the [group and privilege management guide](reference::group-management).
+
+## Further reading
+
+* [System databases and NSS in the GNU C library manual](https://sourceware.org/glibc/manual/latest/html_mono/libc.html#Name-Service-Switch)
+* [authctl CLI reference documentation](reference::cli)
+* [Group and privilege management with authd](reference::group-management)
+

--- a/docs/explanation/user-management.md
+++ b/docs/explanation/user-management.md
@@ -46,7 +46,7 @@ Linux systems can resolve user and group information through NSS.
 This enables administrators to specify which sources to query for information,
 such as user account details.
 
-authd's NSS module gets information from its local cache of the identity
+authd's NSS module gets information from its local database of the identity
 provider's users and groups. This is discussed in the [overview of authd's
 architecture](explanation::authd-architecture).
 

--- a/docs/explanation/user-management.md
+++ b/docs/explanation/user-management.md
@@ -40,7 +40,7 @@ user. See the [group and privilege management
 reference](reference::group-management) for details.
 ```
 
-## authd uses an NSS module to get user information
+## authd provides an NSS module to get user information
 
 Linux systems can resolve user and group information through NSS.
 This enables administrators to specify which files to query for information,

--- a/docs/explanation/user-management.md
+++ b/docs/explanation/user-management.md
@@ -8,9 +8,10 @@ myst:
 (explanation::user-management)=
 # User management with authd
 
-authd is packaged with a Name Service Switch (NSS) module, which it uses
-internally for querying authd-managed users and groups. For administrators
-managing users and groups, authd provides the `authctl` tool.
+authd is packaged with a Name Service Switch (NSS) module that allows
+applications on the system to query authd-managed users and groups through
+standard Linux user and group lookup interfaces. For administrators managing
+users and groups, authd provides the `authctl` tool.
 
 Other tools for managing Linux users, which rely on local files, may be
 incompatible with authd. This page provides a brief explanation of how user

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1,3 +1,4 @@
+(reference::cli)=
 # authctl reference
 
 The `authctl` command line tool is used to manage authd users and groups.


### PR DESCRIPTION
Closes https://github.com/canonical/authd/issues/1014

* Explains why tools for modifying local users may not work with authd
* Explains the role of NSS in authd
* Points to authctl as the recommended tool for user management
* Links to relevant internal/external docs

UDENG-7360