### PR TITLE
msentraid: prevent duplicate Entra device registrations

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -1362,10 +1362,17 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		return access, data
 	}
 
-	// Load existing device registration data if there is any, to avoid re-registering the device.
+	// Load existing auth info and device registration data if present. Keep the
+	// old info so returning device-code logins can use cached groups when the
+	// live group lookup is unavailable.
+	var oldAuthInfo *token.AuthCachedInfo
 	var deviceRegistrationData []byte
-	if oldAuthInfo, err := token.LoadAuthInfo(session.tokenPath); err == nil {
-		deviceRegistrationData = oldAuthInfo.DeviceRegistrationData
+	if cachedInfo, err := token.LoadAuthInfo(session.tokenPath); err == nil {
+		oldAuthInfo = cachedInfo
+		deviceRegistrationData = cachedInfo.DeviceRegistrationData
+		authInfo.UserInfo.Groups = slices.Clone(oldAuthInfo.UserInfo.Groups)
+		authInfo.GroupsResolved = oldAuthInfo.GroupsResolved
+		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
 	}
 	if authInfo.UserInfo.ProviderID != "" && session.providerID == "" {
 		b.ensureProviderIDCacheDir(session, authInfo.UserInfo.ProviderID)
@@ -1376,13 +1383,76 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	if access != "" {
 		return access, data
 	}
+	reusedDeviceRegistration := len(deviceRegistrationData) > 0 &&
+		slices.Equal(deviceRegistrationData, authInfo.DeviceRegistrationData)
 
 	// We can only fetch the groups after registering the device, because the token acquired for device registration
 	// cannot be used with the Microsoft Graph API and a new token must be acquired for the Graph API.
-	authInfo.UserInfo.Groups, err = b.getGroups(ctx, session, authInfo)
+	groups, err := b.getGroups(ctx, session, authInfo)
 	if err != nil {
-		log.Errorf(context.Background(), "failed to get groups: %s", err)
-		return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
+		if errors.Is(err, providerErrors.ErrDeviceDisabled) {
+			return b.denyDisabledDevice(session, authInfo)
+		}
+		if errors.Is(err, providerErrors.ErrInvalidRedirectURI) {
+			log.Errorf(context.Background(), "Login denied: %s", err)
+			return AuthDenied, errorMessageForDisplay(err, "Invalid redirect URI")
+		}
+
+		var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
+		retryingDeviceRegistration := errors.As(err, &retryWithDeviceAuthErr)
+		// Preserve fresh registration data while the provider catches up with it.
+
+		// Without cached groups, there is no safe fallback for a group lookup
+		// failure. The pending registration was persisted above so a later login
+		// can retry it without enrolling another device.
+		if oldAuthInfo == nil || !oldAuthInfo.GroupsResolved {
+			log.Errorf(context.Background(), "failed to get groups: %s", err)
+			return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
+		}
+		authInfo.UserInfo.Groups = oldAuthInfo.UserInfo.Groups
+
+		// Known limitations of this recovery logic, to revisit if they
+		// turn out to matter in practice:
+		//
+		//   - While a fresh registration is pending validation, reused
+		//     data that the provider rejects is never cleared, so a
+		//     permanently bad registration keeps retrying instead of
+		//     re-enrolling.
+		//   - Concurrent flows for the same user each persist their own
+		//     cached state, so a slower flow can write stale data over a
+		//     fresher registration saved by another flow, which can lead
+		//     to another device enrollment.
+		//
+		// The first case recovers on the next successful group lookup.
+		//
+		// Reusing registration data that the provider rejected proves that it is stale.
+		if retryingDeviceRegistration && reusedDeviceRegistration &&
+			!authInfo.DeviceRegistrationDataValidationPending {
+			log.Errorf(context.Background(), "Token acquisition failed: %s. Clearing stale device registration data and retrying authentication.", err)
+			authInfo.DeviceRegistrationData = nil
+			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+				return AuthDenied, unexpectedErrMsg("failed to store token")
+			}
+
+			session.nextAuthModes = reauthModes
+			return AuthNext, errorMessage{Message: "Authentication failed due to a token issue. Please try again."}
+		}
+
+		// A group-fetch failure is not enough to deny a returning login when
+		// cached groups are available.
+		log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
+	} else {
+		authInfo.UserInfo.Groups = groups
+		authInfo.GroupsResolved = true
+		wasDeviceRegistrationValidationPending := authInfo.DeviceRegistrationDataValidationPending
+		clearDeviceRegistrationValidationPending(authInfo)
+		if wasDeviceRegistrationValidationPending ||
+			(oldAuthInfo != nil && !oldAuthInfo.GroupsResolved) {
+			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+			}
+		}
 	}
 
 	// Store the auth info in the session so that we can use it when handling the
@@ -1509,17 +1579,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	// Try to refresh the groups
 	groups, err := b.getGroups(ctx, session, authInfo)
 	if errors.Is(err, providerErrors.ErrDeviceDisabled) {
-		// The device is disabled, deny login
-		log.Errorf(context.Background(), "Login denied: device is disabled in %s for user %q", b.provider.DisplayName(), session.username)
-
-		// Store the information that the device is disabled, so that we can deny login on subsequent offline attempts.
-		authInfo.DeviceIsDisabled = true
-		if err = token.CacheAuthInfo(session.tokenPath, authInfo); err != nil {
-			log.Errorf(context.Background(), "Failed to store token: %s", err)
-			return AuthDenied, unexpectedErrMsg("failed to store token")
-		}
-
-		return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s, please contact your administrator.", b.provider.DisplayName())}
+		return b.denyDisabledDevice(session, authInfo)
 	}
 	if errors.Is(err, providerErrors.ErrInvalidRedirectURI) {
 		// Deny login if the redirect URI is invalid, so that users and administrators are aware of the issue.
@@ -1528,15 +1588,28 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	}
 	var retryWithDeviceAuthError *providerErrors.RetryWithDeviceAuthError
 	if errors.As(err, &retryWithDeviceAuthError) {
+		if authInfo.DeviceRegistrationDataValidationPending {
+			if !authInfo.GroupsResolved {
+				log.Errorf(context.Background(), "failed to get groups: %s", err)
+				return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
+			}
+			log.Warningf(context.Background(), "Could not get groups after registering the device: %v. Using cached groups while registration validation is pending.", err)
+			return b.finishAuth(session, authInfo)
+		}
+
 		log.Errorf(context.Background(), "Token acquisition failed: %s. Try again using the device code flow.", err)
-		// The token acquisition failed unexpectedly.
-		// One possible reason is that the device was deleted by an administrator in Entra ID.
-		// In this case, the user can perform device code flow again to get a new token
-		// and register the device again, allowing the user to log in.
+		// This error is only returned for a specific, known signal that the
+		// device's own registration/authentication is invalid in Entra ID
+		// (e.g. an administrator deleted the device object) -- see
+		// himmelblau.ErrDeviceAuthenticationFailed for caveats on that
+		// signal. In this case, the user can perform device code flow again
+		// to get a new token and register the device again, allowing the user
+		// to log in.
 		// We delete the device registration data to cause device code flow to re-register the device.
 		authInfo.DeviceRegistrationData = nil
-		if err = token.CacheAuthInfo(session.tokenPath, authInfo); err != nil {
-			log.Errorf(context.Background(), "Failed to store token: %s", err)
+		clearDeviceRegistrationValidationPending(authInfo)
+		if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+			log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
 			return AuthDenied, unexpectedErrMsg("failed to store token")
 		}
 
@@ -1549,9 +1622,14 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		// provider check (and force_access_check_with_provider enforcement) happens
 		// at the token refresh above, the same as the device-auth flow, so a
 		// group-fetch failure here falls back to cached groups for both flows.
+		if !authInfo.GroupsResolved {
+			log.Errorf(context.Background(), "failed to get groups: %s", err)
+			return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
+		}
 		log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
 	} else {
 		authInfo.UserInfo.Groups = groups
+		authInfo.GroupsResolved = true
 		clearDeviceRegistrationValidationPending(authInfo)
 	}
 
@@ -1566,6 +1644,18 @@ func markDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
 
 func clearDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
 	authInfo.DeviceRegistrationDataValidationPending = false
+}
+
+func (b *Broker) denyDisabledDevice(session *session, authInfo *token.AuthCachedInfo) (string, isAuthenticatedDataResponse) {
+	log.Errorf(context.Background(), "Login denied: device is disabled in %s for user %q", b.provider.DisplayName(), session.username)
+
+	authInfo.DeviceIsDisabled = true
+	if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+		log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+		return AuthDenied, unexpectedErrMsg("failed to store token")
+	}
+
+	return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s, please contact your administrator.", b.provider.DisplayName())}
 }
 
 func (b *Broker) entraAuth(ctx context.Context, session *session, userPassword string) (string, isAuthenticatedDataResponse) {
@@ -2203,6 +2293,8 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 	// value and silently discard a device that was registered earlier. For a
 	// first-time login (no cached token) it keeps its zero value, which is correct.
 	if oldAuthInfo != nil {
+		authInfo.UserInfo.Groups = slices.Clone(oldAuthInfo.UserInfo.Groups)
+		authInfo.GroupsResolved = oldAuthInfo.GroupsResolved
 		authInfo.DeviceRegistrationData = oldAuthInfo.DeviceRegistrationData
 		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
 	}
@@ -2232,22 +2324,53 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 			return access, data
 		}
 	}
+	reusedDeviceRegistration := len(deviceRegistrationData) > 0 &&
+		slices.Equal(deviceRegistrationData, authInfo.DeviceRegistrationData)
 
 	// Fetch groups. The MFA flow just performed a live provider verification, so a
 	// group-fetch failure here is not a liveness signal: fall back to cached groups
 	// on a returning auth, and only deny first-time logins that have no cached groups.
 	groups, err := b.getGroups(ctx, session, authInfo)
 	if err != nil {
-		if oldAuthInfo != nil {
-			log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
-			authInfo.UserInfo.Groups = oldAuthInfo.UserInfo.Groups
-		} else {
+		if errors.Is(err, providerErrors.ErrDeviceDisabled) {
+			return b.denyDisabledDevice(session, authInfo)
+		}
+		if errors.Is(err, providerErrors.ErrInvalidRedirectURI) {
+			log.Errorf(context.Background(), "Login denied: %s", err)
+			return AuthDenied, errorMessageForDisplay(err, "Invalid redirect URI")
+		}
+
+		var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
+		retryingDeviceRegistration := errors.As(err, &retryWithDeviceAuthErr)
+		if oldAuthInfo == nil || !oldAuthInfo.GroupsResolved {
 			log.Errorf(context.Background(), "failed to get groups: %s", err)
 			return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
 		}
+
+		authInfo.UserInfo.Groups = oldAuthInfo.UserInfo.Groups
+		switch {
+		case retryingDeviceRegistration && authInfo.DeviceRegistrationDataValidationPending:
+			log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups while device registration validation is pending.", err)
+		case retryingDeviceRegistration && reusedDeviceRegistration:
+			// The cached device registration data is stale. Clear it so that the
+			// next login triggers a fresh device registration instead of
+			// repeatedly failing with the same error.
+			log.Warningf(context.Background(), "Could not get groups: %v. Clearing stale device registration data and using cached groups.", err)
+			authInfo.DeviceRegistrationData = nil
+		default:
+			log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
+		}
 	} else {
 		authInfo.UserInfo.Groups = groups
+		authInfo.GroupsResolved = true
+		wasDeviceRegistrationValidationPending := authInfo.DeviceRegistrationDataValidationPending
 		clearDeviceRegistrationValidationPending(authInfo)
+		if wasDeviceRegistrationValidationPending ||
+			(oldAuthInfo != nil && !oldAuthInfo.GroupsResolved) {
+			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+			}
+		}
 	}
 
 	// A passwordless login has no Entra password to cache for offline
@@ -2837,6 +2960,7 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	t := token.NewAuthCachedInfo(oauthToken, rawIDToken, extraFields)
 	t.ProviderMetadata = oldToken.ProviderMetadata
 	t.DeviceRegistrationData = oldToken.DeviceRegistrationData
+	t.GroupsResolved = oldToken.GroupsResolved
 	t.DeviceRegistrationDataValidationPending = oldToken.DeviceRegistrationDataValidationPending
 
 	t.UserInfo, err = b.getUserInfo(ctx, session, oauthToken, rawIDToken, true)
@@ -2950,7 +3074,9 @@ func (b *Broker) maybeRegisterDevice(ctx context.Context, session *session, auth
 		return cleanup, "", nil
 	}
 
-	deviceRegistrationDataBeforeRegistration := append([]byte(nil), existingData...)
+	// MaybeRegisterDevice never mutates existingData, so comparing against
+	// the slice itself is enough to detect a fresh registration.
+	deviceRegistrationDataBeforeRegistration := existingData
 	var err error
 	authInfo.DeviceRegistrationData, cleanup, err = dr.MaybeRegisterDevice(ctx, regToken,
 		session.username,

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -44,6 +44,10 @@ const (
 	maxAuthAttempts    = 3
 	maxRequestDuration = 5 * time.Second
 
+	// A pending registration is discarded after repeated device-authentication
+	// failures outlive the provider replication window.
+	deviceRegistrationValidationGracePeriod = 5 * time.Minute
+
 	// maxMFAPollDuration caps the total wall-clock time spent polling for MFA
 	// approval, to prevent infinite polling.
 	maxMFAPollDuration = 5 * time.Minute
@@ -1367,12 +1371,17 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	// live group lookup is unavailable.
 	var oldAuthInfo *token.AuthCachedInfo
 	var deviceRegistrationData []byte
-	if cachedInfo, err := token.LoadAuthInfo(session.tokenPath); err == nil {
+	if cachedInfo, err := token.LoadAuthInfo(session.tokenPath); err == nil &&
+		cachedAuthInfoMatchesIdentity(session, authInfo, cachedInfo) {
 		oldAuthInfo = cachedInfo
 		deviceRegistrationData = cachedInfo.DeviceRegistrationData
 		authInfo.UserInfo.Groups = slices.Clone(oldAuthInfo.UserInfo.Groups)
 		authInfo.GroupsResolved = oldAuthInfo.GroupsResolved
 		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
+		authInfo.DeviceRegistrationDataValidationFailureSince = oldAuthInfo.DeviceRegistrationDataValidationFailureSince
+		// A live auth verifies the user, not the device object: keep the
+		// persisted disabled-device state.
+		authInfo.DeviceIsDisabled = oldAuthInfo.DeviceIsDisabled
 	}
 	if authInfo.UserInfo.ProviderID != "" && session.providerID == "" {
 		b.ensureProviderIDCacheDir(session, authInfo.UserInfo.ProviderID)
@@ -1400,6 +1409,16 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 
 		var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
 		retryingDeviceRegistration := errors.As(err, &retryWithDeviceAuthErr)
+		if retryingDeviceRegistration && authInfo.DeviceRegistrationDataValidationPending {
+			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, reauthModes); expired {
+				return access, data
+			}
+			markDeviceRegistrationValidationFailure(authInfo)
+			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+				return AuthDenied, unexpectedErrMsg("failed to store token")
+			}
+		}
 		// Preserve fresh registration data while the provider catches up with it.
 
 		// Without cached groups, there is no safe fallback for a group lookup
@@ -1411,25 +1430,12 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		}
 		authInfo.UserInfo.Groups = oldAuthInfo.UserInfo.Groups
 
-		// Known limitations of this recovery logic, to revisit if they
-		// turn out to matter in practice:
-		//
-		//   - While a fresh registration is pending validation, reused
-		//     data that the provider rejects is never cleared, so a
-		//     permanently bad registration keeps retrying instead of
-		//     re-enrolling.
-		//   - Concurrent flows for the same user each persist their own
-		//     cached state, so a slower flow can write stale data over a
-		//     fresher registration saved by another flow, which can lead
-		//     to another device enrollment.
-		//
-		// The first case recovers on the next successful group lookup.
-		//
 		// Reusing registration data that the provider rejected proves that it is stale.
 		if retryingDeviceRegistration && reusedDeviceRegistration &&
 			!authInfo.DeviceRegistrationDataValidationPending {
 			log.Errorf(context.Background(), "Token acquisition failed: %s. Clearing stale device registration data and retrying authentication.", err)
 			authInfo.DeviceRegistrationData = nil
+			clearDeviceRegistrationValidationPending(authInfo)
 			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
 				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
 				return AuthDenied, unexpectedErrMsg("failed to store token")
@@ -1445,6 +1451,9 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	} else {
 		authInfo.UserInfo.Groups = groups
 		authInfo.GroupsResolved = true
+		// A successful lookup is positive evidence that the device is
+		// valid again, so a persisted disabled-device flag can be dropped.
+		authInfo.DeviceIsDisabled = false
 		wasDeviceRegistrationValidationPending := authInfo.DeviceRegistrationDataValidationPending
 		clearDeviceRegistrationValidationPending(authInfo)
 		if wasDeviceRegistrationValidationPending ||
@@ -1479,6 +1488,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		log.Error(context.Background(), err.Error())
 		return AuthDenied, unexpectedErrMsg("could not load stored token")
 	}
+	cachedAuthInfo := authInfo
 
 	// If the session is for changing the password, we don't need to refresh the token and user info (and we don't
 	// want the method call to return an error if refreshing the token or user info fails).
@@ -1497,7 +1507,6 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	// via the provider; all other tokens use the OIDC app refresh. Both paths feed
 	// the same error classification below.
 	if b.cfg.forceAccessCheckWithProvider || !session.isOffline {
-		oldAuthInfo := authInfo
 		// Both refresh paths use the cached refresh token; without one we can't
 		// perform the liveness check, so require re-authentication.
 		if authInfo.Token.RefreshToken == "" {
@@ -1528,8 +1537,8 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 				log.Errorf(context.Background(), "Login denied: user %q is disabled in %s", session.username, b.provider.DisplayName())
 
 				// Store the information that the user is disabled, so that we can deny login on subsequent offline attempts.
-				oldAuthInfo.UserIsDisabled = true
-				if err = token.CacheAuthInfo(session.tokenPath, oldAuthInfo); err != nil {
+				cachedAuthInfo.UserIsDisabled = true
+				if err = token.CacheAuthInfo(session.tokenPath, cachedAuthInfo); err != nil {
 					log.Errorf(context.Background(), "Failed to store token: %s", err)
 					return AuthDenied, unexpectedErrMsg("failed to store token")
 				}
@@ -1545,12 +1554,18 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 			var netErr net.Error
 			if errors.As(err, &netErr) && !b.cfg.forceAccessCheckWithProvider {
 				log.Warningf(context.Background(), "Network error during token refresh for user %q, skipping token refresh", session.username)
-				authInfo = oldAuthInfo
+				authInfo = cachedAuthInfo
 				session.isOffline = true
 			} else {
 				return AuthDenied, errorMessage{Message: "Failed to refresh token"}
 			}
 		}
+	}
+	if !cachedAuthInfoMatchesIdentity(session, authInfo, cachedAuthInfo) {
+		authInfo.UserInfo.Groups = nil
+		authInfo.GroupsResolved = false
+		authInfo.DeviceRegistrationData = nil
+		clearDeviceRegistrationValidationPending(authInfo)
 	}
 
 	// Check disabled status. We have to do this after trying to refresh the token,
@@ -1589,6 +1604,14 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	var retryWithDeviceAuthError *providerErrors.RetryWithDeviceAuthError
 	if errors.As(err, &retryWithDeviceAuthError) {
 		if authInfo.DeviceRegistrationDataValidationPending {
+			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, reauthModes); expired {
+				return access, data
+			}
+			markDeviceRegistrationValidationFailure(authInfo)
+			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+				return AuthDenied, unexpectedErrMsg("failed to store token")
+			}
 			if !authInfo.GroupsResolved {
 				log.Errorf(context.Background(), "failed to get groups: %s", err)
 				return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
@@ -1630,6 +1653,9 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	} else {
 		authInfo.UserInfo.Groups = groups
 		authInfo.GroupsResolved = true
+		// A successful lookup is positive evidence that the device is
+		// valid again, so a persisted disabled-device flag can be dropped.
+		authInfo.DeviceIsDisabled = false
 		clearDeviceRegistrationValidationPending(authInfo)
 	}
 
@@ -1639,11 +1665,66 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 func markDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
 	if len(authInfo.DeviceRegistrationData) > 0 {
 		authInfo.DeviceRegistrationDataValidationPending = true
+		authInfo.DeviceRegistrationDataValidationFailureSince = 0
 	}
 }
 
 func clearDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
 	authInfo.DeviceRegistrationDataValidationPending = false
+	authInfo.DeviceRegistrationDataValidationFailureSince = 0
+}
+
+func markDeviceRegistrationValidationFailure(authInfo *token.AuthCachedInfo) {
+	if authInfo.DeviceRegistrationDataValidationFailureSince == 0 {
+		authInfo.DeviceRegistrationDataValidationFailureSince = time.Now().Unix()
+	}
+}
+
+func recoverExpiredPendingRegistration(session *session, authInfo *token.AuthCachedInfo, nextModes []string) (string, isAuthenticatedDataResponse, bool) {
+	if !deviceRegistrationValidationFailureExpired(authInfo) {
+		return "", nil, false
+	}
+
+	authInfo.DeviceRegistrationData = nil
+	clearDeviceRegistrationValidationPending(authInfo)
+	if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+		log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+		return AuthDenied, unexpectedErrMsg("failed to store token"), true
+	}
+
+	session.nextAuthModes = nextModes
+	return AuthNext, errorMessage{Message: "Authentication failed due to a token issue. Please try again."}, true
+}
+
+func deviceRegistrationValidationFailureExpired(authInfo *token.AuthCachedInfo) bool {
+	if !authInfo.DeviceRegistrationDataValidationPending ||
+		authInfo.DeviceRegistrationDataValidationFailureSince == 0 {
+		return false
+	}
+	return time.Since(time.Unix(authInfo.DeviceRegistrationDataValidationFailureSince, 0)) >= deviceRegistrationValidationGracePeriod
+}
+
+func cachedAuthInfoMatchesIdentity(session *session, authInfo, cachedInfo *token.AuthCachedInfo) bool {
+	if authInfo == nil || cachedInfo == nil {
+		return false
+	}
+
+	authenticatedProviderID := authInfo.UserInfo.ProviderID
+	if authenticatedProviderID == "" {
+		if !session.isOffline {
+			return false
+		}
+		authenticatedProviderID = session.providerID
+	}
+	cachedProviderID := cachedInfo.UserInfo.ProviderID
+	if cachedProviderID == "" {
+		cachedProviderID = session.providerID
+	}
+	if authenticatedProviderID == "" || cachedProviderID == "" ||
+		authenticatedProviderID != cachedProviderID {
+		return false
+	}
+	return session.providerID == "" || session.providerID == authenticatedProviderID
 }
 
 func (b *Broker) denyDisabledDevice(session *session, authInfo *token.AuthCachedInfo) (string, isAuthenticatedDataResponse) {
@@ -2280,6 +2361,10 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 	if authInfo == nil {
 		return access, data
 	}
+	if oldAuthInfo != nil && !cachedAuthInfoMatchesIdentity(session, authInfo, oldAuthInfo) {
+		oldAuthInfo = nil
+		authInfo.RawIDToken = ""
+	}
 
 	// Mark this token as having been obtained via the entra_auth flow so
 	// that returning logins refresh it through the Microsoft Broker App public
@@ -2297,6 +2382,8 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 		authInfo.GroupsResolved = oldAuthInfo.GroupsResolved
 		authInfo.DeviceRegistrationData = oldAuthInfo.DeviceRegistrationData
 		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
+		authInfo.DeviceRegistrationDataValidationFailureSince = oldAuthInfo.DeviceRegistrationDataValidationFailureSince
+		authInfo.DeviceIsDisabled = oldAuthInfo.DeviceIsDisabled
 	}
 
 	var deviceRegistrationData []byte
@@ -2342,6 +2429,16 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 
 		var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
 		retryingDeviceRegistration := errors.As(err, &retryWithDeviceAuthErr)
+		if retryingDeviceRegistration && authInfo.DeviceRegistrationDataValidationPending {
+			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, reauthModes); expired {
+				return access, data
+			}
+			markDeviceRegistrationValidationFailure(authInfo)
+			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+				return AuthDenied, unexpectedErrMsg("failed to store token")
+			}
+		}
 		if oldAuthInfo == nil || !oldAuthInfo.GroupsResolved {
 			log.Errorf(context.Background(), "failed to get groups: %s", err)
 			return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
@@ -2363,6 +2460,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 	} else {
 		authInfo.UserInfo.Groups = groups
 		authInfo.GroupsResolved = true
+		authInfo.DeviceIsDisabled = false
 		wasDeviceRegistrationValidationPending := authInfo.DeviceRegistrationDataValidationPending
 		clearDeviceRegistrationValidationPending(authInfo)
 		if wasDeviceRegistrationValidationPending ||
@@ -2961,7 +3059,12 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	t.ProviderMetadata = oldToken.ProviderMetadata
 	t.DeviceRegistrationData = oldToken.DeviceRegistrationData
 	t.GroupsResolved = oldToken.GroupsResolved
+	// A successful refresh verifies the user, not the device: keep the
+	// persisted disabled-device flag until a group lookup proves the
+	// device is valid again.
+	t.DeviceIsDisabled = oldToken.DeviceIsDisabled
 	t.DeviceRegistrationDataValidationPending = oldToken.DeviceRegistrationDataValidationPending
+	t.DeviceRegistrationDataValidationFailureSince = oldToken.DeviceRegistrationDataValidationFailureSince
 
 	t.UserInfo, err = b.getUserInfo(ctx, session, oauthToken, rawIDToken, true)
 	if err != nil {

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -1552,9 +1552,20 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
 	} else {
 		authInfo.UserInfo.Groups = groups
+		clearDeviceRegistrationValidationPending(authInfo)
 	}
 
 	return b.finishAuth(session, authInfo)
+}
+
+func markDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
+	if len(authInfo.DeviceRegistrationData) > 0 {
+		authInfo.DeviceRegistrationDataValidationPending = true
+	}
+}
+
+func clearDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
+	authInfo.DeviceRegistrationDataValidationPending = false
 }
 
 func (b *Broker) entraAuth(ctx context.Context, session *session, userPassword string) (string, isAuthenticatedDataResponse) {
@@ -2193,6 +2204,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 	// first-time login (no cached token) it keeps its zero value, which is correct.
 	if oldAuthInfo != nil {
 		authInfo.DeviceRegistrationData = oldAuthInfo.DeviceRegistrationData
+		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
 	}
 
 	var deviceRegistrationData []byte
@@ -2235,6 +2247,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 		}
 	} else {
 		authInfo.UserInfo.Groups = groups
+		clearDeviceRegistrationValidationPending(authInfo)
 	}
 
 	// A passwordless login has no Entra password to cache for offline
@@ -2824,6 +2837,7 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	t := token.NewAuthCachedInfo(oauthToken, rawIDToken, extraFields)
 	t.ProviderMetadata = oldToken.ProviderMetadata
 	t.DeviceRegistrationData = oldToken.DeviceRegistrationData
+	t.DeviceRegistrationDataValidationPending = oldToken.DeviceRegistrationDataValidationPending
 
 	t.UserInfo, err = b.getUserInfo(ctx, session, oauthToken, rawIDToken, true)
 	if err != nil {
@@ -2936,6 +2950,7 @@ func (b *Broker) maybeRegisterDevice(ctx context.Context, session *session, auth
 		return cleanup, "", nil
 	}
 
+	deviceRegistrationDataBeforeRegistration := append([]byte(nil), existingData...)
 	var err error
 	authInfo.DeviceRegistrationData, cleanup, err = dr.MaybeRegisterDevice(ctx, regToken,
 		session.username,
@@ -2946,8 +2961,13 @@ func (b *Broker) maybeRegisterDevice(ctx context.Context, session *session, auth
 		log.Errorf(context.Background(), "error registering device: %s", err)
 		return func() {}, AuthDenied, errorMessage{Message: "Error registering device"}
 	}
+	if len(authInfo.DeviceRegistrationData) > 0 &&
+		!slices.Equal(authInfo.DeviceRegistrationData, deviceRegistrationDataBeforeRegistration) {
+		markDeviceRegistrationValidationPending(authInfo)
+	}
 
-	// Store the auth info, so that the device registration data is not lost if the login fails after this point.
+	// Store the auth info before group lookup, so fresh registration data remains
+	// pending if the login stops before validation succeeds.
 	if err := token.CacheAuthInfo(session.tokenPath, authInfo); err != nil {
 		log.Errorf(context.Background(), "Failed to store token: %s", err)
 		return cleanup, AuthDenied, unexpectedErrMsg("failed to store token")

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -1246,6 +1246,14 @@ func (b *Broker) IsAuthenticated(sessionID, authenticationData string) (string, 
 
 	select {
 	case <-authDone:
+		if ctx.Err() != nil {
+			// The handler may return AuthCancelled after observing the
+			// cancelled context. Keep the response consistent with the
+			// cancellation branch below and avoid updating the session with
+			// the handler's stale session copy.
+			msg, _ := json.Marshal(errorMessage{Message: "Authentication request cancelled"})
+			return AuthCancelled, string(msg), ctx.Err()
+		}
 	case <-ctx.Done():
 		// We can ignore the error here since the message is constant.
 		msg, _ := json.Marshal(errorMessage{Message: "Authentication request cancelled"})
@@ -1398,6 +1406,10 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	// We can only fetch the groups after registering the device, because the token acquired for device registration
 	// cannot be used with the Microsoft Graph API and a new token must be acquired for the Graph API.
 	groups, err := b.getGroups(ctx, session, authInfo)
+	if ctx.Err() != nil {
+		log.Noticef(context.Background(), "Authentication request cancelled for user %q", session.username)
+		return AuthCancelled, nil
+	}
 	if err != nil {
 		if errors.Is(err, providerErrors.ErrDeviceDisabled) {
 			return b.denyDisabledDevice(session, authInfo)
@@ -1593,6 +1605,10 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 
 	// Try to refresh the groups
 	groups, err := b.getGroups(ctx, session, authInfo)
+	if ctx.Err() != nil {
+		log.Noticef(context.Background(), "Authentication request cancelled for user %q", session.username)
+		return AuthCancelled, nil
+	}
 	if errors.Is(err, providerErrors.ErrDeviceDisabled) {
 		return b.denyDisabledDevice(session, authInfo)
 	}
@@ -2432,6 +2448,10 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 	// group-fetch failure here is not a liveness signal: fall back to cached groups
 	// on a returning auth, and only deny first-time logins that have no cached groups.
 	groups, err := b.getGroups(ctx, session, authInfo)
+	if ctx.Err() != nil {
+		log.Noticef(context.Background(), "Authentication request cancelled for user %q", session.username)
+		return AuthCancelled, nil
+	}
 	if err != nil {
 		if errors.Is(err, providerErrors.ErrDeviceDisabled) {
 			return b.denyDisabledDevice(session, authInfo)

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -1372,7 +1372,7 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	var oldAuthInfo *token.AuthCachedInfo
 	var deviceRegistrationData []byte
 	if cachedInfo, err := token.LoadAuthInfo(session.tokenPath); err == nil &&
-		cachedAuthInfoMatchesIdentity(session, authInfo, cachedInfo) {
+		b.cachedAuthInfoMatchesIdentity(session, authInfo, cachedInfo) {
 		oldAuthInfo = cachedInfo
 		deviceRegistrationData = cachedInfo.DeviceRegistrationData
 		authInfo.UserInfo.Groups = slices.Clone(oldAuthInfo.UserInfo.Groups)
@@ -1561,7 +1561,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 			}
 		}
 	}
-	if !cachedAuthInfoMatchesIdentity(session, authInfo, cachedAuthInfo) {
+	if !b.cachedAuthInfoMatchesIdentity(session, authInfo, cachedAuthInfo) {
 		authInfo.UserInfo.Groups = nil
 		authInfo.GroupsResolved = false
 		authInfo.DeviceRegistrationData = nil
@@ -1704,27 +1704,41 @@ func deviceRegistrationValidationFailureExpired(authInfo *token.AuthCachedInfo) 
 	return time.Since(time.Unix(authInfo.DeviceRegistrationDataValidationFailureSince, 0)) >= deviceRegistrationValidationGracePeriod
 }
 
-func cachedAuthInfoMatchesIdentity(session *session, authInfo, cachedInfo *token.AuthCachedInfo) bool {
-	if authInfo == nil || cachedInfo == nil {
+func (b *Broker) cachedAuthInfoMatchesIdentity(session *session, authInfo, cachedInfo *token.AuthCachedInfo) bool {
+	if b.provider == nil || session == nil || authInfo == nil || cachedInfo == nil {
 		return false
 	}
 
 	authenticatedProviderID := authInfo.UserInfo.ProviderID
-	if authenticatedProviderID == "" {
-		if !session.isOffline {
+	cachedProviderID := cachedInfo.UserInfo.ProviderID
+	if session.providerID != "" {
+		if authenticatedProviderID != "" && session.providerID != authenticatedProviderID {
 			return false
 		}
-		authenticatedProviderID = session.providerID
+		if cachedProviderID != "" && session.providerID != cachedProviderID {
+			return false
+		}
+
+		// The session provider ID is supplied by authd from the user database,
+		// so it can identify a legacy cache even when the cache predates the
+		// ProviderID field (including after a username change).
+		return authInfo.UserInfo.Name != "" && cachedInfo.UserInfo.Name != ""
 	}
-	cachedProviderID := cachedInfo.UserInfo.ProviderID
-	if cachedProviderID == "" {
-		cachedProviderID = session.providerID
+
+	if authenticatedProviderID != "" && cachedProviderID != "" {
+		return authenticatedProviderID == cachedProviderID
 	}
-	if authenticatedProviderID == "" || cachedProviderID == "" ||
-		authenticatedProviderID != cachedProviderID {
+
+	// A cache from before ProviderID was added can only be matched by the
+	// username that the current authentication path verified. This preserves
+	// legacy caches without allowing a known provider-ID mismatch through.
+	if authInfo.UserInfo.Name == "" || cachedInfo.UserInfo.Name == "" {
 		return false
 	}
-	return session.providerID == "" || session.providerID == authenticatedProviderID
+	if err := b.provider.VerifyUsername(session.username, authInfo.UserInfo.Name); err != nil {
+		return false
+	}
+	return b.provider.VerifyUsername(session.username, cachedInfo.UserInfo.Name) == nil
 }
 
 func (b *Broker) denyDisabledDevice(session *session, authInfo *token.AuthCachedInfo) (string, isAuthenticatedDataResponse) {
@@ -2361,7 +2375,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 	if authInfo == nil {
 		return access, data
 	}
-	if oldAuthInfo != nil && !cachedAuthInfoMatchesIdentity(session, authInfo, oldAuthInfo) {
+	if oldAuthInfo != nil && !b.cachedAuthInfoMatchesIdentity(session, authInfo, oldAuthInfo) {
 		oldAuthInfo = nil
 		authInfo.RawIDToken = ""
 	}

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -5937,6 +5937,107 @@ func TestDeviceAuthRedirectsToExistingProviderIDDir(t *testing.T) {
 	})
 }
 
+func writeLegacyCacheWithoutProviderID(t *testing.T, path, username string, groups []info.Group, deviceData []byte) {
+	t.Helper()
+
+	legacyCache := map[string]any{
+		"Token": map[string]string{
+			"access_token":  "cached-access-token",
+			"refresh_token": "cached-refresh-token",
+		},
+		"UserInfo": map[string]any{
+			"name":   username,
+			"groups": groups,
+		},
+		"DeviceRegistrationData": deviceData,
+	}
+	data, err := json.Marshal(legacyCache)
+	require.NoError(t, err, "Setup: marshaling the legacy cache should not fail")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700), "Setup: creating the legacy cache directory should not fail")
+	require.NoError(t, os.WriteFile(path, data, 0600), "Setup: writing the legacy cache should not fail")
+}
+
+func TestDeviceAuthReusesLegacyCacheWithoutProviderID(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	provider := &mockEntraAuthProvider{MockProvider: &testutils.MockProvider{}}
+	cfg := &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	}
+	b := newBrokerForTests(t, cfg)
+
+	sessionID, _ := newSessionForTests(t, b, username, sessionmode.Login)
+	writeLegacyCacheWithoutProviderID(
+		t,
+		b.TokenPathForSession(sessionID),
+		username,
+		[]info.Group{{Name: "cached-group", UGID: "cached-group-id"}},
+		mockDeviceRegistrationData,
+	)
+
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, mockDeviceRegistrationData, provider.registrationExistingData,
+		"device auth should reuse registration data from a legacy username-keyed cache")
+	require.Zero(t, provider.registrationEnrollments,
+		"reusing a legacy cache must not enroll the device again")
+}
+
+func TestPasswordAuthReusesLegacyCacheWithoutProviderID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		username        = "test-user@email.com"
+		correctPassword = "password"
+	)
+	provider := &mockEntraAuthProvider{MockProvider: &testutils.MockProvider{}}
+	cfg := &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	}
+	b := newBrokerForTests(t, cfg)
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	writeLegacyCacheWithoutProviderID(
+		t,
+		b.TokenPathForSession(sessionID),
+		username,
+		[]info.Group{{Name: "cached-group", UGID: "cached-group-id"}},
+		mockDeviceRegistrationData,
+	)
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Equal(t, mockDeviceRegistrationData, provider.registrationExistingData,
+		"password auth should reuse registration data from a legacy username-keyed cache")
+	require.Zero(t, provider.registrationEnrollments,
+		"reusing a legacy cache must not enroll the device again")
+}
+
 // TestOfflineLoginCacheDirectoryResolution covers how the cache directory is resolved
 // when the first login after the broker update happens while offline. The provider ID
 // can only be learned online (from a token refresh), so:

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -60,25 +60,29 @@ func lockMFAFlowStateForTests(flow *himmelblau.MFAFlowState) func() {
 
 type mockEntraAuthProvider struct {
 	*testutils.MockProvider
-	flowState             *himmelblau.MFAFlowState
-	challengeInfo         *himmelblau.MFAChallengeInfo
-	mfaTokenResult        *oauth2.Token
-	initErr               error
-	recordedPollAttempts  []int
-	recordedChallengeData []string
-	recordedInitAuthOpts  [][]himmelblau.AuthOption
-	recordedInitPasswords []string
-	recordedInitDevScopes []bool
-	registerDeviceCalls   int
-	refreshResult         *oauth2.Token // returned by RefreshEntraToken (defaults to a rotated token)
-	refreshErr            error         // when set, RefreshEntraToken returns it (e.g. AADSTS50057)
-	refreshDelay          time.Duration
-	refreshCtxDeadline    time.Time
-	verifyCtxDeadline     time.Time
-	userDisabledErrorCode string     // when set, IsUserDisabledError matches an *oauth2.RetrieveError with this code
-	verifyAccessTokenErr  error      // when set, VerifyAccessToken returns it (signature verification failure)
-	accessTokenUserInfo   *info.User // when set, UserInfoFromAccessToken returns this user info
-	userInfoFromTokenErr  error      // when set, UserInfoFromAccessToken returns this error
+	flowState                     *himmelblau.MFAFlowState
+	challengeInfo                 *himmelblau.MFAChallengeInfo
+	mfaTokenResult                *oauth2.Token
+	initErr                       error
+	recordedPollAttempts          []int
+	recordedChallengeData         []string
+	recordedInitAuthOpts          [][]himmelblau.AuthOption
+	recordedInitPasswords         []string
+	recordedInitDevScopes         []bool
+	registerDeviceCalls           int
+	refreshResult                 *oauth2.Token // returned by RefreshEntraToken (defaults to a rotated token)
+	refreshErr                    error         // when set, RefreshEntraToken returns it (e.g. AADSTS50057)
+	refreshDelay                  time.Duration
+	refreshCtxDeadline            time.Time
+	verifyCtxDeadline             time.Time
+	userDisabledErrorCode         string     // when set, IsUserDisabledError matches an *oauth2.RetrieveError with this code
+	verifyAccessTokenErr          error      // when set, VerifyAccessToken returns it (signature verification failure)
+	accessTokenUserInfo           *info.User // when set, UserInfoFromAccessToken returns this user info
+	userInfoFromTokenErr          error      // when set, UserInfoFromAccessToken returns this error
+	registrationAttempts          int
+	registrationEnrollments       int
+	registrationExistingData      []byte
+	registrationExistingDataCalls [][]byte
 }
 
 type blockingMFAProvider struct {
@@ -187,9 +191,14 @@ func (p *mockEntraAuthProvider) IsTokenForDeviceRegistration(authInfo *token.Aut
 
 func (p *mockEntraAuthProvider) MaybeRegisterDevice(_ context.Context, _ *oauth2.Token, _ string, _ string, oldData []byte) ([]byte, func(), error) {
 	p.registerDeviceCalls++
+	p.registrationAttempts++
+	oldDataCopy := append([]byte(nil), oldData...)
+	p.registrationExistingData = oldDataCopy
+	p.registrationExistingDataCalls = append(p.registrationExistingDataCalls, oldDataCopy)
 	if len(oldData) > 0 {
 		return oldData, func() {}, nil
 	}
+	p.registrationEnrollments++
 	return mockDeviceRegistrationData, func() {}, nil
 }
 
@@ -2695,6 +2704,31 @@ func advanceToEntraMFAWait(t *testing.T, b *broker.Broker, sessionID, key string
 	require.NoError(t, err)
 }
 
+func advanceToEntraMFACode(t *testing.T, b *broker.Broker, sessionID, key string) {
+	t.Helper()
+
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuth)
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+
+	access, _, err := b.IsAuthenticated(sessionID, passwordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraMFACode}, b.GetNextAuthModes(sessionID))
+
+	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraMFACode))
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.EntraMFACode)
+	require.NoError(t, err)
+}
+
+func submitEntraMFACode(t *testing.T, b *broker.Broker, sessionID, key string) (string, string) {
+	t.Helper()
+
+	otpAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "123456", key))
+	access, data, err := b.IsAuthenticated(sessionID, otpAuthData)
+	require.NoError(t, err)
+	return access, data
+}
+
 // TestIsAuthenticatedEntraAuthDeniesOnAccessTokenVerificationFailure verifies that
 // when the MFA access token fails signature verification (the TLS-MITM defense),
 // the login is denied rather than trusting the token's identity claims.
@@ -3421,6 +3455,335 @@ func TestIsAuthenticatedPasswordEntraTokenFallsBackToCachedGroupsOnGroupFetchErr
 	require.Equal(t, cachedGroups, payload.UserInfo.Groups, "cached groups must be used when the group fetch fails")
 }
 
+// TestIsAuthenticatedPasswordKeepsDeviceRegistrationOnMissingClientCredentials
+// verifies the #1721 regression boundary. AADSTS7000218 is an Entra application
+// configuration error, so a returning user's cached registration must survive it.
+// Otherwise, the next login sees no registration data and enrolls the same machine
+// again as a distinct Entra device.
+func TestIsAuthenticatedPasswordKeepsDeviceRegistrationOnMissingClientCredentials(t *testing.T) {
+	t.Parallel()
+
+	const (
+		correctPassword        = "password"
+		username               = "test-user@email.com"
+		deviceRegistrationData = "device-registration-data"
+	)
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", himmelblau.ErrMissingClientCredentials)
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                       broker.Config{DataDir: t.TempDir()},
+		provider:                     provider,
+		ownerAllowed:                 true,
+		firstUserBecomesOwner:        true,
+		issuerURL:                    defaultIssuerURL,
+		registerDevice:               true,
+		forceAccessCheckWithProvider: true,
+	})
+
+	sessionID, _ := newSessionForTests(t, b, username, sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{
+		username:                username,
+		issuer:                  defaultIssuerURL,
+		obtainedViaEntraAuth:    true,
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	authenticate := func() {
+		sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+		updateAuthModes(t, b, sessionID, authmodes.Password)
+		authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+
+		access, _, err := b.IsAuthenticated(sessionID, authData)
+		require.NoError(t, err)
+		require.Equal(t, broker.AuthGranted, access)
+	}
+
+	authenticate()
+	authenticate()
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Equal(t, []byte(deviceRegistrationData), cached.DeviceRegistrationData,
+		"AADSTS7000218 must not discard the existing Entra device registration")
+	require.Zero(t, provider.registrationEnrollments,
+		"returning logins after AADSTS7000218 must reuse the existing registration instead of enrolling another device")
+}
+
+// TestFinishEntraAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError
+// verifies that a confirmed device-authentication failure invalidates cached
+// registration data while preserving the returning user's cached groups.
+// AADSTS7000218, as reported in #1680, is not classified as this error.
+func TestFinishEntraAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: himmelblau.ErrDeviceAuthenticationFailed}
+			},
+		},
+		flowState: &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Please type in the code displayed on your authenticator app from your device:",
+			Method:            "PhoneAppOTP",
+			PollingIntervalMs: 5000,
+			MaxPollAttempts:   10,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	// isForDeviceRegistration seeds a non-empty (stale) DeviceRegistrationData;
+	// this is the cached token loaded as oldAuthInfo by entraAuth.
+	generateAndStoreCachedInfo(t, tokenOptions{
+		username:                username,
+		issuer:                  defaultIssuerURL,
+		obtainedViaEntraAuth:    true,
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+
+	advanceToEntraMFACode(t, b, sessionID, key)
+	access, data := submitEntraMFACode(t, b, sessionID, key)
+	require.Equal(t, broker.AuthGranted, access,
+		"a returning Entra login must fall back to cached groups when the group fetch fails with a retryable device-auth error")
+
+	var payload struct {
+		UserInfo struct {
+			Groups []info.Group `json:"groups"`
+		} `json:"userinfo"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t, cachedGroups, payload.UserInfo.Groups, "cached groups must still be used while the device is re-registered")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Empty(t, cached.DeviceRegistrationData,
+		"stale DeviceRegistrationData must be cleared so the next login re-registers the device "+
+			"instead of repeatedly failing getGroups with the same stale data")
+}
+
+// TestFinishEntraAuthPreservesFreshDeviceRegistrationOnRetryWithDeviceAuthError
+// verifies that a possible replication failure immediately after a new
+// registration does not discard the new registration on a returning login.
+func TestFinishEntraAuthPreservesFreshDeviceRegistrationOnRetryWithDeviceAuthError(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("device registration is not replicated yet")}
+			},
+		},
+		flowState: &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Please type in the code displayed on your authenticator app from your device:",
+			Method:            "PhoneAppOTP",
+			PollingIntervalMs: 5000,
+			MaxPollAttempts:   10,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+		registerDevice:        true,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	// The cached token exists but has no registration data: this login creates
+	// the fresh registration that must survive a possible replication failure.
+	generateAndStoreCachedInfo(t, tokenOptions{
+		username:             username,
+		issuer:               defaultIssuerURL,
+		obtainedViaEntraAuth: true,
+		groups:               cachedGroups,
+	}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+
+	advanceToEntraMFACode(t, b, sessionID, key)
+	access, data := submitEntraMFACode(t, b, sessionID, key)
+	require.Equal(t, broker.AuthGranted, access,
+		"a returning Entra login must preserve a fresh registration during a possible replication failure")
+
+	var payload struct {
+		UserInfo struct {
+			Groups []info.Group `json:"groups"`
+		} `json:"userinfo"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t, cachedGroups, payload.UserInfo.Groups)
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData,
+		"fresh DeviceRegistrationData must survive a possible post-enrollment replication failure")
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"fresh registration must remain pending until Graph group lookup succeeds")
+
+	retrySessionID, retryKey := newSessionForTests(t, b, username, sessionmode.Login)
+	updateAuthModes(t, b, retrySessionID, authmodes.Password)
+	retryAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", retryKey))
+	access, _, err = b.IsAuthenticated(retrySessionID, retryAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"a later local-password login must retain the fresh device registration")
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"a pending registration must be reused instead of enrolling another device")
+}
+
+func TestFinishEntraAuthFirstLoginPersistsFreshRegistrationPendingValidation(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("device registration is not replicated yet")}
+			},
+		},
+		flowState: &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Please type in the code displayed on your authenticator app from your device:",
+			Method:            "PhoneAppOTP",
+			PollingIntervalMs: 5000,
+			MaxPollAttempts:   10,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+		registerDevice:        true,
+	})
+
+	authenticate := func() (string, string) {
+		sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+		advanceToEntraMFACode(t, b, sessionID, key)
+		access, _ := submitEntraMFACode(t, b, sessionID, key)
+		return sessionID, access
+	}
+
+	firstSessionID, access := authenticate()
+	require.Equal(t, broker.AuthDenied, access,
+		"a first login without cached groups must still be denied")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(firstSessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData)
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"the fresh registration must be marked pending before the first login is denied")
+
+	secondSessionID, access := authenticate()
+	require.Equal(t, broker.AuthDenied, access,
+		"the next interactive login must not use groups that were never resolved")
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"retrying after the first denial must not enroll another device")
+
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(secondSessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData)
+	require.True(t, cached.DeviceRegistrationDataValidationPending)
+}
+
+// TestFinishEntraAuthRejectsTerminalGroupErrors verifies that terminal
+// provider errors are not converted into cached-group fallbacks.
+func TestFinishEntraAuthRejectsTerminalGroupErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		groupErr           error
+		wantDeviceDisabled bool
+		wantMessage        string
+	}{
+		"device_disabled": {
+			groupErr:           providerErrors.ErrDeviceDisabled,
+			wantDeviceDisabled: true,
+		},
+		"invalid_redirect_uri": {
+			groupErr:    providerErrors.ErrInvalidRedirectURI,
+			wantMessage: "Invalid redirect URI",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			const username = "test-user@email.com"
+			mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+			provider := &mockEntraAuthProvider{
+				MockProvider: &testutils.MockProvider{
+					GetGroupsFunc: func() ([]info.Group, error) {
+						return nil, tc.groupErr
+					},
+				},
+				flowState: &himmelblau.MFAFlowState{},
+				challengeInfo: &himmelblau.MFAChallengeInfo{
+					Message:           "Please type in the code displayed on your authenticator app from your device:",
+					Method:            "PhoneAppOTP",
+					PollingIntervalMs: 5000,
+					MaxPollAttempts:   10,
+				},
+				mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+			}
+			b := newBrokerForTests(t, &brokerForTestConfig{
+				Config:                broker.Config{DataDir: t.TempDir()},
+				ownerAllowed:          true,
+				firstUserBecomesOwner: true,
+				provider:              provider,
+				issuerURL:             defaultIssuerURL,
+				registerDevice:        true,
+			})
+
+			sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+			advanceToEntraMFACode(t, b, sessionID, key)
+			access, data := submitEntraMFACode(t, b, sessionID, key)
+			require.Equal(t, broker.AuthDenied, access)
+			if tc.wantMessage != "" {
+				require.Contains(t, data, tc.wantMessage)
+			}
+
+			if tc.wantDeviceDisabled {
+				cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+				require.NoError(t, err)
+				require.True(t, cached.DeviceIsDisabled,
+					"the disabled state must be persisted so offline logins are denied too")
+			}
+		})
+	}
+}
+
 // TestIsAuthenticatedPasswordEntraTokenRefreshDetectsDisabledUser verifies that on a
 // returning login the Entra password token refresh (refreshEntraToken) is the
 // live disabled-user check: an AADSTS50057-class rejection is classified exactly like
@@ -3820,6 +4183,305 @@ func TestDeviceAuthClearsDeviceRegistrationDataWhenRegistrationDisabled(t *testi
 	require.Empty(t, cached.DeviceRegistrationData,
 		"re-authenticating via device-code with register_device=false must store a token "+
 			"without DeviceRegistrationData so subsequent group lookups don't attempt PRT exchange")
+}
+
+// TestDeviceAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError
+// verifies that a returning device-code login clears a cached registration
+// when the provider positively reports that the device authentication failed.
+func TestDeviceAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("device registration data is stale")}
+			},
+		},
+	}
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	sessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, b.TokenPathForSession(sessionID))
+
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, data, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(sessionID))
+	require.Contains(t, data, "token issue")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Empty(t, cached.DeviceRegistrationData,
+		"stale device registration data must be cleared before device-code reauthentication")
+	require.Equal(t, cachedGroups, cached.UserInfo.Groups,
+		"clearing stale registration must preserve cached groups")
+}
+
+// TestDeviceAuthPersistsDisabledDeviceState verifies that a device-auth login
+// whose group lookup reports a disabled device caches that state for offline
+// logins.
+func TestDeviceAuthPersistsDisabledDeviceState(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, providerErrors.ErrDeviceDisabled
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	sessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access)
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.True(t, cached.DeviceIsDisabled,
+		"the disabled state must be persisted so offline logins are denied too")
+}
+
+// TestDeviceAuthFallsBackToCachedGroupsOnGroupFetchError verifies that a
+// returning device-code login preserves access and registration state when a
+// group lookup fails for a reason that does not prove device invalidation.
+func TestDeviceAuthFallsBackToCachedGroupsOnGroupFetchError(t *testing.T) {
+	t.Parallel()
+
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, errors.New("temporary group lookup failure")
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{{"aud": consts.MicrosoftBrokerAppID}},
+		},
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, b.TokenPathForSession(sessionID))
+
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.NewPassword}, b.GetNextAuthModes(sessionID))
+
+	updateAuthModes(t, b, sessionID, authmodes.NewPassword)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "new-password", key))
+	access, data, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+
+	var payload struct {
+		UserInfo struct {
+			Groups []info.Group `json:"groups"`
+		} `json:"userinfo"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t, cachedGroups, payload.UserInfo.Groups)
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData,
+		"a non-device group error must preserve the existing registration")
+}
+
+// TestDeviceAuthPreservesFreshRegistrationOnRetryWithDeviceAuthError verifies
+// that a 50155-like failure immediately after a new enrollment does not clear
+// the fresh registration, allowing a later retry to survive a replication race.
+func TestDeviceAuthPreservesFreshRegistrationOnRetryWithDeviceAuthError(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("device registration is not replicated yet")}
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	sessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a fresh registration failure should deny this first login without discarding the new registration")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData,
+		"a fresh registration must survive a possible post-enrollment replication failure")
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"the fresh registration must be marked pending before the first login is denied")
+}
+
+// TestDeviceAuthPreservesFreshRegistrationOnRecoverableGraphFailure verifies
+// that a non-device Graph error, such as AADSTS7000218, also preserves fresh
+// registration data across device-auth requests.
+func TestDeviceAuthPreservesFreshRegistrationOnRecoverableGraphFailure(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, fmt.Errorf("failed to acquire Graph token: %w", himmelblau.ErrMissingClientCredentials)
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	firstSessionID, _ := newSessionForTests(t, b, username, sessionmode.Login)
+	updateAuthModes(t, b, firstSessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(firstSessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a first login without cached groups must still be denied")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(firstSessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData,
+		"fresh registration data must survive a recoverable Graph error")
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"fresh registration must remain pending until Graph lookup succeeds")
+
+	secondSessionID, _ := newSessionForTests(t, b, username, sessionmode.Login)
+	updateAuthModes(t, b, secondSessionID, authmodes.DeviceQr)
+	access, _, err = b.IsAuthenticated(secondSessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a later device-auth request must not use groups that were never resolved")
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"a recoverable Graph error must not trigger another device enrollment")
+	require.Len(t, provider.registrationExistingDataCalls, 2)
+	require.Equal(t, mockDeviceRegistrationData, provider.registrationExistingDataCalls[1],
+		"the second device-auth request must receive the cached registration data")
+}
+
+func TestDeviceAuthPersistsClearedValidationPendingAfterGroupSuccess(t *testing.T) {
+	t.Parallel()
+
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	groupFetches := 0
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				groupFetches++
+				if groupFetches == 1 {
+					return cachedGroups, nil
+				}
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("device registration data is stale")}
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	firstSessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	updateAuthModes(t, b, firstSessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(firstSessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.NewPassword}, b.GetNextAuthModes(firstSessionID))
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(firstSessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataValidationPending,
+		"successful group lookup must persist that registration validation completed")
+
+	retrySessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	updateAuthModes(t, b, retrySessionID, authmodes.DeviceQr)
+	access, _, err = b.IsAuthenticated(retrySessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(retrySessionID))
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"a later device-auth failure must invalidate the existing registration instead of enrolling during this flow")
+
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(retrySessionID))
+	require.NoError(t, err)
+	require.Empty(t, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataValidationPending)
 }
 
 // TestIsAuthenticatedPhoneAppOTPRoutesToMFACode verifies that PhoneAppOTP

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -1240,7 +1240,7 @@ func TestIsAuthenticated(t *testing.T) {
 		},
 		"Authenticating_with_password_keeps_old_groups_if_fetching_groups_fails": {
 			firstMode:      authmodes.Password,
-			token:          &tokenOptions{groups: []info.Group{{Name: "old-group"}}},
+			token:          &tokenOptions{groups: []info.Group{{Name: "old-group"}}, providerID: "test-user-id"},
 			getGroupsFails: true,
 			wantGroups:     []info.Group{{Name: "old-group"}},
 		},
@@ -3887,6 +3887,247 @@ func TestIsAuthenticatedPasswordRefreshPreservesRotationOnUserInfoError(t *testi
 		"a failed local validation must not replace the cached raw ID token")
 }
 
+// TestIsAuthenticatedPasswordRefreshKeepsDisabledDeviceFlagUntilGroupSuccess
+// verifies that a successful refresh does not wipe a persisted disabled-device
+// flag: a refresh verifies the user, not the device, so the flag survives and
+// only a successful group lookup — positive evidence that the device is valid
+// again — clears it.
+func TestIsAuthenticatedPasswordRefreshKeepsDisabledDeviceFlagUntilGroupSuccess(t *testing.T) {
+	t.Parallel()
+
+	const correctPassword = "password"
+
+	tests := map[string]struct {
+		groupsErr    error
+		wantDisabled bool
+	}{
+		"Group_lookup_failure_keeps_the_flag": {
+			groupsErr:    errors.New("temporary group lookup failure"),
+			wantDisabled: true,
+		},
+		"Successful_group_lookup_clears_the_flag": {
+			wantDisabled: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &testutils.MockProvider{
+				GetGroupsFunc: func() ([]info.Group, error) {
+					if tc.groupsErr != nil {
+						return nil, tc.groupsErr
+					}
+					return []info.Group{{Name: "remote-group"}}, nil
+				},
+			}
+			b := newBrokerForTests(t, &brokerForTestConfig{
+				Config:                broker.Config{DataDir: t.TempDir()},
+				ownerAllowed:          true,
+				firstUserBecomesOwner: true,
+				provider:              provider,
+				tokenHandlerOptions: &testutils.TokenHandlerOptions{
+					// An empty claims map keeps the mock token endpoint's
+					// default OIDC audience while the test helper injects
+					// the "sub" that matches the seeded cache identity.
+					IDTokenClaims: []map[string]interface{}{
+						{},
+					},
+				},
+			})
+
+			sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+			generateAndStoreCachedInfo(t, tokenOptions{
+				deviceIsDisabled: true,
+				groups:           []info.Group{{Name: "cached-group", UGID: "cached-id"}},
+			}, b.TokenPathForSession(sessionID))
+			require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+			updateAuthModes(t, b, sessionID, authmodes.Password)
+			authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+
+			access, _, err := b.IsAuthenticated(sessionID, authData)
+			require.NoError(t, err)
+			require.Equal(t, broker.AuthGranted, access,
+				"a returning login with resolved cached groups must complete regardless of the persisted device state")
+
+			cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+			require.NoError(t, err)
+			if tc.wantDisabled {
+				require.True(t, cached.DeviceIsDisabled,
+					"a refresh verifies the user, not the device: the disabled flag must survive until a group lookup succeeds")
+			} else {
+				require.False(t, cached.DeviceIsDisabled,
+					"a successful group lookup proves the device is valid and must clear the disabled flag")
+			}
+		})
+	}
+}
+
+// TestDeviceAuthKeepsDisabledDeviceFlagUntilGroupSuccess verifies that a
+// returning device-code login preserves a persisted disabled-device flag:
+// a group-fetch failure is not evidence that the device is valid again, so
+// the flag survives the fallback, and only a successful group lookup clears
+// it.
+func TestDeviceAuthKeepsDisabledDeviceFlagUntilGroupSuccess(t *testing.T) {
+	t.Parallel()
+
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	tests := map[string]struct {
+		groupsErr    error
+		wantDisabled bool
+	}{
+		"Group_lookup_failure_keeps_the_flag": {
+			groupsErr:    errors.New("temporary group lookup failure"),
+			wantDisabled: true,
+		},
+		"Successful_group_lookup_clears_the_flag": {
+			wantDisabled: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &mockEntraAuthProvider{
+				MockProvider: &testutils.MockProvider{
+					GetGroupsFunc: func() ([]info.Group, error) {
+						if tc.groupsErr != nil {
+							return nil, tc.groupsErr
+						}
+						return []info.Group{{Name: "remote-group"}}, nil
+					},
+				},
+			}
+			b := newBrokerForTests(t, &brokerForTestConfig{
+				Config:                broker.Config{DataDir: t.TempDir()},
+				ownerAllowed:          true,
+				firstUserBecomesOwner: true,
+				provider:              provider,
+				registerDevice:        true,
+				tokenHandlerOptions: &testutils.TokenHandlerOptions{
+					IDTokenClaims: []map[string]interface{}{{"aud": consts.MicrosoftBrokerAppID}},
+				},
+			})
+
+			sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+			generateAndStoreCachedInfo(t, tokenOptions{
+				isForDeviceRegistration: true,
+				deviceIsDisabled:        true,
+				groups:                  cachedGroups,
+			}, b.TokenPathForSession(sessionID))
+
+			updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+			access, _, err := b.IsAuthenticated(sessionID, "{}")
+			require.NoError(t, err)
+			require.Equal(t, broker.AuthNext, access)
+			require.Equal(t, []string{authmodes.NewPassword}, b.GetNextAuthModes(sessionID))
+
+			updateAuthModes(t, b, sessionID, authmodes.NewPassword)
+			authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "new-password", key))
+			access, _, err = b.IsAuthenticated(sessionID, authData)
+			require.NoError(t, err)
+			require.Equal(t, broker.AuthGranted, access)
+
+			cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+			require.NoError(t, err)
+			if tc.wantDisabled {
+				require.True(t, cached.DeviceIsDisabled,
+					"a group-fetch failure is not evidence the device is valid: the disabled flag must survive the fallback")
+			} else {
+				require.False(t, cached.DeviceIsDisabled,
+					"a successful group lookup proves the device is valid and must clear the disabled flag")
+			}
+		})
+	}
+}
+
+// TestEntraAuthKeepsDisabledDeviceFlagUntilGroupSuccess verifies the same
+// preserved-flag contract on the Entra MFA flow: a live MFA assertion
+// verifies the user, not the device object, so a cached disabled-device flag
+// survives a group-fetch failure and only a successful group lookup clears
+// it.
+func TestEntraAuthKeepsDisabledDeviceFlagUntilGroupSuccess(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	tests := map[string]struct {
+		groupsErr    error
+		wantDisabled bool
+	}{
+		"Group_lookup_failure_keeps_the_flag": {
+			groupsErr:    errors.New("temporary group lookup failure"),
+			wantDisabled: true,
+		},
+		"Successful_group_lookup_clears_the_flag": {
+			wantDisabled: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mfaAuthInfo := generateCachedInfo(t, tokenOptions{
+				username: username,
+				issuer:   defaultIssuerURL,
+			})
+			provider := &mockEntraAuthProvider{
+				MockProvider: &testutils.MockProvider{
+					GetGroupsFunc: func() ([]info.Group, error) {
+						if tc.groupsErr != nil {
+							return nil, tc.groupsErr
+						}
+						return []info.Group{{Name: "remote-group"}}, nil
+					},
+				},
+				flowState: &himmelblau.MFAFlowState{},
+				challengeInfo: &himmelblau.MFAChallengeInfo{
+					Message:           "Please type in the code displayed on your authenticator app from your device:",
+					Method:            "PhoneAppOTP",
+					PollingIntervalMs: 5000,
+					MaxPollAttempts:   10,
+				},
+				mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+			}
+			b := newBrokerForTests(t, &brokerForTestConfig{
+				Config:                broker.Config{DataDir: t.TempDir()},
+				ownerAllowed:          true,
+				firstUserBecomesOwner: true,
+				provider:              provider,
+				issuerURL:             defaultIssuerURL,
+				registerDevice:        true,
+			})
+
+			sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+			generateAndStoreCachedInfo(t, tokenOptions{
+				username:                username,
+				issuer:                  defaultIssuerURL,
+				obtainedViaEntraAuth:    true,
+				isForDeviceRegistration: true,
+				deviceIsDisabled:        true,
+				groups:                  cachedGroups,
+			}, b.TokenPathForSession(sessionID))
+			require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+
+			advanceToEntraMFACode(t, b, sessionID, key)
+			access, _ := submitEntraMFACode(t, b, sessionID, key)
+			require.Equal(t, broker.AuthGranted, access,
+				"a returning Entra login must fall back to cached groups when the group fetch fails without proving device invalidation")
+
+			cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+			require.NoError(t, err)
+			if tc.wantDisabled {
+				require.True(t, cached.DeviceIsDisabled,
+					"a group-fetch failure is not evidence the device is valid: the disabled flag must survive the fallback")
+			} else {
+				require.False(t, cached.DeviceIsDisabled,
+					"a successful group lookup proves the device is valid and must clear the disabled flag")
+			}
+		})
+	}
+}
+
 // TestIsAuthenticatedPasswordEntraTokenRefreshRotatesRefreshToken verifies that a
 // successful Entra password token refresh on a returning login rotates the cached
 // refresh token (kept fresh on each login, like the device-auth flow) and that the
@@ -4135,6 +4376,41 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnUsernameMismatch(t *tes
 		"a local username verification failure must not discard an already-rotated refresh token")
 }
 
+func TestIsAuthenticatedPasswordEntraTokenRefreshDoesNotReuseGroupsForDifferentIdentity(t *testing.T) {
+	t.Parallel()
+
+	const correctPassword = "password"
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{GetGroupsFunc: func() ([]info.Group, error) {
+			return nil, errors.New("temporary group lookup failure")
+		}},
+		refreshResult:       &oauth2.Token{AccessToken: "new-access-token", RefreshToken: "new-refresh-token"},
+		accessTokenUserInfo: &info.User{Name: "test-user@email.com", ProviderID: "replacement-user-id"},
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{
+		obtainedViaEntraAuth: true,
+		groups:               []info.Group{{Name: "sudo", UGID: "privileged-group-id"}},
+	}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a replacement identity must not inherit cached authorization groups when Graph lookup fails")
+}
+
 // TestDeviceAuthClearsDeviceRegistrationDataWhenRegistrationDisabled verifies that
 // when register_device is changed from true to false and the user re-authenticates
 // via device-code (which they are forced into because the stale device-registration
@@ -4369,6 +4645,70 @@ func TestDeviceAuthPreservesFreshRegistrationOnRetryWithDeviceAuthError(t *testi
 		"a fresh registration must survive a possible post-enrollment replication failure")
 	require.True(t, cached.DeviceRegistrationDataValidationPending,
 		"the fresh registration must be marked pending before the first login is denied")
+	require.NotZero(t, cached.DeviceRegistrationDataValidationFailureSince,
+		"the first confirmed device-authentication failure must start the recovery grace period")
+}
+
+func TestDeviceAuthReenrollsAfterPendingValidationFailureGracePeriod(t *testing.T) {
+	t.Parallel()
+
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{
+					Err: himmelblau.ErrDeviceAuthenticationFailed,
+				}
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	sessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	cachedInfo := generateCachedInfo(t, tokenOptions{
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	})
+	cachedInfo.DeviceRegistrationDataValidationPending = true
+	cachedInfo.DeviceRegistrationDataValidationFailureSince = time.Now().Add(-time.Hour).Unix()
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), cachedInfo))
+	cachedInfo, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.True(t, cachedInfo.DeviceRegistrationDataValidationPending)
+	require.NotZero(t, cachedInfo.DeviceRegistrationDataValidationFailureSince)
+
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(sessionID))
+	require.Zero(t, provider.registrationEnrollments,
+		"an expired pending registration must be invalidated before a replacement is enrolled")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Empty(t, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataValidationPending)
+	require.Zero(t, cached.DeviceRegistrationDataValidationFailureSince)
+
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err = b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"the next authentication must enroll a replacement after the pending registration expires")
 }
 
 // TestDeviceAuthPreservesFreshRegistrationOnRecoverableGraphFailure verifies
@@ -4412,6 +4752,8 @@ func TestDeviceAuthPreservesFreshRegistrationOnRecoverableGraphFailure(t *testin
 		"fresh registration data must survive a recoverable Graph error")
 	require.True(t, cached.DeviceRegistrationDataValidationPending,
 		"fresh registration must remain pending until Graph lookup succeeds")
+	require.Zero(t, cached.DeviceRegistrationDataValidationFailureSince,
+		"non-device Graph errors must not start device-registration recovery")
 
 	secondSessionID, _ := newSessionForTests(t, b, username, sessionmode.Login)
 	updateAuthModes(t, b, secondSessionID, authmodes.DeviceQr)
@@ -4424,6 +4766,10 @@ func TestDeviceAuthPreservesFreshRegistrationOnRecoverableGraphFailure(t *testin
 	require.Len(t, provider.registrationExistingDataCalls, 2)
 	require.Equal(t, mockDeviceRegistrationData, provider.registrationExistingDataCalls[1],
 		"the second device-auth request must receive the cached registration data")
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(secondSessionID))
+	require.NoError(t, err)
+	require.Zero(t, cached.DeviceRegistrationDataValidationFailureSince,
+		"non-device Graph errors must not start device-registration recovery")
 }
 
 func TestDeviceAuthPersistsClearedValidationPendingAfterGroupSuccess(t *testing.T) {

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -2149,6 +2149,88 @@ func TestCancelIsAuthenticated(t *testing.T) {
 	<-stopped
 }
 
+func TestCancelledPasswordAuthDoesNotFinishCachedGroupFallback(t *testing.T) {
+	t.Parallel()
+
+	const (
+		username        = "test-user@email.com"
+		correctPassword = "password"
+	)
+	groupsStarted := make(chan struct{})
+	releaseGroups := make(chan struct{})
+	groupsDone := make(chan struct{})
+	provider := &testutils.MockProvider{
+		GetGroupsFunc: func() ([]info.Group, error) {
+			close(groupsStarted)
+			<-releaseGroups
+			close(groupsDone)
+			return nil, errors.New("temporary group lookup failure")
+		},
+	}
+	configFile := filepath.Join(t.TempDir(), "authd.conf")
+	require.NoError(t, os.WriteFile(configFile, []byte(fmt.Sprintf(
+		"[oidc]\nissuer = %s\nclient_id = test-client-id\n",
+		defaultIssuerURL,
+	)), 0600))
+	cfg := &brokerForTestConfig{
+		Config:                broker.Config{ConfigFile: configFile, DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	}
+	b := newBrokerForTests(t, cfg)
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{
+		username:   username,
+		issuer:     defaultIssuerURL,
+		providerID: "test-user-id",
+		gecos:      "cached-gecos",
+		groups:     []info.Group{{Name: "cached-group", UGID: "cached-group-id"}},
+	}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+	authDone := make(chan struct{})
+	var access, data string
+	var authErr error
+	go func() {
+		access, data, authErr = b.IsAuthenticated(sessionID, authData)
+		close(authDone)
+	}()
+
+	select {
+	case <-groupsStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("group lookup did not start")
+	}
+
+	b.CancelIsAuthenticated(sessionID)
+	select {
+	case <-authDone:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled authentication did not return")
+	}
+	require.Equal(t, broker.AuthCancelled, access)
+	require.Contains(t, data, "Authentication request cancelled")
+	require.ErrorIs(t, authErr, context.Canceled)
+
+	close(releaseGroups)
+	select {
+	case <-groupsDone:
+	case <-time.After(time.Second):
+		t.Fatal("group lookup did not finish")
+	}
+
+	require.Never(t, func() bool {
+		_, err := os.Stat(broker.GetDropInDir(configFile))
+		return err == nil
+	}, time.Second, 10*time.Millisecond,
+		"cancelled authentication must not finish the cached-group fallback")
+}
+
 func TestIsAuthenticatedMaxAttempts(t *testing.T) {
 	t.Parallel()
 

--- a/authd-oidc-brokers/internal/broker/helper_test.go
+++ b/authd-oidc-brokers/internal/broker/helper_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -165,6 +166,22 @@ func newBrokerForTests(t *testing.T, cfg *brokerForTestConfig) (b *broker.Broker
 		for endpoint, handler := range cfg.customHandlers {
 			serverOpts = append(serverOpts, testutils.WithHandler(endpoint, handler))
 		}
+		if cfg.tokenHandlerOptions != nil {
+			// Clone before mutating: tests run in parallel and must not share
+			// option maps. This aligns live-token identity with the cached
+			// identity the broker tests use. A test that needs an absent
+			// "sub" claim can opt out by setting claims["sub"] = "".
+			opts := *cfg.tokenHandlerOptions
+			opts.IDTokenClaims = make([]map[string]interface{}, len(cfg.tokenHandlerOptions.IDTokenClaims))
+			for i, claims := range cfg.tokenHandlerOptions.IDTokenClaims {
+				cloned := maps.Clone(claims)
+				if _, exists := cloned["sub"]; !exists {
+					cloned["sub"] = "saved-user-id"
+				}
+				opts.IDTokenClaims[i] = cloned
+			}
+			cfg.tokenHandlerOptions = &opts
+		}
 		issuerURL, cleanup := testutils.StartMockProviderServer(
 			cfg.listenAddress,
 			cfg.tokenHandlerOptions,
@@ -257,10 +274,11 @@ func generateAndStoreCachedInfo(t *testing.T, options tokenOptions, path string)
 }
 
 type tokenOptions struct {
-	username string
-	issuer   string
-	gecos    string
-	groups   []info.Group
+	username   string
+	issuer     string
+	gecos      string
+	groups     []info.Group
+	providerID string
 
 	expired                     bool
 	noRefreshToken              bool
@@ -290,10 +308,13 @@ func generateCachedInfo(t *testing.T, options tokenOptions) *token.AuthCachedInf
 	if options.username == "-" {
 		options.username = ""
 	}
+	if options.providerID == "" {
+		options.providerID = "saved-user-id"
+	}
 
 	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"iss":                options.issuer,
-		"sub":                "saved-user-id",
+		"sub":                options.providerID,
 		"aud":                "test-client-id",
 		"exp":                9999999999,
 		"name":               "test-user",
@@ -343,7 +364,7 @@ func generateCachedInfo(t *testing.T, options tokenOptions) *token.AuthCachedInf
 		}
 		tok.UserInfo = info.User{
 			Name:       options.username,
-			ProviderID: "saved-user-id",
+			ProviderID: options.providerID,
 			Home:       "/home/" + options.username,
 			Gecos:      options.gecos,
 			Shell:      "/usr/bin/bash",

--- a/authd-oidc-brokers/internal/broker/helper_test.go
+++ b/authd-oidc-brokers/internal/broker/helper_test.go
@@ -313,6 +313,9 @@ func generateCachedInfo(t *testing.T, options tokenOptions) *token.AuthCachedInf
 		DeviceIsDisabled:     options.deviceIsDisabled,
 		UserIsDisabled:       options.userIsDisabled,
 		ObtainedViaEntraAuth: options.obtainedViaEntraAuth,
+		// A seeded cache simulates a previously successful login, so its
+		// groups count as resolved.
+		GroupsResolved: true,
 	}
 
 	if options.expired {

--- a/authd-oidc-brokers/internal/providers/msentraid/export_test.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/export_test.go
@@ -2,7 +2,14 @@
 
 package msentraid
 
-import "strings"
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/himmelblau"
+	"golang.org/x/oauth2"
+)
 
 // AllExpectedScopes returns all the default expected scopes for a new provider.
 func AllExpectedScopes() string {
@@ -12,4 +19,34 @@ func AllExpectedScopes() string {
 // SetTokenScopesForGraphAPI can be used in tests to set the scopes for the Microsoft Graph API access token.
 func (p *Provider) SetTokenScopesForGraphAPI(scopes []string) {
 	p.tokenScopesForGraphAPI = scopes
+}
+
+// ClassifyGraphTokenAcquisitionError exposes classifyGraphTokenAcquisitionError for tests.
+func ClassifyGraphTokenAcquisitionError(err error) error {
+	return classifyGraphTokenAcquisitionError(err)
+}
+
+// AcquireGraphAccessTokenWithRetry exposes acquireGraphAccessTokenWithRetry for tests.
+func AcquireGraphAccessTokenWithRetry(
+	ctx context.Context,
+	acquire func() (string, error),
+	retryInterval time.Duration,
+	retryTimeout ...time.Duration,
+) (string, error) {
+	timeout := graphTokenAcquisitionRetryTimeout
+	if len(retryTimeout) > 0 {
+		timeout = retryTimeout[0]
+	}
+	return acquireGraphAccessTokenWithRetry(ctx, acquire, retryInterval, timeout)
+}
+
+// SetGraphAccessTokenAcquirerForTests overrides the Graph token exchange for tests.
+func (p *Provider) SetGraphAccessTokenAcquirerForTests(acquirer func(
+	context.Context,
+	string,
+	string,
+	*oauth2.Token,
+	himmelblau.DeviceRegistrationData,
+) (string, error)) {
+	p.graphAccessTokenAcquirerForTests = acquirer
 }

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/errors.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/errors.go
@@ -1,7 +1,10 @@
 // Package himmelblau provides functions to use the libhimmelblau library.
 package himmelblau
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ErrDeviceDisabled is returned when the device is disabled in Microsoft Entra ID.
 var ErrDeviceDisabled = fmt.Errorf("device is disabled in Microsoft Entra ID")
@@ -9,11 +12,82 @@ var ErrDeviceDisabled = fmt.Errorf("device is disabled in Microsoft Entra ID")
 // ErrInvalidRedirectURI is returned when the redirect URI of the client application is missing or invalid.
 var ErrInvalidRedirectURI = fmt.Errorf("invalid redirect URI")
 
-// TokenAcquisitionError is returned when an error occurs while acquiring a token via libhimmelblau.
-type TokenAcquisitionError struct {
-	msg string
+// ErrMissingClientCredentials is returned when the token endpoint requires
+// client credentials but none were supplied.
+var ErrMissingClientCredentials = fmt.Errorf("token endpoint requires client credentials")
+
+// ErrDeviceAuthenticationFailed is returned when Microsoft Entra reports that
+// the device itself failed authentication (AADSTS50155). Microsoft returns
+// this generic code for several distinct situations, including (per
+// Microsoft's docs and himmelblau-idm/himmelblau's handling of the same
+// code) an administrator deleting the device object, but also a transient
+// replication delay right after a device was (re-)registered. himmelblau-idm
+// retries once after a short delay before treating a fresh registration's
+// AADSTS50155 as final (see the DEVICE_AUTH_FAIL retry in
+// unix_user_online_auth_step, src/common/src/idprovider/himmelblau.rs).
+//
+// An administrator deleting the device object is the manual positive control
+// for this signal, but it is not a universal mapping for every tenant or
+// authentication operation. Microsoft can still return a different code for
+// another device-invalid scenario, and a freshly registered device may report
+// AADSTS50155 transiently while Entra replicates it. The latter is why this
+// code should not be treated as proof that every AADSTS50155 is permanent
+// without a bounded retry/grace period.
+var ErrDeviceAuthenticationFailed = fmt.Errorf("device authentication failed in Microsoft Entra ID")
+
+// Entra AADSTS error codes as defined in
+// https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
+const (
+	// AADSTS135011 Device used during the authentication is disabled.
+	deviceDisabledErrorCode = 135011
+	// AADSTS50011 InvalidReplyTo - The reply address is missing, misconfigured,
+	// or doesn't match reply addresses configured for the app.
+	invalidRedirectURIErrorCode = 50011
+	// AADSTS500113 - No reply address is registered for the application.
+	// A separate documented code, but the same reply-address misconfiguration
+	// family as AADSTS50011.
+	noReplyAddressErrorCode = 500113
+	// AADSTS7000218 RequestBodyMustContainClientAssertion - The request body
+	// must contain a client_assertion or client_secret.
+	missingClientCredentialsErrorCode = 7000218
+	// AADSTS50155 DeviceAuthenticationFailed - the device used during
+	// authentication is no longer known/valid to Microsoft Entra, e.g.
+	// because an administrator deleted the device object. See the caveats on
+	// ErrDeviceAuthenticationFailed for the non-universal and transient-race
+	// limitations.
+	deviceAuthenticationFailedErrorCode = 50155
+)
+
+func tokenAcquisitionError(errorCodes []uint32, message string) error {
+	for _, errorCode := range errorCodes {
+		// Match AADSTS codes exactly. Every code handled here is a
+		// documented, distinct error. A wrong guess is costly: 50155
+		// triggers re-enrollment, while the redirect-URI and
+		// device-disabled codes deny the login. An unrecognized code falls
+		// through to the catch-all below, which preserves cached state.
+		switch errorCode {
+		case invalidRedirectURIErrorCode, noReplyAddressErrorCode:
+			return withAADSTSErrorCode(ErrInvalidRedirectURI, errorCode, message)
+		case missingClientCredentialsErrorCode:
+			return withAADSTSErrorCode(ErrMissingClientCredentials, errorCode, message)
+		case deviceDisabledErrorCode:
+			return withAADSTSErrorCode(ErrDeviceDisabled, errorCode, message)
+		case deviceAuthenticationFailedErrorCode:
+			return withAADSTSErrorCode(ErrDeviceAuthenticationFailed, errorCode, message)
+		}
+	}
+
+	// The token acquisition failed for a reason we don't specifically
+	// recognize. Unlike ErrDeviceAuthenticationFailed, this is NOT positive
+	// evidence that the device registration itself is invalid, so callers
+	// must not treat it as such (e.g. by clearing cached registration data).
+	return fmt.Errorf("error acquiring access token using refresh token: %v", message)
 }
 
-func (e TokenAcquisitionError) Error() string {
-	return e.msg
+func withAADSTSErrorCode(err error, errorCode uint32, message string) error {
+	aadstsCode := fmt.Sprintf("AADSTS%d", errorCode)
+	if strings.Contains(message, aadstsCode) {
+		return fmt.Errorf("%w: %s", err, message)
+	}
+	return fmt.Errorf("%w (%s): %s", err, aadstsCode, message)
 }

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/errors_test.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/errors_test.go
@@ -1,0 +1,77 @@
+package himmelblau
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenAcquisitionErrorClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		errorCodes []uint32
+		want       error
+		wantCode   string
+	}{
+		"Device_disabled":      {errorCodes: []uint32{deviceDisabledErrorCode}, want: ErrDeviceDisabled, wantCode: "AADSTS135011"},
+		"Invalid_redirect_URI": {errorCodes: []uint32{invalidRedirectURIErrorCode}, want: ErrInvalidRedirectURI, wantCode: "AADSTS50011"},
+		// AADSTS500113 is a separate documented code, but the same
+		// reply-address misconfiguration family as AADSTS50011. It must be
+		// classified explicitly rather than caught by prefix matching.
+		"No_reply_address":             {errorCodes: []uint32{noReplyAddressErrorCode}, want: ErrInvalidRedirectURI, wantCode: "AADSTS500113"},
+		"Missing_client_credentials":   {errorCodes: []uint32{missingClientCredentialsErrorCode}, want: ErrMissingClientCredentials, wantCode: "AADSTS7000218"},
+		"Device_authentication_failed": {errorCodes: []uint32{deviceAuthenticationFailedErrorCode}, want: ErrDeviceAuthenticationFailed, wantCode: "AADSTS50155"},
+		// AADSTS codes are exact numeric identifiers. An unknown code that
+		// shares a prefix with a handled code must fall through to the catch-all.
+		"Unrelated_code_sharing_50011_prefix_is_not_invalid_redirect": {errorCodes: []uint32{500114}},
+		// AADSTS50155/DEVICE_AUTH_FAIL has no documented subcode family, and
+		// misclassifying an unrelated code as a confirmed device-auth
+		// failure is destructive (clears cached device registration data).
+		// An undocumented/future code that merely starts with "50155" must
+		// NOT match -- it should fall through to the non-destructive
+		// catch-all, not to ErrDeviceAuthenticationFailed.
+		"Unrelated_code_sharing_50155_prefix_is_not_device_authentication_failed": {errorCodes: []uint32{501559}},
+		// ErrDeviceDisabled denies the login outright, and AADSTS135011 has
+		// no documented subcode family. An undocumented/future code that
+		// merely starts with "135011" must fall through to the catch-all
+		// instead of denying a login based on a guessed classification.
+		"Unrelated_code_sharing_135011_prefix_is_not_device_disabled":             {errorCodes: []uint32{1350119}},
+		"Unrelated_code_sharing_7000218_prefix_is_not_missing_client_credentials": {errorCodes: []uint32{70002181}},
+		// A genuinely unclassified/unknown AADSTS code (not one of the ones
+		// above) must fall back to a plain error, never to one of the specific
+		// sentinels.
+		"Unexpected_token_acquisition": {errorCodes: []uint32{999999}},
+		"Empty_error_codes_list":       {errorCodes: nil},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tokenAcquisitionError(tc.errorCodes, "token acquisition failed")
+			if tc.want != nil {
+				require.ErrorIs(t, err, tc.want)
+				require.Contains(t, err.Error(), tc.wantCode)
+				return
+			}
+			require.Error(t, err)
+			for _, sentinel := range []error{ErrDeviceDisabled, ErrInvalidRedirectURI, ErrMissingClientCredentials, ErrDeviceAuthenticationFailed} {
+				require.NotErrorIs(t, err, sentinel)
+			}
+		})
+	}
+}
+
+func TestWithAADSTSErrorCodeDoesNotDuplicateCodeInProviderMessage(t *testing.T) {
+	t.Parallel()
+
+	err := withAADSTSErrorCode(
+		ErrMissingClientCredentials,
+		missingClientCredentialsErrorCode,
+		"Token acquisition failed: invalid_client (AADSTS7000218: missing client credentials)",
+	)
+
+	require.Equal(t, 1, strings.Count(err.Error(), "AADSTS7000218"))
+}

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/himmelblau_c.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/himmelblau_c.go
@@ -31,9 +31,8 @@ import "C"
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"unsafe"
 
 	"github.com/canonical/authd/log"
@@ -78,20 +77,6 @@ func mfaErrorCategory(code uint32) MFAErrorCategory {
 	}
 	return MFAErrorOther
 }
-
-// Entra AADSTS error codes as defined in
-// https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
-const (
-	// AADSTS135011 Device used during the authentication is disabled.
-	deviceDisabledErrorCode = 135011
-	// AADSTS50011 InvalidReplyTo - The reply address is missing, misconfigured,
-	// or doesn't match reply addresses configured for the app. As a resolution
-	// ensures to add this missing reply address to the Microsoft Entra
-	// application or have someone with the permissions to manage your
-	// application in Microsoft Entra IF do this for you. To learn more, see the
-	// troubleshooting article for error AADSTS50011.
-	invalidRedirectURIErrorCode = 50011
-)
 
 type boxedDynTPM C.BoxedDynTpm
 type brokerClientApplication C.BrokerClientApplication
@@ -383,31 +368,24 @@ func acquireTokenByRefreshToken(broker *brokerClientApplication, refreshToken st
 		defer C.error_free(msalErr)
 		// Error codes can be returned by libhimmelblau as a single code in the aadsts_code field or
 		// as a list of error codes in the acquire_token_error_codes field.
-		errorCodes := []C.uint32_t{msalErr.aadsts_code}
+		errorCodes := []uint32{uint32(msalErr.aadsts_code)}
 		if msalErr.acquire_token_error_codes != nil && msalErr.acquire_token_error_codes_len > 0 {
-			errorCodes = unsafe.Slice(msalErr.acquire_token_error_codes, msalErr.acquire_token_error_codes_len)
-		}
-
-		for _, errorCode := range errorCodes {
-			errorCodeStr := strconv.Itoa(int(errorCode))
-			switch {
-			// AADSTS error codes can have additional digits or subcodes appended
-			// (e.g. AADSTS500113 as a variation of AADSTS50011).
-			// Checking the prefix ensures we catch all variations of the base error code.
-			case strings.HasPrefix(errorCodeStr, strconv.Itoa(deviceDisabledErrorCode)):
-				log.Error(context.Background(), C.GoString(msalErr.msg))
-				return nil, nil, ErrDeviceDisabled
-			case strings.HasPrefix(errorCodeStr, strconv.Itoa(invalidRedirectURIErrorCode)):
-				log.Errorf(context.Background(), "Token acquisition failed: %v", C.GoString(msalErr.msg))
-				return nil, nil, ErrInvalidRedirectURI
+			cErrorCodes := unsafe.Slice(msalErr.acquire_token_error_codes, msalErr.acquire_token_error_codes_len)
+			errorCodes = make([]uint32, len(cErrorCodes))
+			for i, code := range cErrorCodes {
+				errorCodes[i] = uint32(code)
 			}
 		}
 
-		// The token acquisition failed unexpectedly.
-		// One possible reason is that the device was deleted by an administrator in Entra ID.
-		// Unfortunately, Microsoft doesn't return a specific error code for that case,
-		// it returns the generic error "AADSTS50155: Device authentication failed".
-		return nil, nil, TokenAcquisitionError{msg: fmt.Sprintf("error acquiring access token using refresh token: %v", C.GoString(msalErr.msg))}
+		err := tokenAcquisitionError(errorCodes, C.GoString(msalErr.msg))
+		switch {
+		case errors.Is(err, ErrDeviceDisabled),
+			errors.Is(err, ErrInvalidRedirectURI),
+			errors.Is(err, ErrMissingClientCredentials),
+			errors.Is(err, ErrDeviceAuthenticationFailed):
+			log.Errorf(context.Background(), "Token acquisition failed: %v", err)
+		}
+		return nil, nil, err
 	}
 
 	cleanup = func() { C.user_token_free(userToken) }

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -47,9 +47,20 @@ const (
 	msgraphAPIVersion  = "v1.0"
 )
 
+type graphAccessTokenAcquirer func(
+	ctx context.Context,
+	clientID string,
+	tenantID string,
+	token *oauth2.Token,
+	data himmelblau.DeviceRegistrationData,
+) (string, error)
+
 // Provider is the Microsoft Entra ID provider implementation.
 type Provider struct {
 	expectedScopes []string
+
+	// Used in tests to replace the cgo-backed Graph token exchange.
+	graphAccessTokenAcquirerForTests graphAccessTokenAcquirer
 
 	// graphClientSecret, when non-empty, enables the app-only (client credentials)
 	// path for group lookups. The secret belongs to the same client_id configured
@@ -73,6 +84,14 @@ type Provider struct {
 func (p *Provider) SetGraphClientSecret(secret string) {
 	p.graphClientSecret = secret
 }
+
+const (
+	// graphTokenAcquisitionRetryInterval is how often to retry AADSTS50155.
+	graphTokenAcquisitionRetryInterval = time.Second
+	// graphTokenAcquisitionRetryTimeout bounds retries while Entra replicates a
+	// freshly registered device (see himmelblau-idm/himmelblau#113).
+	graphTokenAcquisitionRetryTimeout = 10 * time.Second
+)
 
 // New returns a new MSEntraID provider.
 func New() *Provider {
@@ -280,20 +299,11 @@ func (p *Provider) GetGroups(
 		}
 
 		tenantID := tenantID(issuerURL)
-		accessTokenStr, err = himmelblau.AcquireAccessTokenForGraphAPI(ctx, clientID, tenantID, token, data)
-		if errors.Is(err, himmelblau.ErrDeviceDisabled) {
-			return nil, fmt.Errorf("%w: %w", providerErrors.ErrDeviceDisabled, err)
-		}
-		if errors.Is(err, himmelblau.ErrInvalidRedirectURI) {
-			msg := "Token acquisition failed: The app is misconfigured in Microsoft Entra (the redirect URI is missing or invalid). Please contact your administrator."
-			return nil, &providerErrors.ForDisplayError{Message: msg, Err: fmt.Errorf("%w: %w", providerErrors.ErrInvalidRedirectURI, err)}
-		}
-		var tokenAcquisitionError himmelblau.TokenAcquisitionError
-		if errors.As(err, &tokenAcquisitionError) {
-			return nil, &providerErrors.RetryWithDeviceAuthError{Err: fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", err)}
-		}
+		accessTokenStr, err = acquireGraphAccessTokenWithRetry(ctx, func() (string, error) {
+			return p.acquireGraphAccessToken(ctx, clientID, tenantID, token, data)
+		}, graphTokenAcquisitionRetryInterval, graphTokenAcquisitionRetryTimeout)
 		if err != nil {
-			return nil, fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", err)
+			return nil, classifyGraphTokenAcquisitionError(err)
 		}
 
 		// Re-parse the newly acquired token.
@@ -308,6 +318,122 @@ func (p *Provider) GetGroups(
 	msgraphHost := resolveMSGraphHost(providerMetadata)
 
 	return p.fetchUserGroups(accessToken, msgraphHost)
+}
+
+func (p *Provider) acquireGraphAccessToken(
+	ctx context.Context,
+	clientID string,
+	tenantID string,
+	token *oauth2.Token,
+	data himmelblau.DeviceRegistrationData,
+) (string, error) {
+	if p.graphAccessTokenAcquirerForTests != nil {
+		return p.graphAccessTokenAcquirerForTests(ctx, clientID, tenantID, token, data)
+	}
+	return himmelblau.AcquireAccessTokenForGraphAPI(ctx, clientID, tenantID, token, data)
+}
+
+// acquireGraphAccessTokenWithRetry retries AADSTS50155 until the retry timeout
+// expires so a single device-authentication failure does not immediately
+// trigger re-enrollment. Retries are delayed to allow replication and are
+// cancelled with the request.
+func acquireGraphAccessTokenWithRetry(
+	ctx context.Context,
+	acquire func() (string, error),
+	retryInterval time.Duration,
+	retryTimeout time.Duration,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	accessToken, err := acquire()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", ctxErr
+	}
+	if err == nil || !errors.Is(err, himmelblau.ErrDeviceAuthenticationFailed) {
+		return accessToken, err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	retryTimer := time.NewTimer(retryInterval)
+	defer retryTimer.Stop()
+	timeoutTimer := time.NewTimer(retryTimeout)
+	defer timeoutTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-timeoutTimer.C:
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			return accessToken, err
+		case <-retryTimer.C:
+			// Prefer the timeout over a retry that becomes ready at the same
+			// time, and avoid starting an acquisition after cancellation.
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-timeoutTimer.C:
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return "", ctxErr
+				}
+				return accessToken, err
+			default:
+			}
+
+			accessToken, err = acquire()
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			if err == nil || !errors.Is(err, himmelblau.ErrDeviceAuthenticationFailed) {
+				return accessToken, err
+			}
+
+			retryTimer.Reset(retryInterval)
+		}
+	}
+}
+
+// classifyGraphTokenAcquisitionError maps a himmelblau Graph-token acquisition
+// error (from AcquireAccessTokenForGraphAPI) to the error the broker should
+// see.
+//
+// Only ErrDeviceAuthenticationFailed (AADSTS50155) is treated as evidence
+// that the device's own registration/authentication is invalid in Entra ID
+// (e.g. an administrator deleted the device object). See the caveats
+// documented on that error: this is not a universal mapping for every tenant
+// or authentication operation. This is the sole case mapped to
+// RetryWithDeviceAuthError, which makes the broker clear the cached device
+// registration data and force the user through device re-enrollment.
+//
+// Every other error -- ErrMissingClientCredentials (AADSTS7000218, an Entra
+// app-configuration error), and any unclassified himmelblau error (an
+// unrecognized AADSTS code, or any other acquisition failure, e.g. a transient
+// one) -- is returned as a plain error instead. A plain error makes
+// the broker preserve the cached registration data and fall back to cached
+// groups rather than assuming the registration is stale. Treating unknown
+// errors as "assume stale" was the root cause of #1721: any Graph-token
+// failure we didn't specifically recognize was clearing the device
+// registration and forcing re-enrollment on every retry, which could
+// register the same machine as a new Entra device object repeatedly.
+func classifyGraphTokenAcquisitionError(err error) error {
+	if errors.Is(err, himmelblau.ErrDeviceDisabled) {
+		return fmt.Errorf("%w: %w", providerErrors.ErrDeviceDisabled, err)
+	}
+	if errors.Is(err, himmelblau.ErrInvalidRedirectURI) {
+		msg := "Token acquisition failed: The app is misconfigured in Microsoft Entra (the redirect URI is missing or invalid). Please contact your administrator."
+		return &providerErrors.ForDisplayError{Message: msg, Err: fmt.Errorf("%w: %w", providerErrors.ErrInvalidRedirectURI, err)}
+	}
+	if errors.Is(err, himmelblau.ErrDeviceAuthenticationFailed) {
+		return &providerErrors.RetryWithDeviceAuthError{Err: fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", err)}
+	}
+	return fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", err)
 }
 
 // resolveMSGraphHost resolves the Microsoft Graph API host URL from provider metadata,

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid_test.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid_test.go
@@ -5,6 +5,7 @@ package msentraid_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/himmelblau"
@@ -406,6 +408,269 @@ func TestGetGroupsInvalidTokenWithClientCredentialsReturnsError(t *testing.T) {
 		false,
 	)
 	require.Error(t, err, "GetGroups should return an error instead of panicking on invalid delegated tokens")
+}
+
+// TestClassifyGraphTokenAcquisitionError verifies the #1721 regression
+// boundary at the classification level: only a positively-confirmed
+// device-authentication failure (AADSTS50155) must be classified as a
+// RetryWithDeviceAuthError. Every other error -- including
+// ErrMissingClientCredentials (AADSTS7000218) and any other himmelblau
+// error (unknown/future AADSTS codes, or any other acquisition failure) --
+// must NOT be classified as one, since that would
+// make the broker clear the cached device registration data and force a new
+// Entra device enrollment even though the registration itself was never
+// confirmed invalid.
+func TestClassifyGraphTokenAcquisitionError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err error
+
+		wantRetryWithDeviceAuth bool
+		wantForDisplay          bool
+		wantDeviceDisabled      bool
+	}{
+		"Device_disabled_denies_login": {
+			err:                himmelblau.ErrDeviceDisabled,
+			wantDeviceDisabled: true,
+		},
+		"Invalid_redirect_URI_is_displayed_to_the_user": {
+			err:            himmelblau.ErrInvalidRedirectURI,
+			wantForDisplay: true,
+		},
+		"Device_authentication_failed_retries_with_device_auth": {
+			err:                     himmelblau.ErrDeviceAuthenticationFailed,
+			wantRetryWithDeviceAuth: true,
+		},
+		"Missing_client_credentials_is_a_plain_error": {
+			err: himmelblau.ErrMissingClientCredentials,
+		},
+		"Unclassified_token_acquisition_error_is_a_plain_error": {
+			err: errors.New("unclassified token acquisition error"),
+		},
+		"Unrelated_error_is_a_plain_error": {
+			err: fmt.Errorf("some other unrelated error"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := msentraid.ClassifyGraphTokenAcquisitionError(tc.err)
+			require.Error(t, got, "classifyGraphTokenAcquisitionError should always return an error for a non-nil input")
+
+			var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
+			require.Equal(t, tc.wantRetryWithDeviceAuth, errors.As(got, &retryWithDeviceAuthErr),
+				"unexpected RetryWithDeviceAuthError classification")
+
+			var forDisplayErr *providerErrors.ForDisplayError
+			require.Equal(t, tc.wantForDisplay, errors.As(got, &forDisplayErr),
+				"unexpected ForDisplayError classification")
+
+			require.Equal(t, tc.wantDeviceDisabled, errors.Is(got, providerErrors.ErrDeviceDisabled),
+				"unexpected ErrDeviceDisabled classification")
+		})
+	}
+}
+
+func TestAcquireGraphAccessTokenWithRetry(t *testing.T) {
+	t.Parallel()
+
+	otherErr := errors.New("token endpoint unavailable")
+	tests := map[string]struct {
+		errs          []error
+		tokens        []string
+		wantToken     string
+		wantErr       error
+		wantCalls     int
+		wantMinCalls  int
+		retryInterval time.Duration
+		retryTimeout  time.Duration
+		cancelRequest bool
+	}{
+		"Transient_device_authentication_failure_retries_until_success": {
+			errs:          []error{himmelblau.ErrDeviceAuthenticationFailed, himmelblau.ErrDeviceAuthenticationFailed, nil},
+			tokens:        []string{"", "", "access-token"},
+			wantToken:     "access-token",
+			wantCalls:     3,
+			retryInterval: 0,
+			retryTimeout:  time.Second,
+		},
+		"Persistent_device_authentication_failure_is_returned": {
+			errs:          []error{himmelblau.ErrDeviceAuthenticationFailed},
+			wantErr:       himmelblau.ErrDeviceAuthenticationFailed,
+			wantMinCalls:  2,
+			retryInterval: 0,
+			retryTimeout:  5 * time.Millisecond,
+		},
+		"Retry_result_with_other_error_is_not_destructive": {
+			errs:          []error{himmelblau.ErrDeviceAuthenticationFailed, otherErr},
+			wantErr:       otherErr,
+			wantCalls:     2,
+			retryInterval: 0,
+			retryTimeout:  time.Second,
+		},
+		"Other_errors_are_not_retried": {
+			errs:          []error{otherErr},
+			wantErr:       otherErr,
+			wantCalls:     1,
+			retryInterval: time.Second,
+			retryTimeout:  time.Second,
+		},
+		"Cancelled_request_is_not_retried": {
+			errs:          []error{himmelblau.ErrDeviceAuthenticationFailed},
+			wantErr:       context.Canceled,
+			wantCalls:     1,
+			retryInterval: time.Second,
+			retryTimeout:  time.Second,
+			cancelRequest: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			calls := 0
+			gotToken, gotErr := msentraid.AcquireGraphAccessTokenWithRetry(ctx, func() (string, error) {
+				calls++
+				if tc.cancelRequest {
+					cancel()
+				}
+				token := ""
+				if calls <= len(tc.tokens) {
+					token = tc.tokens[calls-1]
+				}
+				err := tc.errs[min(calls-1, len(tc.errs)-1)]
+				return token, err
+			}, tc.retryInterval, tc.retryTimeout)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, gotErr, tc.wantErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+			require.Equal(t, tc.wantToken, gotToken)
+			if tc.wantMinCalls > 0 {
+				require.GreaterOrEqual(t, calls, tc.wantMinCalls)
+			} else {
+				require.Equal(t, tc.wantCalls, calls)
+			}
+		})
+	}
+}
+
+func TestAcquireGraphAccessTokenWithRetryCancelledDuringDelay(t *testing.T) {
+	t.Parallel()
+
+	// The retry windows are an hour, so only this deadline can end the
+	// test. Keep it generous so CI scheduling cannot starve the first
+	// acquire call before it is counted.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	calls := 0
+	gotToken, gotErr := msentraid.AcquireGraphAccessTokenWithRetry(ctx, func() (string, error) {
+		calls++
+		return "", himmelblau.ErrDeviceAuthenticationFailed
+	}, time.Hour, time.Hour)
+
+	require.ErrorIs(t, gotErr, context.DeadlineExceeded,
+		"a request cancelled during the replication delay must not be retried")
+	require.Zero(t, gotToken)
+	require.Equal(t, 1, calls)
+}
+
+func TestAcquireGraphAccessTokenWithRetryRejectsTokenAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	gotToken, gotErr := msentraid.AcquireGraphAccessTokenWithRetry(ctx, func() (string, error) {
+		cancel()
+		return "access-token", nil
+	}, 0)
+
+	require.ErrorIs(t, gotErr, context.Canceled,
+		"a token returned after request cancellation must not be accepted")
+	require.Empty(t, gotToken)
+}
+
+func TestAcquireGraphAccessTokenWithRetryRejectsRetryTokenAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	gotToken, gotErr := msentraid.AcquireGraphAccessTokenWithRetry(ctx, func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", himmelblau.ErrDeviceAuthenticationFailed
+		}
+		cancel()
+		return "access-token", nil
+	}, 0)
+
+	require.ErrorIs(t, gotErr, context.Canceled,
+		"a retry token returned after request cancellation must not be accepted")
+	require.Empty(t, gotToken)
+	require.Equal(t, 2, calls)
+}
+
+func TestGetGroupsRetriesTransientDeviceAuthenticationFailure(t *testing.T) {
+	t.Parallel()
+
+	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"scp": "User.Read",
+	})
+	accessTokenStr, err := accessToken.SignedString(testutils.MockKey)
+	require.NoError(t, err, "Failed to sign access token")
+
+	graphAccessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"scp": "GroupMember.Read.All",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	graphAccessTokenStr, err := graphAccessToken.SignedString(testutils.MockKey)
+	require.NoError(t, err, "Failed to sign Graph access token")
+
+	mockServer, cleanup := startMockMSServer(t, nil)
+	t.Cleanup(cleanup)
+
+	var acquireCalls atomic.Int32
+	p := msentraid.New()
+	p.SetTokenScopesForGraphAPI([]string{"GroupMember.Read.All"})
+	p.SetGraphAccessTokenAcquirerForTests(func(
+		context.Context,
+		string,
+		string,
+		*oauth2.Token,
+		himmelblau.DeviceRegistrationData,
+	) (string, error) {
+		if acquireCalls.Add(1) < 3 {
+			return "", himmelblau.ErrDeviceAuthenticationFailed
+		}
+		return graphAccessTokenStr, nil
+	})
+
+	deviceRegistrationData, err := json.Marshal(himmelblau.DeviceRegistrationData{})
+	require.NoError(t, err)
+
+	got, err := p.GetGroups(
+		context.Background(),
+		"client-id",
+		"tenant-id",
+		&oauth2.Token{AccessToken: accessTokenStr, RefreshToken: "refresh-token"},
+		map[string]any{"msgraph_host": mockServer.URL},
+		deviceRegistrationData,
+		true,
+	)
+	require.NoError(t, err, "GetGroups should retry transient device authentication failures")
+	require.Equal(t, int32(3), acquireCalls.Load(), "Graph token acquisition should be retried until it succeeds")
+	require.ElementsMatch(t, []info.Group{
+		{Name: "group1", UGID: "id1"},
+		{Name: "group2", UGID: "id2"},
+	}, got)
 }
 
 func TestGetGroupsClientCredentialsUsesConfiguredIssuerAndGraphHosts(t *testing.T) {

--- a/authd-oidc-brokers/internal/token/token.go
+++ b/authd-oidc-brokers/internal/token/token.go
@@ -19,8 +19,12 @@ type AuthCachedInfo struct {
 	ProviderMetadata       map[string]interface{}
 	UserInfo               info.User
 	DeviceRegistrationData []byte
-	DeviceIsDisabled       bool
-	UserIsDisabled         bool
+	// DeviceRegistrationDataValidationPending is set when fresh registration
+	// data was obtained but group lookup has not yet succeeded.
+	// The data is retained and reused until group lookup succeeds.
+	DeviceRegistrationDataValidationPending bool `json:",omitempty"`
+	DeviceIsDisabled                        bool
+	UserIsDisabled                          bool
 	// ObtainedViaEntraAuth is set when the token was obtained through the
 	// entra_auth flow. On a returning login it selects the refresh path:
 	// these tokens are refreshed as the Microsoft Broker App (public client, no

--- a/authd-oidc-brokers/internal/token/token.go
+++ b/authd-oidc-brokers/internal/token/token.go
@@ -27,14 +27,45 @@ type AuthCachedInfo struct {
 	// data was obtained but group lookup has not yet succeeded.
 	// The data is retained and reused until group lookup succeeds.
 	DeviceRegistrationDataValidationPending bool `json:",omitempty"`
-	DeviceIsDisabled                        bool
-	UserIsDisabled                          bool
+	// DeviceRegistrationDataValidationFailureSince stores the Unix timestamp
+	// of the first device-authentication failure while validation is pending.
+	DeviceRegistrationDataValidationFailureSince int64 `json:",omitempty"`
+	DeviceIsDisabled                             bool
+	UserIsDisabled                               bool
 	// ObtainedViaEntraAuth is set when the token was obtained through the
 	// entra_auth flow. On a returning login it selects the refresh path:
 	// these tokens are refreshed as the Microsoft Broker App (public client, no
 	// client_secret) for the liveness/revocation check, rather than via the OIDC
 	// app refresh used by device-auth tokens.
 	ObtainedViaEntraAuth bool
+}
+
+// UnmarshalJSON keeps legacy caches usable after GroupsResolved was added.
+// Legacy caches with an identified user or cached groups retain the previous
+// cached-group fallback behavior.
+func (a *AuthCachedInfo) UnmarshalJSON(data []byte) error {
+	type authCachedInfo AuthCachedInfo
+
+	var decoded authCachedInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	// CacheAuthInfo always marshals the exact Go field name, so key
+	// presence is a plain lookup.
+	_, groupsResolvedPresent := fields["GroupsResolved"]
+	if !groupsResolvedPresent && decoded.Token != nil && decoded.UserInfo.Name != "" &&
+		(decoded.UserInfo.ProviderID != "" || decoded.UserInfo.Groups != nil) {
+		decoded.GroupsResolved = true
+	}
+
+	*a = AuthCachedInfo(decoded)
+	return nil
 }
 
 // NewAuthCachedInfo creates a new AuthCachedInfo. It sets the provided token and rawIDToken and the provider-specific

--- a/authd-oidc-brokers/internal/token/token.go
+++ b/authd-oidc-brokers/internal/token/token.go
@@ -19,6 +19,10 @@ type AuthCachedInfo struct {
 	ProviderMetadata       map[string]interface{}
 	UserInfo               info.User
 	DeviceRegistrationData []byte
+	// GroupsResolved records that UserInfo.Groups was successfully fetched
+	// from the provider at least once. A group-fetch failure may only fall
+	// back to cached groups when this is set.
+	GroupsResolved bool
 	// DeviceRegistrationDataValidationPending is set when fresh registration
 	// data was obtained but group lookup has not yet succeeded.
 	// The data is retained and reused until group lookup succeeds.

--- a/authd-oidc-brokers/internal/token/token.go
+++ b/authd-oidc-brokers/internal/token/token.go
@@ -41,8 +41,9 @@ type AuthCachedInfo struct {
 }
 
 // UnmarshalJSON keeps legacy caches usable after GroupsResolved was added.
-// Legacy caches with an identified user or cached groups retain the previous
-// cached-group fallback behavior.
+// Legacy caches with cached groups retain the previous cached-group fallback
+// behavior. A provider ID alone is not enough because device registration can
+// be cached before group lookup succeeds.
 func (a *AuthCachedInfo) UnmarshalJSON(data []byte) error {
 	type authCachedInfo AuthCachedInfo
 
@@ -60,7 +61,7 @@ func (a *AuthCachedInfo) UnmarshalJSON(data []byte) error {
 	// presence is a plain lookup.
 	_, groupsResolvedPresent := fields["GroupsResolved"]
 	if !groupsResolvedPresent && decoded.Token != nil && decoded.UserInfo.Name != "" &&
-		(decoded.UserInfo.ProviderID != "" || decoded.UserInfo.Groups != nil) {
+		decoded.UserInfo.Groups != nil {
 		decoded.GroupsResolved = true
 	}
 

--- a/authd-oidc-brokers/internal/token/token_test.go
+++ b/authd-oidc-brokers/internal/token/token_test.go
@@ -147,3 +147,27 @@ func TestLoadAuthInfoLegacyTokenDefaultsValidationPendingToFalse(t *testing.T) {
 	require.False(t, got.GroupsResolved,
 		"legacy caches without the field must not be treated as groups-resolved")
 }
+
+func TestLoadAuthInfoLegacyTokenInfersGroupsResolved(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "parent", "token.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(tokenPath), 0700))
+	require.NoError(t, os.WriteFile(tokenPath, []byte(`{
+		"Token": {
+			"access_token": "accesstoken",
+			"refresh_token": "refreshtoken"
+		},
+		"UserInfo": {
+			"name": "legacy-user",
+			"provider_id": "legacy-user-id",
+			"groups": [{"name": "legacy-group", "ugid": "legacy-group-id"}]
+		}
+	}`), 0600))
+
+	got, err := token.LoadAuthInfo(tokenPath)
+	require.NoError(t, err)
+	require.True(t, got.GroupsResolved,
+		"legacy caches with authenticated user information must preserve cached-group fallback")
+	require.Equal(t, []info.Group{{Name: "legacy-group", UGID: "legacy-group-id"}}, got.UserInfo.Groups)
+}

--- a/authd-oidc-brokers/internal/token/token_test.go
+++ b/authd-oidc-brokers/internal/token/token_test.go
@@ -144,4 +144,6 @@ func TestLoadAuthInfoLegacyTokenDefaultsValidationPendingToFalse(t *testing.T) {
 	require.Equal(t, []byte("legacy-device-data"), got.DeviceRegistrationData)
 	require.False(t, got.DeviceRegistrationDataValidationPending,
 		"legacy caches without the field must load as not pending")
+	require.False(t, got.GroupsResolved,
+		"legacy caches without the field must not be treated as groups-resolved")
 }

--- a/authd-oidc-brokers/internal/token/token_test.go
+++ b/authd-oidc-brokers/internal/token/token_test.go
@@ -125,3 +125,23 @@ func TestLoadAuthInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadAuthInfoLegacyTokenDefaultsValidationPendingToFalse(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "parent", "token.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(tokenPath), 0700))
+	require.NoError(t, os.WriteFile(tokenPath, []byte(`{
+		"Token": {
+			"access_token": "accesstoken",
+			"refresh_token": "refreshtoken"
+		},
+		"DeviceRegistrationData": "bGVnYWN5LWRldmljZS1kYXRh"
+	}`), 0600))
+
+	got, err := token.LoadAuthInfo(tokenPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("legacy-device-data"), got.DeviceRegistrationData)
+	require.False(t, got.DeviceRegistrationDataValidationPending,
+		"legacy caches without the field must load as not pending")
+}

--- a/authd-oidc-brokers/internal/token/token_test.go
+++ b/authd-oidc-brokers/internal/token/token_test.go
@@ -148,6 +148,29 @@ func TestLoadAuthInfoLegacyTokenDefaultsValidationPendingToFalse(t *testing.T) {
 		"legacy caches without the field must not be treated as groups-resolved")
 }
 
+func TestLoadAuthInfoLegacyTokenWithProviderIDButWithoutGroupsDoesNotInferGroupsResolved(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "parent", "token.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(tokenPath), 0700))
+	require.NoError(t, os.WriteFile(tokenPath, []byte(`{
+		"Token": {
+			"access_token": "accesstoken",
+			"refresh_token": "refreshtoken"
+		},
+		"UserInfo": {
+			"name": "legacy-user",
+			"provider_id": "legacy-user-id"
+		},
+		"DeviceRegistrationData": "bGVnYWN5LWRldmljZS1kYXRh"
+	}`), 0600))
+
+	got, err := token.LoadAuthInfo(tokenPath)
+	require.NoError(t, err)
+	require.False(t, got.GroupsResolved,
+		"a provider ID without cached groups must not imply that group lookup succeeded")
+}
+
 func TestLoadAuthInfoLegacyTokenInfersGroupsResolved(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Graph token-acquisition failures that did not prove cached device data was
stale could clear it and enroll the same machine as a new Entra device on
later attempts. This could exhaust the tenant device cap reported in #1721.

Classify documented AADSTS codes exactly at the libhimmelblau boundary:

- Treat exact `AADSTS50155` as the device-authentication failure that can start
  device recovery.
- Retry `AADSTS50155` once per second for up to ten seconds so a newly enrolled
  device has time to propagate through Entra.
- Keep `AADSTS7000218` and unknown Graph token failures non-destructive because
  they do not prove that registration data is stale.
- Continue to surface invalid redirect URI and disabled-device errors
  explicitly.

Persist fresh device registration data as validation-pending before group
lookup. On returning logins, reuse that registration and cached groups while
lookup is unavailable, then clear the pending state after lookup succeeds. If
no cached groups exist, the first login is still denied, but the registration
is kept so the next login can retry without another enrollment.

## Relationship to #1742 and #1825

#1742 attempted to address repeated `AADSTS7000218` errors reported in #1680
by clearing device registration data when group fetching failed. #1825 later
reverted that handling after identifying the Entra application configuration
as the likely cause: the redirect URI must be registered under **Mobile and
desktop applications**, not **Web**, using
`https://login.microsoftonline.com/common/oauth2/nativeclient`.

This PR preserves the revert: `AADSTS7000218` does not invalidate device
registration. The remaining recovery behavior applies only after the provider
reports exact `AADSTS50155`.

## Verification

- Exact AADSTS classifications, including `AADSTS500113`, `AADSTS7000218`, and
  `AADSTS50155`, with unknown or future codes asserted against every sentinel.
- Cancellation and the bounded `AADSTS50155` retry window.
- Fresh registration persistence before group lookup, including a first-login
  failure that preserves the registration for the next attempt.
- Cached-group fallback without duplicate enrollment.
- Device-code and Entra authentication paths.

Closes #1721.

## Follow-up hardening

Returning flows can use cached groups while validation is pending; a first
login without cached groups remains denied. Once group lookup succeeds, the
broker stores the groups and clears the pending state.

A validation-pending registration now expires after five minutes of repeated
device-authentication failures (`deviceRegistrationValidationGracePeriod`).
The expiry invalidates the registration and offers the interactive recovery
modes, so a registration that keeps failing validation cannot stay pending
forever.

Pre-existing issues noticed during review (not introduced by this stack):

- The `TestGetGroups` subtests in the msentraid provider can report a data
  race under heavy load with `-race`. The test scaffolding involved predates
  this stack. (A related gap — `refreshToken` dropping the persisted
  `DeviceIsDisabled` flag — is fixed by this stack.)

UDENG-11242