### PR TITLE
e2e: allow PRs to select which brokers to test

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+E2E tests in CI
+
+The E2E workflow runs for a pull request only when it has the `e2e-tests`
+label. Copy the relevant line(s) below into the visible part of the pull
+request description to override the defaults. Leave these examples commented
+to use the defaults:
+
+- both brokers (`authd-google` and `authd-msentraid`)
+- the complete test suite
+- the `authd-edge` PPA
+
+e2e-brokers: google
+e2e-tests: allowed_users.robot login_gdm.robot
+e2e-ppa: authd-dev
+
+The `e2e-ppa: authd-dev` marker sets the workflow's `authd-ppa` input to
+`ubuntu-enterprise-desktop/authd-dev` instead of `authd-edge`.
+-->

--- a/.github/scripts/parse-e2e-options.sh
+++ b/.github/scripts/parse-e2e-options.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${E2E_TESTS_DESCRIPTION:=}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+body_without_comments=$(
+    tr -d '\r' <<<"${E2E_TESTS_DESCRIPTION}" |
+        perl -0pe 's/<!--.*?(?:-->|$)//gs'
+)
+
+marker_values() {
+    local marker="$1"
+
+    sed -nE \
+        "s/^[[:space:]]*${marker}:[[:space:]]*(.+)[[:space:]]*$/\1/p" \
+        <<<"${body_without_comments}" |
+        tr -s ' \t,' '\n'
+}
+
+brokers=()
+declare -A seen_brokers=()
+while IFS= read -r selected; do
+    [[ -n "${selected}" ]] || continue
+
+    case "${selected}" in
+        google|authd-google)
+            broker="authd-google"
+            ;;
+        msentraid|authd-msentraid)
+            broker="authd-msentraid"
+            ;;
+        *)
+            echo "::warning::Ignoring unknown broker '${selected}' in e2e-brokers marker"
+            continue
+            ;;
+    esac
+
+    if [[ -z "${seen_brokers[${broker}]:-}" ]]; then
+        seen_brokers["${broker}"]=1
+        brokers+=("${broker}")
+    fi
+done < <(marker_values e2e-brokers)
+
+if ((${#brokers[@]} == 0)); then
+    brokers=(authd-msentraid authd-google)
+fi
+
+tests=()
+while IFS= read -r test; do
+    [[ -n "${test}" ]] || continue
+    tests+=("${test}")
+done < <(marker_values e2e-tests)
+
+authd_ppa=
+while IFS= read -r ppa; do
+    case "${ppa}" in
+        authd-dev)
+            authd_ppa="ubuntu-enterprise-desktop/authd-dev"
+            break
+            ;;
+        "")
+            ;;
+        *)
+            echo "::warning::Ignoring unknown PPA '${ppa}' in e2e-ppa marker"
+            ;;
+    esac
+done < <(marker_values e2e-ppa)
+
+json_array() {
+    if (($# == 0)); then
+        printf '[]'
+    else
+        printf '%s\n' "$@" | jq -R . | jq -sc .
+    fi
+}
+
+{
+    printf 'brokers=%s\n' "$(json_array "${brokers[@]}")"
+    printf 'tests=%s\n' "$(json_array "${tests[@]}")"
+    printf 'authd_ppa=%s\n' "${authd_ppa}"
+} >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -25,11 +25,16 @@ on:
         type: string
         required: false
         default: ''
-      e2e-tests-description:
-        description: 'PR description containing an optional e2e-tests: suite list'
+      brokers:
+        description: 'JSON array of brokers to test'
         type: string
         required: false
-        default: ''
+        default: '["authd-msentraid","authd-google"]'
+      e2e-tests:
+        description: 'JSON array of test suite filenames; an empty array runs the full suite'
+        type: string
+        required: false
+        default: '[]'
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -162,7 +167,7 @@ jobs:
       - build-deb
     strategy:
       matrix:
-        broker: [authd-msentraid, authd-google]
+        broker: ${{ fromJSON(inputs.brokers) }}
       fail-fast: false
     uses: ./.github/workflows/e2e-tests-run.yaml
     with:
@@ -170,5 +175,5 @@ jobs:
       broker: ${{ matrix.broker }}
       broker-snap-channel: ${{ inputs.broker-snap-channel }}
       authd-ppa: ${{ inputs.authd-ppa }}
-      e2e-tests-description: ${{ inputs.e2e-tests-description }}
+      e2e-tests: ${{ inputs.e2e-tests }}
     secrets: inherit

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -19,11 +19,11 @@ on:
         required: false
         type: string
         default: ''
-      e2e-tests-description:
-        description: 'PR description containing an optional e2e-tests: suite list'
+      e2e-tests:
+        description: 'JSON array of test suite filenames; an empty array runs the full suite'
         required: false
         type: string
-        default: ''
+        default: '[]'
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -233,7 +233,7 @@ jobs:
         env:
           RELEASE: ${{ inputs.ubuntu-version }}
           BROKER: ${{ inputs.broker }}
-          E2E_TESTS_DESCRIPTION: ${{ inputs.e2e-tests-description }}
+          E2E_TESTS: ${{ inputs.e2e-tests }}
         run: |
           set -eux
           export PATH="$(realpath "${{ env.E2E_TESTS_DIR }}/vm/helpers"):${PATH}"
@@ -250,15 +250,12 @@ jobs:
             export TOTP_SECRET="${{ secrets.E2E_GOOGLE_TOTP_SECRET }}"
           fi
 
-          e2e_tests=()
-          while IFS= read -r test; do
-            e2e_tests+=("$test")
-          done < <(
-            tr -d '\r' <<< "${E2E_TESTS_DESCRIPTION}" \
-              | sed -nE \
-                  's/^[[:space:]]*e2e-tests:[[:space:]]*(.+)[[:space:]]*$/\1/p' \
-              | tr -s ' \t' '\n'
-          )
+          if ! jq -e 'type == "array" and all(.[]; type == "string")' \
+              <<< "${E2E_TESTS}" >/dev/null; then
+            echo "Invalid e2e-tests JSON input" >&2
+            exit 1
+          fi
+          mapfile -t e2e_tests < <(jq -r '.[]' <<< "${E2E_TESTS}")
 
           ${{ env.E2E_TESTS_DIR }}/run-tests.sh \
             --output-dir "${{ env.OUTPUT_DIR }}" \

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,8 +62,18 @@ on:
         required: false
         default: ''
         type: string
-      e2e-tests-description:
-        description: 'Optional e2e-brokers, e2e-tests, and e2e-ppa settings'
+      e2e-brokers:
+        description: 'Optional comma- or space-separated broker list; empty runs both brokers'
+        required: false
+        default: ''
+        type: string
+      e2e-tests:
+        description: 'Optional comma- or space-separated test suite list; empty runs the full suite'
+        required: false
+        default: ''
+        type: string
+      e2e-ppa:
+        description: 'Optional PPA name, such as authd-dev; empty uses authd-edge'
         required: false
         default: ''
         type: string
@@ -91,6 +101,9 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       files-hash: ${{ steps.hash.outputs.hash }}
       brokers: ${{ steps.parse_e2e_options.outputs.brokers }}
@@ -106,13 +119,29 @@ jobs:
       - name: Parse E2E options
         id: parse_e2e_options
         env:
-          E2E_TESTS_DESCRIPTION: >-
-            ${{
-              github.event_name == 'pull_request' &&
-              github.event.pull_request.body ||
-              inputs.e2e-tests-description || ''
-            }}
-        run: bash .github/scripts/parse-e2e-options.sh
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          E2E_BROKERS: ${{ inputs.e2e-brokers || '' }}
+          E2E_TESTS: ${{ inputs.e2e-tests || '' }}
+          E2E_PPA: ${{ inputs.e2e-ppa || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
+            E2E_TESTS_DESCRIPTION=$(
+              gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" \
+                --jq '.body // ""'
+            )
+          else
+            E2E_TESTS_DESCRIPTION=$(
+              printf 'e2e-brokers: %s\ne2e-tests: %s\ne2e-ppa: %s\n' \
+                "${E2E_BROKERS}" "${E2E_TESTS}" "${E2E_PPA}"
+            )
+          fi
+
+          export E2E_TESTS_DESCRIPTION
+          bash .github/scripts/parse-e2e-options.sh
 
   provision-and-run:
     needs: prepare-e2e

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/e2e-tests-provision-and-run.yaml'
       - '.github/workflows/e2e-tests-run.yaml'
       - '.github/workflows/debian-build.yaml'
+      - '.github/scripts/parse-e2e-options.sh'
       - '!.gitignore'
       - '!.gitmodules'
       - '!.golangci.yaml'
@@ -36,6 +37,7 @@ on:
       - '.github/workflows/e2e-tests-provision-and-run.yaml'
       - '.github/workflows/e2e-tests-run.yaml'
       - '.github/workflows/debian-build.yaml'
+      - '.github/scripts/parse-e2e-options.sh'
       - '!.gitignore'
       - '!.gitmodules'
       - '!.golangci.yaml'
@@ -60,6 +62,11 @@ on:
         required: false
         default: ''
         type: string
+      e2e-tests-description:
+        description: 'Optional e2e-brokers, e2e-tests, and e2e-ppa settings'
+        required: false
+        default: ''
+        type: string
   schedule:
     - cron: '0 0 * * 1' # Runs every Monday at midnight
 
@@ -68,8 +75,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  compute-hash:
-    name: Compute hash of build-relevant files
+  prepare-e2e:
+    name: Prepare E2E inputs
     # Skip this job (and the provision-and-run job which depends on it) if the
     # PR is from a fork, as we don't have the permission to upload the Debian
     # package to the OCI registry in the provision-and-run workflow.
@@ -86,6 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files-hash: ${{ steps.hash.outputs.hash }}
+      brokers: ${{ steps.parse_e2e_options.outputs.brokers }}
+      tests: ${{ steps.parse_e2e_options.outputs.tests }}
+      authd_ppa: ${{ steps.parse_e2e_options.outputs.authd_ppa }}
     steps:
       - uses: actions/checkout@v7
       - name: Compute hash of build-relevant files
@@ -93,9 +103,19 @@ jobs:
         run: |
           hash=$(bash .github/scripts/compute-deb-build-hash.sh)
           echo "hash=${hash}" >> "${GITHUB_OUTPUT}"
+      - name: Parse E2E options
+        id: parse_e2e_options
+        env:
+          E2E_TESTS_DESCRIPTION: >-
+            ${{
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.body ||
+              inputs.e2e-tests-description || ''
+            }}
+        run: bash .github/scripts/parse-e2e-options.sh
 
   provision-and-run:
-    needs: compute-hash
+    needs: prepare-e2e
     permissions:
       contents: read
       packages: write
@@ -107,24 +127,11 @@ jobs:
     uses: ./.github/workflows/e2e-tests-provision-and-run.yaml
     with:
       ubuntu-version: ${{ matrix.ubuntu-version }}
-      files-hash: ${{ needs.compute-hash.outputs.files-hash }}
+      files-hash: ${{ needs.prepare-e2e.outputs.files-hash }}
       force-fresh-image: ${{ github.event_name == 'schedule' }}
       broker-snap-channel: ${{ inputs.broker-snap-channel || '' }}
       # PRs opt in by adding "e2e-ppa: authd-dev" to their description.
-      authd-ppa: >-
-        ${{
-          github.event_name == 'pull_request' &&
-          contains(
-            github.event.pull_request.body,
-            'e2e-ppa: authd-dev'
-          ) &&
-          'ubuntu-enterprise-desktop/authd-dev' || ''
-        }}
-      # PRs can limit the suites by adding, for example,
-      # "e2e-tests: login_gdm.robot login.robot" to their description.
-      e2e-tests-description: >-
-        ${{
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.body || ''
-        }}
+      authd-ppa: ${{ needs.prepare-e2e.outputs.authd_ppa }}
+      brokers: ${{ needs.prepare-e2e.outputs.brokers }}
+      e2e-tests: ${{ needs.prepare-e2e.outputs.tests }}
     secrets: inherit

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -1,6 +1,6 @@
 # End-to-end tests
 
-The end-to-end tests are implemented using [YARF](https://github.com/canonical/yarf).
+The end-to-end tests are implemented using [YARF][yarf].
 They cover a wide range of scenarios, both for authd and the brokers.
 
 ## Setting up the environment
@@ -52,30 +52,13 @@ ssh-add /path/to/key
 ```
 
 This sets up a libvirt VM with Ubuntu, installs authd and the broker, and
-creates the snapshots required by the tests. By default, authd is installed from
-the edge PPA and the broker from the edge channel snap. Use `--authd-deb` to
-install a locally built authd package, `--authd-ppa <ppa>` to select a different
-PPA for authd and its dependencies, or `--broker-snap` to install a locally
-built broker snap. Run `./e2e-tests/vm/provision.sh --help` for all available
-options, including `--force` to reprovision.
-
-When running the tests in GitHub CI, add `e2e-ppa: authd-dev` to the pull request
-description to install the authd package and its dependencies from the
-`ubuntu-enterprise-desktop/authd-dev` PPA instead of `authd-edge`.
-
-To run only selected end-to-end test suites in GitHub CI, add an `e2e-tests:`
-line to the pull request description, followed by a space-separated list of
-suite filenames:
-
-```text
-e2e-tests: login_gdm.robot login.robot
-```
-
-Without this marker, GitHub CI runs the complete end-to-end test suite.
-Editing the pull request description does not automatically re-run the
-workflow, so if you change the `e2e-tests:` line after the workflow has
-already run, re-run it manually (e.g. "Re-run all jobs" in the GitHub
-Actions UI, or `gh run rerun <run-id>`) to pick up the new suite selection.
+creates the snapshots required by the tests. By default, authd is installed
+from the [authd-edge PPA][authd-edge-ppa] and the broker from the edge channel
+snap. Use `--authd-deb` to install a locally built authd package, `--authd-ppa
+<ppa>` to select a different PPA for authd and its dependencies, or
+`--broker-snap` to install a locally built broker snap. Run
+`./e2e-tests/vm/provision.sh --help` for all available options, including
+`--force` to reprovision.
 
 ### 4. Set up YARF
 
@@ -96,3 +79,45 @@ environment.
 `e2e-tests-google.env` for `authd-google`). Omit the test file argument to run
 the full suite. Run `./e2e-tests/run-tests.sh --help` for all available options,
 including `--rerunfailed` and `--output-dir`.
+
+## Running in GitHub CI
+
+By default, GitHub CI runs the end-to-end tests against both `authd-google` and
+`authd-msentraid`, using the complete test suite and packages from the
+[authd-edge PPA][authd-edge-ppa].
+
+The E2E workflow runs for a pull request only when it has the `e2e-tests` label.
+The pull request template contains commented examples for selecting brokers,
+test suites, and the authd PPA. Copy the relevant line into the visible part of
+the pull request description to enable it; leave it commented to use the
+default.
+
+To install authd and its dependencies from the [authd-dev PPA][authd-dev-ppa]
+instead, add `e2e-ppa: authd-dev` to the pull request description.
+
+To run only selected end-to-end test suites, add an `e2e-tests:` line to the
+pull request description, followed by a space- or comma-separated list of suite
+filenames:
+
+```text
+e2e-tests: login_gdm.robot login.robot
+```
+
+To run the tests against only selected brokers, add an `e2e-brokers:` line to
+the pull request description, followed by a space- or comma-separated list of
+`google`/`authd-google` and/or `msentraid`/`authd-msentraid`:
+
+```text
+e2e-brokers: google
+```
+
+Editing the pull request description does not automatically re-run the
+workflow. If you change an `e2e-tests:`, `e2e-brokers:`, or `e2e-ppa:` line
+after the workflow has already run, re-run the workflow. It fetches the current
+pull request description from GitHub. If you start the workflow with
+`workflow_dispatch`, use its separate `e2e-brokers`, `e2e-tests`, and `e2e-ppa`
+inputs instead.
+
+[yarf]: https://github.com/canonical/yarf
+[authd-edge-ppa]: https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge
+[authd-dev-ppa]: https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-dev


### PR DESCRIPTION
Some changes only affect one broker's integration, so waiting on both authd-google and authd-msentraid runs (each requiring a VM provision and full suite) wastes CI time. Reuse the existing e2e-tests-description input (the PR body) and parse an "e2e-brokers:" marker to compute the broker matrix dynamically via a new compute-brokers job, defaulting to both brokers when the marker is absent.

e2e-brokers: google
e2e-tests: allowed_users.robot

Closes #1779 
