### PR TITLE
Bump Go toolchain version to 1.25.13

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/authd-oidc-brokers/tools/go.mod
+++ b/authd-oidc-brokers/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers/tools
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.12.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/tools
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.25.12:

```
Vulnerability #1: GO-2026-6218
    Avoid quadratic complexity in resolvePath in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-6218
  Standard library
    Found in: net/url@go1.25.12
    Fixed in: net/url@go1.25.13
    Example traces found:
    Error:       #1: internal/providers/msentraid/tokenverify/keyset.go:63:26: tokenverify.RemoteKeySet.fetch calls http.Client.Do, which eventually calls url.URL.Parse

Vulnerability #2: GO-2026-6090
    Limit handshake messages we are willing to accept post-handshake in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-6090
  Standard library
    Found in: crypto/tls@go1.25.12
    Fixed in: crypto/tls@go1.25.13
    Example traces found:
    Error:       #1: internal/testutils/provider.go:111:14: testutils.StartMockProviderServer calls httptest.Server.Start, which eventually calls tls.Conn.HandshakeContext
    Error:       #2: cmd/authd-oidc/daemon/daemon_test.go:249:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
    Error:       #3: cmd/authd-oidc/daemon/daemon_test.go:437:14: daemon_test.TestMain calls fmt.Fprintf, which calls tls.Conn.Write
    Error:       #4: internal/providers/msentraid/tokenverify/keyset.go:63:26: tokenverify.RemoteKeySet.fetch calls http.Client.Do, which eventually calls tls.Dialer.DialContext

Vulnerability #3: GO-2026-6089
    Apply ReadHeaderTimeout when doing unencrypted HTTP/2 check in net/http
  More info: https://pkg.go.dev/vuln/GO-2026-6089
  Standard library
    Found in: net/http@go1.25.12
    Fixed in: net/http@go1.25.13
    Example traces found:
    Error:       #1: internal/testutils/provider.go:111:14: testutils.StartMockProviderServer calls httptest.Server.Start, which eventually calls http.Server.Serve

Vulnerability #4: GO-2026-5972
    Enforce maximum recursion depth in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2026-5972
  Standard library
    Found in: encoding/asn1@go1.25.12
    Fixed in: encoding/asn1@go1.25.13
    Example traces found:
    Error:       #1: internal/broker/helper_test.go:211:40: broker_test.encryptSecret calls x509.ParsePKIXPublicKey, which calls asn1.Unmarshal

Vulnerability #5: GO-2026-5026
    Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
  More info: https://pkg.go.dev/vuln/GO-2026-5026
  Standard library
    Found in: net/http@go1.25.12
    Fixed in: net/http@go1.25.13
    Example traces found:
    Error:       #1: internal/providers/msentraid/tokenverify/keyset.go:63:26: tokenverify.RemoteKeySet.fetch calls http.Client.Do
    Error:       #2: internal/providers/msentraid/tokenverify/keyset_test.go:204:2: tokenverify_test.TestRemoteKeySetCachesKeyAfterFetch calls httptest.Server.Close, which calls http.Transport.CloseIdleConnections
```

[Sanity CI job failure example](https://github.com/canonical/authd/actions/runs/31776778309/job/94693762427)