### PR TITLE
pam/gdmmodel-test: increase timeout for qrcode-regeneration test

### DIFF
--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1522,6 +1522,10 @@ func TestGdmModel(t *testing.T) {
 			wantPAMReturnValue: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_regenerated_after_wait_started_at_auth_selection_stage_from_client_after_client_side_broker_and_auth_mode_selection": {
+			// This test has one more event cycle than its sibling test above,
+			// so it needs at least as much time to avoid flaking on loaded CI
+			// runners.
+			timeout: 30 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(pam_test.WithWait(true)),
 				pam_test.QrCodeUILayout(),


### PR DESCRIPTION
TestGdmModel/Authenticated_with_qrcode_regenerated_after_wait_started _at_auth_selection_stage_... intermittently timed out in CI ("Timeout waiting for expected events"), causing required gdm events to arrive out of order relative to the assertion deadline.

This test case has one more changeStage/authModeSelected/authEvent cycle than its sibling test right above it, yet was left at the default 20s timeout while the sibling was already bumped to 30s in an earlier flakiness fix (6f9de813d). Under loaded CI runners the extra cycle pushed it past the shorter deadline.

Align the timeout with the sibling test so both get the same margin.

Closes #1761
