### PR TITLE
Run broker tests with all available providers

### DIFF
--- a/.github/workflows/brokers-qa.yaml
+++ b/.github/workflows/brokers-qa.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Install gotestfmt and our wrapper script
         uses: canonical/desktop-engineering/gh-actions/go/gotestfmt@main
 
-      - name: Run tests (with coverage collection)
+      - name: Run tests for all providers (with coverage collection)
         if: matrix.test == 'coverage'
         run: |
           set -euo pipefail
@@ -125,21 +125,40 @@ jobs:
           # The coverage is not written if the output directory does not exist, so we need to create it.
           cov_dir=${PWD}/coverage
           raw_cov_dir=${cov_dir}/raw_files
+          merged_cov_dir=${cov_dir}/raw_merged
           codecov_dir=${cov_dir}/codecov
 
-          mkdir -p "${raw_cov_dir}" "${codecov_dir}"
+          mkdir -p "${raw_cov_dir}" "${merged_cov_dir}" "${codecov_dir}"
 
           # Print executed commands to ease debugging
           set -x
 
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.
-          #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
-          go test -tags withmsentraid -json -cover -covermode=set ./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}" 2>&1 | \
-            gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_DIR}/gotestfmt.cover.log"
+          # TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
+          for provider in default google msentraid; do
+            provider_cov_dir="${raw_cov_dir}/${provider}"
+            mkdir -p "${provider_cov_dir}"
+
+            go_test_tags=()
+            if [ "${provider}" = "google" ]; then
+              go_test_tags=(-tags withgoogle)
+            elif [ "${provider}" = "msentraid" ]; then
+              go_test_tags=(-tags withmsentraid)
+            fi
+
+            go test "${go_test_tags[@]}" -json -cover -covermode=set ./... -shuffle=on -args \
+              -test.gocoverdir="${provider_cov_dir}" 2>&1 | \
+              gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_DIR}/gotestfmt.cover.${provider}.log"
+          done
+
+          # Merge the per-provider coverage data into a single report for Codecov/TICS.
+          go tool covdata merge \
+            -i="${raw_cov_dir}/default,${raw_cov_dir}/google,${raw_cov_dir}/msentraid" \
+            -o="${merged_cov_dir}"
 
           # Convert the raw coverage data into textfmt so we can merge the Rust one into it
-          go tool covdata textfmt -i="${raw_cov_dir}" -o="${cov_dir}/coverage.out"
+          go tool covdata textfmt -i="${merged_cov_dir}" -o="${cov_dir}/coverage.out"
 
           # Filter out the testutils package
           grep -v -e "testutils" "${cov_dir}/coverage.out" >"${cov_dir}/coverage.out.filtered"
@@ -169,7 +188,7 @@ jobs:
 
           # We only run the msentraid tests with ASAN because only these use cgo.
           pushd ./internal/providers/msentraid
-          go test -asan -gcflags=all="${GO_GC_FLAGS}" -c
+          go test -tags withmsentraid -asan -gcflags=all="${GO_GC_FLAGS}" -c
           go tool test2json -p internal/providers/msentraid ./msentraid.test \
             -test.v=test2json \
             -test.failfast \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,21 @@ cargo build                              # NSS (debug mode)
 - **Test helpers with underscores**: Functions prefixed `Z_ForTests_` are test-only exports (e.g., `Z_ForTests_CreateDBFromYAML`)
 - **Environment variables**:
   - `AUTHD_SKIP_ROOT_TESTS=1`: Skip tests that fail when run as root
+- **Broker provider build tags**: An untagged broker test run does not compile
+  the provider-specific wiring. When changing broker code, run tests for every
+  provider configuration:
+  ```bash
+  go -C authd-oidc-brokers test ./...
+  go -C authd-oidc-brokers test -tags withgoogle ./...
+  go -C authd-oidc-brokers generate --tags withmsentraid ./internal/providers/msentraid/...
+  go -C authd-oidc-brokers test -tags withmsentraid ./...
+  ```
+  The `withmsentraid` generation step requires the recursive
+  `libhimmelblau` submodule and generates the `himmelblau.h` and library
+  artifacts.
+- **Broker linting**: Pass provider tags explicitly, for example:
+  `scripts/golangci-lint -C authd-oidc-brokers run --build-tags withmsentraid`.
+  Use `--build-tags withgoogle` for Google-specific changes.
 
 ### Code Generation
 Critical: Run `go generate` before building PAM or when modifying protobuf files:


### PR DESCRIPTION
Run broker tests with the default, `withgoogle`, and `withmsentraid` build tags, including ASAN for Entra, so provider-specific build failures are caught in CI.

UDENG-8449