### PR TITLE
ci(e2e): stop chunking the VM image OCI artifact upload

### DIFF
--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -129,13 +129,15 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-          # Chunk qcow2 into stable fixed-size layers (64 MiB)
-          WORKDIR=$(mktemp -d)
-          split -b 64M "$IMAGE_PATH" "$WORKDIR/chunk-"
-
-          # Push as a layered OCI artifact (each chunk becomes a layer)
-          cd "$WORKDIR"
-          oras push "${OCI_REPO}:${OCI_TAG}" chunk-* --artifact-type application/vnd.qemu.qcow2
+          # Push the qcow2 as a single layer. It used to be split into
+          # many small chunks hoping unchanged chunks would be deduped
+          # and skipped, but in practice each provisioning run bakes in
+          # new random data (UUIDs, timestamps, ...) so virtually no
+          # chunks are ever reused - we just paid for dozens of extra
+          # API requests per push, which was tripping ghcr.io's
+          # secondary rate limit.
+          oras push "${OCI_REPO}:${OCI_TAG}" "$IMAGE_PATH" \
+            --artifact-type application/vnd.qemu.qcow2
 
   build-deb:
     uses: ./.github/workflows/debian-build.yaml

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -136,8 +136,13 @@ jobs:
           # chunks are ever reused - we just paid for dozens of extra
           # API requests per push, which was tripping ghcr.io's
           # secondary rate limit.
-          oras push "${OCI_REPO}:${OCI_TAG}" "$IMAGE_PATH" \
-            --artifact-type application/vnd.qemu.qcow2
+          image_dir="$(dirname "$IMAGE_PATH")"
+          image_name="$(basename "$IMAGE_PATH")"
+          (
+            cd "$image_dir"
+            oras push "${OCI_REPO}:${OCI_TAG}" "$image_name" \
+              --artifact-type application/vnd.qemu.qcow2
+          )
 
   build-deb:
     uses: ./.github/workflows/debian-build.yaml

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -161,6 +161,12 @@ jobs:
             | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
           oras pull "${OCI_REPO}:${OCI_TAG}" -o "$(dirname "$IMAGE_PATH")"
+          if [ ! -f "$IMAGE_PATH" ]; then
+            echo "Error: Expected image not found at $IMAGE_PATH after pull"
+            echo "Downloaded files:"
+            find "$(dirname "$IMAGE_PATH")" -type f -print
+            exit 1
+          fi
           echo "image-path=${IMAGE_PATH}" >> $GITHUB_OUTPUT
 
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -160,9 +160,7 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-          oras pull "${OCI_REPO}:${OCI_TAG}"
-          cat chunk-* > "$IMAGE_PATH"
-          rm chunk-*
+          oras pull "${OCI_REPO}:${OCI_TAG}" -o "$(dirname "$IMAGE_PATH")"
           echo "image-path=${IMAGE_PATH}" >> $GITHUB_OUTPUT
 
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main


### PR DESCRIPTION
The VM qcow2 image was split into fixed-size chunks before being pushed to ghcr.io as a layered OCI artifact, on the assumption that unchanged chunks between runs would be deduped and skipped, saving time and bandwidth.

Checking chunk push logs across 34 recent CI runs shows this almost never pays off: when the image is fully unchanged (same commit), all chunks are skipped, but a single blob would dedupe just as well. When the image changes at all, each provisioning run bakes in fresh random data (UUIDs, timestamps, ...), so on average only ~3% of chunks in a changed image happened to already exist - not meaningful reuse, just occasional coincidental matches (e.g. sparse zero blocks).

So chunking bought virtually no savings while turning every push into 50-60 small concurrent blob uploads, which occasionally tripped ghcr.io's secondary rate limit (403) and failed the job (e.g. in https://github.com/canonical/authd/actions/runs/31398258504/job/93486515030?pr=1709).

Push/pull the qcow2 as a single layer instead.