### PR TITLE
e2e: diagnose and reduce flakiness in browser login TOTP handling

### DIFF
--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -234,6 +234,14 @@ jobs:
           RELEASE: ${{ inputs.ubuntu-version }}
           BROKER: ${{ inputs.broker }}
           E2E_TESTS_DESCRIPTION: ${{ inputs.e2e-tests-description }}
+          # Browser.Login uses this short-lived lock; the rest of the e2e
+          # tests remain parallel across Ubuntu releases. This is an
+          # experiment for an observed correlation, not a guaranteed fix.
+          E2E_BROWSER_LOGIN_LOCK_BUCKET: authd-e2e-test-logs
+          E2E_BROWSER_LOGIN_LOCK_KEY: e2e-tests/browser-login/${{ inputs.broker }}
+          E2E_BROWSER_LOGIN_LOCK_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           set -eux
           export PATH="$(realpath "${{ env.E2E_TESTS_DIR }}/vm/helpers"):${PATH}"

--- a/e2e-tests/resources/Browser.py
+++ b/e2e-tests/resources/Browser.py
@@ -3,10 +3,13 @@ import subprocess
 import sys
 import threading
 
-from robot.api.deco import keyword, library  # type: ignore
 from robot.api import logger
+from robot.api.deco import keyword, library  # type: ignore
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+from browser_login_lock import get_browser_login_lock
+
 BROWSER_LOGIN_DIR = os.path.join(SCRIPT_DIR, "browser_login")
 
 # Map broker names to their broker-specific browser login scripts.
@@ -57,18 +60,19 @@ class Browser:
             command = ["/usr/bin/env", "GDK_BACKEND=x11", "xvfb-run", "-a", "--"] + command
 
         lines = []
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        stdout_thread = threading.Thread(
-            target=_stream_to_stderr, args=(process.stdout, lines), daemon=True
-        )
-        stdout_thread.start()
-        process.wait()
-        stdout_thread.join()
+        with get_browser_login_lock():
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            stdout_thread = threading.Thread(
+                target=_stream_to_stderr, args=(process.stdout, lines), daemon=True
+            )
+            stdout_thread.start()
+            process.wait()
+            stdout_thread.join()
 
         for line in lines:
             logger.info(line)

--- a/e2e-tests/resources/TOTP.py
+++ b/e2e-tests/resources/TOTP.py
@@ -15,9 +15,8 @@ class TOTP:
     def generate_totp_code(self) -> str:
         """Return the current TOTP code derived from the TOTP_SECRET environment variable.
 
-        Waits until there are at least 5 seconds left in the current time window
-        before generating the code (see generate_totp.py) so the code remains
-        valid long enough to be typed in.
+        Waits until the code is valid for long enough to be typed in (see
+        MIN_VALIDITY_S in generate_totp.py) before generating it.
         """
         secret = os.environ.get("TOTP_SECRET", "")
         if not secret:

--- a/e2e-tests/resources/browser_login/browser_window.py
+++ b/e2e-tests/resources/browser_login/browser_window.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import time
 import traceback
 import sys
 
@@ -306,6 +307,99 @@ class BrowserWindow(Gtk.Window):
 
         logger.info(f"Found strings matching pattern: {found!r}")
         return found
+
+    def run_javascript_sync(self, js: str, timeout_ms: int = 5000) -> str:
+        """Run `js` in the page and return its result as a string.
+
+        Blocks the caller by running a nested main loop until the script
+        finishes or `timeout_ms` elapses.
+        """
+        loop = GLib.MainLoop()
+        cancellable = Gio.Cancellable()
+        result = ""
+        error = None
+        timed_out = False
+
+        def on_timeout():
+            nonlocal timed_out
+
+            timed_out = True
+            cancellable.cancel()
+            loop.quit()
+            return False
+
+        def on_js_finished(web_view, task):
+            nonlocal result, error
+
+            try:
+                result = web_view.run_javascript_finish(task).get_js_value().to_string()
+            except GLib.Error as e:
+                if e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
+                    return
+                error = e
+            except Exception as e:
+                error = e
+
+            loop.quit()
+
+        timeout_id = GLib.timeout_add(timeout_ms, on_timeout)
+        self.web_view.run_javascript(js, cancellable, on_js_finished)
+        loop.run()
+
+        if timed_out:
+            raise TimeoutError(f"Timed out after {timeout_ms}ms running JavaScript")
+
+        GLib.source_remove(timeout_id)
+
+        if error is not None:
+            raise error
+
+        return result
+
+    def get_focused_input_value(self, timeout_ms: int = 5000) -> str | None:
+        """Return the text of the currently focused input element.
+
+        Returns None if no input element is focused, which is different from
+        an empty string, meaning a focused but empty input element.
+        """
+        js = """(function() {
+                    var el = document.activeElement;
+                    if (!el || typeof el.value !== 'string') {
+                        return JSON.stringify({focused: false, value: ''});
+                    }
+                    return JSON.stringify({focused: true, value: el.value});
+                })()"""
+
+        state = json.loads(self.run_javascript_sync(js, timeout_ms=timeout_ms))
+        return state["value"] if state["focused"] else None
+
+    def wait_for_focused_input_value(self, expected: str, timeout_ms: int = 5000,
+                                     poll_interval_ms: int = 50) -> str | None:
+        """Wait for the focused input element to contain `expected`.
+
+        Key events are handed to the web content asynchronously, so the typed
+        text only appears in the DOM some time after send_key_taps returned.
+
+        Returns the value of the field, which differs from `expected` if it
+        did not appear before the timeout.
+        """
+        deadline = time.monotonic() + timeout_ms / 1000
+        while True:
+            value = self.get_focused_input_value()
+            if value == expected or time.monotonic() >= deadline:
+                return value
+            self.wait_ms(poll_interval_ms)
+
+    def wait_ms(self, timeout_ms: int) -> None:
+        """Keep the main loop running for `timeout_ms` milliseconds."""
+        loop = GLib.MainLoop()
+
+        def on_timeout():
+            loop.quit()
+            return False
+
+        GLib.timeout_add(timeout_ms, on_timeout)
+        loop.run()
 
     def send_key(self, event_type, key, silent=False):
         if not silent:

--- a/e2e-tests/resources/browser_login/google.py
+++ b/e2e-tests/resources/browser_login/google.py
@@ -19,8 +19,14 @@ from base import (
     logger,
     run_browser_login,
 )
+from generate_totp import TOTP_CODE_LENGTH, TOTPCode, generate_totp_details
 
 TOTP_CODE_MAX_TRIES = 5
+
+# How long to wait for a typed TOTP code to show up in the input field. Kept
+# short because a mismatch costs this twice, before the code is submitted, and
+# the code is only valid for MIN_VALIDITY_S seconds after it was generated.
+TOTP_FIELD_TIMEOUT_MS = 2000
 
 # Patterns that identify each page, used in wait_for_pattern calls.
 _ENTER_CODE = "Enter the code displayed on your device"
@@ -92,6 +98,8 @@ class GoogleLoginFlow:
         self._totp_secret = totp_secret
         self._screenshot_dir = screenshot_dir
         self._last_totp_code: str | None = None
+        self._submitted_totp: TOTPCode | None = None
+        self._totp_submitted_at: float | None = None
 
     def run(self) -> None:
         """Execute the full login flow, retrying on TOTP failures."""
@@ -162,6 +170,7 @@ class GoogleLoginFlow:
                 "\"too many failed attempts\" lockout page. The test "
                 "account is likely locked out for a few hours.")
         if _matches_phrase(matches, _WRONG_TOTP, _WRONG_NUMBER_OF_DIGITS):
+            self._log_rejected_totp_code()
             raise WrongTOTPCodeError("TOTP code was rejected")
         if _matches_phrase(matches, "find your google account", _EMAIL_INVALID):
             self._handle_wrong_email()
@@ -195,7 +204,7 @@ class GoogleLoginFlow:
         self._browser.capture_snapshot(self._screenshot_dir, "device-login-enter-username")
         # Clear any text that may have accumulated in the field from previous
         # attempts (due to the page-load race described in _handle_wrong_email).
-        self._clear_input_field(self._username)
+        self._clear_input_field(len(self._username))
         self._browser.send_key_taps(
             ascii_string_to_key_events(self._username) + [Gdk.KEY_Return])
 
@@ -206,9 +215,62 @@ class GoogleLoginFlow:
 
     def _handle_totp_page(self) -> None:
         self._browser.capture_snapshot(self._screenshot_dir, "device-login-enter-totp-code")
-        self._last_totp_code = generate_totp(self._totp_secret)
-        self._browser.send_key_taps(
-            ascii_string_to_key_events(self._last_totp_code) + [Gdk.KEY_Return])
+
+        # Clear the field before typing: this handler can be entered again
+        # while the previous submission is still being validated, because the
+        # page still shows the 2-Step Verification text until Google answers.
+        # Leftover digits would be silently truncated to the field's maximum
+        # length, which turns into a wrong code rather than into an obvious
+        # error about the number of digits.
+        self._clear_input_field(TOTP_CODE_LENGTH)
+
+        totp = generate_totp_details(self._totp_secret)
+        self._last_totp_code = totp.code
+        self._browser.send_key_taps(ascii_string_to_key_events(totp.code))
+
+        self._verify_totp_field(totp.code)
+
+        self._submitted_totp = totp
+        self._totp_submitted_at = time.monotonic()
+        logger.info(f"Submitting TOTP code {totp.code} (time step {totp.time_step}), "
+                    f"generated {totp.age():.1f}s ago, "
+                    f"valid for another {totp.seconds_left():.1f}s")
+        self._browser.send_key_taps([Gdk.KEY_Return])
+
+    def _verify_totp_field(self, expected_code: str) -> None:
+        """Check that the typed code actually made it into the input field.
+
+        Key events can get lost or land in the wrong element, and the code that
+        is submitted then is rejected as wrong, which is indistinguishable from
+        a code generated from a wrong clock. Reading the field back tells the
+        two apart. It also makes sure the code is complete before it is
+        submitted, since key events reach the web content asynchronously.
+
+        Retypes the code once, since a dropped key event is transient.
+        """
+        for attempt in range(2):
+            try:
+                value = self._browser.wait_for_focused_input_value(
+                    expected_code, timeout_ms=TOTP_FIELD_TIMEOUT_MS)
+            except TimeoutError as e:
+                logger.warning(f"Could not read back the TOTP input field: {e}")
+                return
+
+            if value == expected_code:
+                return
+
+            logger.warning(f"TOTP input field contains {value!r} instead of "
+                           f"{expected_code!r}")
+            if attempt > 0:
+                break
+
+            logger.info("Clearing the field and typing the code again")
+            self._clear_input_field(max(len(value or ""), TOTP_CODE_LENGTH))
+            self._browser.send_key_taps(ascii_string_to_key_events(expected_code))
+
+        raise RuntimeError(
+            f"Failed to type the TOTP code into the input field: it contains "
+            f"{value!r} instead of {expected_code!r}")
 
     def _handle_choose_account_page(self) -> None:
         self._browser.capture_snapshot(self._screenshot_dir, "device-login-choose-account")
@@ -231,7 +293,7 @@ class GoogleLoginFlow:
         # next wait_for_pattern would still see it and re-enter this handler.
         # Clear the field and retype the email immediately so the form is
         # resubmitted and the error is dismissed within this single dispatch.
-        self._clear_input_field(self._username)
+        self._clear_input_field(len(self._username))
         self._browser.send_key_taps(
             ascii_string_to_key_events(self._username) + [Gdk.KEY_Return])
 
@@ -245,16 +307,29 @@ class GoogleLoginFlow:
 
     def _handle_wrong_password(self) -> None:
         self._browser.capture_snapshot(self._screenshot_dir, "device-login-wrong-password")
-        self._clear_input_field(self._password)
+        self._clear_input_field(len(self._password))
 
-    def _clear_input_field(self, field_value: str) -> None:
+    def _log_rejected_totp_code(self) -> None:
+        """Log the timing of a rejected code, to tell a stale code apart from
+        one that was wrong the moment it was submitted."""
+        if self._submitted_totp is None or self._totp_submitted_at is None:
+            logger.warning("A TOTP code was rejected, but none was submitted")
+            return
+
+        totp = self._submitted_totp
+        logger.info(f"TOTP code {totp.code} (time step {totp.time_step}) was rejected "
+                    f"{time.monotonic() - self._totp_submitted_at:.1f}s after it was "
+                    f"submitted; it was still valid for {totp.seconds_left():.1f}s "
+                    "at that point")
+
+    def _clear_input_field(self, content_length: int) -> None:
         """Delete all text from the focused input field.
 
-        Sends twice as many BackSpace events as the length of field_value to
-        account for text that may have accumulated from multiple typing attempts.
-        Extra BackSpaces beyond the actual content are harmless.
+        Sends twice as many BackSpace events as `content_length` to account for
+        text that may have accumulated from multiple typing attempts. Extra
+        BackSpaces beyond the actual content are harmless.
         """
-        self._browser.send_key_taps(2 * len(field_value) * [Gdk.KEY_BackSpace])
+        self._browser.send_key_taps(2 * content_length * [Gdk.KEY_BackSpace])
 
 def login(browser, username: str, password: str, device_code: str, totp_secret: str, screenshot_dir: str = "."):
     GoogleLoginFlow(browser, username, password, device_code, totp_secret, screenshot_dir).run()

--- a/e2e-tests/resources/browser_login_lock.py
+++ b/e2e-tests/resources/browser_login_lock.py
@@ -1,0 +1,326 @@
+"""Distributed lock used to serialize browser-based identity-provider logins."""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import json
+import logging
+import os
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserLoginLockError(RuntimeError):
+    """Raised when the shared browser-login lock cannot be used."""
+
+
+@dataclass(frozen=True)
+class BrowserLoginLockConfig:
+    bucket: str
+    key: str
+    endpoint: str
+    region: str
+    wait_timeout_s: float
+    lease_timeout_s: float
+    poll_interval_s: float
+
+    @classmethod
+    def from_environment(cls) -> BrowserLoginLockConfig | None:
+        """Read the lock configuration, or disable locking when unset."""
+        names = {
+            "bucket": "E2E_BROWSER_LOGIN_LOCK_BUCKET",
+            "key": "E2E_BROWSER_LOGIN_LOCK_KEY",
+            "endpoint": "E2E_BROWSER_LOGIN_LOCK_ENDPOINT",
+        }
+        values = {name: os.getenv(environment_name) for name, environment_name in names.items()}
+        configured = [value is not None for value in values.values()]
+        if not any(configured):
+            return None
+        if not all(configured):
+            missing = [
+                environment_name
+                for name, environment_name in names.items()
+                if values[name] is None
+            ]
+            raise BrowserLoginLockError(
+                "Browser-login locking is partially configured; missing "
+                + ", ".join(missing)
+            )
+
+        return cls(
+            bucket=values["bucket"],
+            key=values["key"],
+            endpoint=values["endpoint"],
+            region=os.getenv("E2E_BROWSER_LOGIN_LOCK_REGION", "auto"),
+            wait_timeout_s=_positive_duration(
+                "E2E_BROWSER_LOGIN_LOCK_WAIT_TIMEOUT_S", default=30 * 60
+            ),
+            lease_timeout_s=_positive_duration(
+                "E2E_BROWSER_LOGIN_LOCK_LEASE_TIMEOUT_S", default=30 * 60
+            ),
+            poll_interval_s=_positive_duration(
+                "E2E_BROWSER_LOGIN_LOCK_POLL_INTERVAL_S", default=10
+            ),
+        )
+
+
+def _positive_duration(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        duration = float(value)
+    except ValueError as e:
+        raise BrowserLoginLockError(f"{name} must be a positive number") from e
+    if duration <= 0:
+        raise BrowserLoginLockError(f"{name} must be a positive number")
+    return duration
+
+
+@dataclass(frozen=True)
+class _LockMetadata:
+    etag: str
+    last_modified: float
+
+
+class BrowserLoginLock:
+    """An S3-compatible lease lock backed by a conditional object."""
+
+    def __init__(self, config: BrowserLoginLockConfig):
+        self._config = config
+        self._etag: str | None = None
+        self._token = uuid.uuid4().hex
+
+    def __enter__(self) -> Self:
+        self.acquire()
+        return self
+
+    def __exit__(self, exception_type, exception, traceback) -> bool:
+        try:
+            self.release()
+        except BrowserLoginLockError:
+            if exception_type is None:
+                raise
+            logger.exception("Could not release the browser-login lock")
+        return False
+
+    def acquire(self) -> None:
+        """Wait for and acquire the lock, recovering an expired lease."""
+        if self._etag is not None:
+            raise BrowserLoginLockError("The browser-login lock is already acquired")
+
+        deadline = time.monotonic() + self._config.wait_timeout_s
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as token_file:
+            token_file.write(self._token)
+            token_path = token_file.name
+
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise BrowserLoginLockError(
+                        "Timed out waiting for the shared browser-login lock"
+                    )
+
+                if self._try_create(token_path):
+                    logger.info("Acquired the shared browser-login lock")
+                    return
+
+                metadata = self._get_metadata()
+                if metadata is None:
+                    continue
+
+                age = time.time() - metadata.last_modified
+                if age >= self._config.lease_timeout_s:
+                    logger.warning(
+                        "Recovering a stale browser-login lock that is %.0fs old", age
+                    )
+                    self._try_delete(metadata.etag)
+                    continue
+
+                logger.info(
+                    "Another browser login holds the shared lock; waiting %.0fs",
+                    min(self._config.poll_interval_s, remaining),
+                )
+                time.sleep(min(self._config.poll_interval_s, remaining))
+        finally:
+            os.unlink(token_path)
+
+    def release(self) -> None:
+        """Release the lock only if the object is still owned by this instance."""
+        if self._etag is None:
+            return
+
+        etag = self._etag
+        if not self._try_delete(etag):
+            raise BrowserLoginLockError(
+                "The browser-login lock changed before it could be released"
+            )
+
+        self._etag = None
+        logger.info("Released the shared browser-login lock")
+
+    def _try_create(self, token_path: str) -> bool:
+        result = self._run_aws(
+            "put-object",
+            "--body",
+            token_path,
+            "--if-none-match",
+            "*",
+        )
+        if result.returncode != 0:
+            if _is_precondition_failure(result):
+                return False
+            raise _aws_error("put-object", result)
+
+        response = _parse_response("put-object", result)
+        etag = _normalise_etag(response.get("ETag"))
+        if etag is None:
+            raise BrowserLoginLockError(
+                "The browser-login lock was created without an object ETag"
+            )
+        self._etag = etag
+        return True
+
+    def _get_metadata(self) -> _LockMetadata | None:
+        result = self._run_aws("head-object")
+        if result.returncode != 0:
+            if _is_not_found(result):
+                return None
+            raise _aws_error("head-object", result)
+
+        response = _parse_response("head-object", result)
+        etag = _normalise_etag(response.get("ETag"))
+        last_modified = response.get("LastModified")
+        if etag is None or not isinstance(last_modified, str):
+            raise BrowserLoginLockError(
+                "The browser-login lock object has incomplete metadata"
+            )
+        try:
+            modified_at = datetime.datetime.fromisoformat(
+                last_modified.replace("Z", "+00:00")
+            ).timestamp()
+        except ValueError as e:
+            raise BrowserLoginLockError(
+                f"Could not parse browser-login lock timestamp {last_modified!r}"
+            ) from e
+        return _LockMetadata(etag=etag, last_modified=modified_at)
+
+    def _try_delete(self, etag: str) -> bool:
+        # R2 supports conditional PutObject, but not a conditional
+        # DeleteObject. First replace the object only if this lease is still
+        # ours, then delete the replacement. A competing owner cannot acquire
+        # the key between those operations because it still exists.
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as token_file:
+            token_file.write(uuid.uuid4().hex)
+            token_file.flush()
+            result = self._run_aws(
+                "put-object",
+                "--body",
+                token_file.name,
+                "--if-match",
+                etag,
+            )
+            if result.returncode != 0:
+                if _is_precondition_failure(result):
+                    return False
+                raise _aws_error("put-object", result)
+
+        result = self._run_aws("delete-object")
+        if result.returncode != 0:
+            raise _aws_error("delete-object", result)
+        return True
+
+    def _run_aws(self, operation: str, *arguments: str) -> subprocess.CompletedProcess[str]:
+        command = [
+            "aws",
+            "s3api",
+            operation,
+            "--bucket",
+            self._config.bucket,
+            "--key",
+            self._config.key,
+            "--endpoint-url",
+            self._config.endpoint,
+            "--region",
+            self._config.region,
+            "--output",
+            "json",
+            *arguments,
+        ]
+        environment = os.environ.copy()
+        environment["AWS_PAGER"] = ""
+        try:
+            return subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+        except FileNotFoundError as e:
+            raise BrowserLoginLockError(
+                "The browser-login lock is enabled, but the aws command is unavailable"
+            ) from e
+
+
+def _parse_response(
+    operation: str, result: subprocess.CompletedProcess[str]
+) -> dict[str, Any]:
+    try:
+        response = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise BrowserLoginLockError(
+            f"aws {operation} returned invalid JSON"
+        ) from e
+    if not isinstance(response, dict):
+        raise BrowserLoginLockError(f"aws {operation} returned a non-object response")
+    return response
+
+
+def _normalise_etag(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    # Preserve the quotes returned by S3: they are part of the If-Match
+    # entity-tag value sent back on the conditional PutObject request.
+    return value.strip()
+
+
+def _is_precondition_failure(result: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    return "preconditionfailed" in output or "412" in output
+
+
+def _is_not_found(result: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    return (
+        "notfound" in output
+        or "nosuchkey" in output
+        or "404" in output
+    )
+
+
+def _aws_error(operation: str, result: subprocess.CompletedProcess[str]) -> BrowserLoginLockError:
+    details = (result.stderr or result.stdout).strip()
+    if len(details) > 500:
+        details = details[:500] + "..."
+    return BrowserLoginLockError(
+        f"aws {operation} failed with exit code {result.returncode}: {details}"
+    )
+
+
+def get_browser_login_lock() -> contextlib.AbstractContextManager[None]:
+    """Return the configured lock, or a no-op context for local runs."""
+    config = BrowserLoginLockConfig.from_environment()
+    if config is None:
+        return contextlib.nullcontext()
+    return BrowserLoginLock(config)

--- a/e2e-tests/resources/generate_totp.py
+++ b/e2e-tests/resources/generate_totp.py
@@ -2,29 +2,79 @@
 
 import argparse
 import base64
+import dataclasses
 import hashlib
 import hmac
 import struct
 import time
 
-TIME_WINDOW = 5
+# Length of a TOTP time step, as defined by RFC 6238 and used by both Google
+# and Microsoft Entra ID.
+TIME_STEP_S = 30
 
-def generate_totp(secret: str) -> str:
-    # The code is generated according to the current time and is valid for 30 seconds.
-    # This means that if we generate the code just before the time window changes,
-    # it might be invalid by the time we use it. To avoid this, we make sure the time
-    # is safely within a new window before generating the code.
-    while time.time() % 30 > (30 - TIME_WINDOW):
-        time.sleep(0.1)
+# Minimum validity a freshly generated code must have left. Generating a code
+# shortly before its time step ends leaves too little time to type it in and
+# have the identity provider validate it, so we wait for the next step instead.
+MIN_VALIDITY_S = 10
 
+TOTP_CODE_LENGTH = 6
+
+
+@dataclasses.dataclass(frozen=True)
+class TOTPCode:
+    """A TOTP code together with the timing information it was derived from."""
+
+    code: str
+    time_step: int
+    generated_at: float
+
+    def seconds_left(self, now: float | None = None) -> float:
+        """Return for how much longer this code is valid, in seconds."""
+        if now is None:
+            now = time.time()
+        return (self.time_step + 1) * TIME_STEP_S - now
+
+    def age(self, now: float | None = None) -> float:
+        """Return how long ago this code was generated, in seconds."""
+        if now is None:
+            now = time.time()
+        return now - self.generated_at
+
+
+def totp_for_time_step(secret: str, time_step: int) -> str:
+    """Derive the TOTP code for `time_step` from `secret`."""
     key = base64.b32decode(secret, True)
-    msg = struct.pack(">Q", int(time.time()) // 30)
+    msg = struct.pack(">Q", time_step)
     hashed_obj = hmac.new(key, msg, hashlib.sha1).digest()
     o = hashed_obj[19] & 15
 
     totp_code = (struct.unpack(">I", hashed_obj[o:o + 4])[0] & 0x7fffffff) % 1000000
 
-    return f"{totp_code:06d}"
+    return f"{totp_code:0{TOTP_CODE_LENGTH}d}"
+
+
+def generate_totp_details(secret: str) -> TOTPCode:
+    """Generate a TOTP code and return it along with its timing information.
+
+    Waits until the code is valid for at least MIN_VALIDITY_S seconds.
+    """
+    # The code is generated from the current time and is only valid until the
+    # end of its time step. This means that if we generate the code just before
+    # the time step ends, it might already be invalid by the time the identity
+    # provider validates it, so we wait for the next step in that case.
+    while TIME_STEP_S - time.time() % TIME_STEP_S < MIN_VALIDITY_S:
+        time.sleep(0.1)
+
+    generated_at = time.time()
+    time_step = int(generated_at) // TIME_STEP_S
+
+    return TOTPCode(code=totp_for_time_step(secret, time_step),
+                    time_step=time_step,
+                    generated_at=generated_at)
+
+
+def generate_totp(secret: str) -> str:
+    return generate_totp_details(secret).code
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Tries to fix the e2e browser login test flakiness described in #1777. TOTP-based logins were intermittently failing with no way to tell whether a rejected code was actually wrong, stale, or never made it into the page at all.

See commit messages for details.