### PR TITLE
e2e-tests: restore SSH denial assertion

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -389,10 +389,6 @@ Check That Login Is Handled By PAM Unix
     Match Text    Password:
 
 
-Check That SSH Connection Is Closed
-    Match Text    Connection closed
-
-
 Check If User Was Added Properly
     [Arguments]    ${username}
     Wait Until Keyword Succeeds    30s    1s    Check User Information    ${username}

--- a/e2e-tests/tests/ssh_deny_login_if_prefix_not_allowed.robot
+++ b/e2e-tests/tests/ssh_deny_login_if_prefix_not_allowed.robot
@@ -32,11 +32,4 @@ Test that login is denied if user is not allowed to log in via SSH
     ${username} =    Set Variable    other-user@${domain}
     Open Terminal
     Start Log In With Remote User Through SSH: QR Code    ${username}
-    # On Noble, the SSH login for not allowed users is handled by PAM Unix, which returns a generic "Permission denied" message without specifying the reason.
-    # In newer versions, the login attempt is blocked and the connection closed before reaching PAM.
-    # Check the %{RELEASE} variable to determine the expected behavior.
-    IF    '%{RELEASE}' == 'noble'
-        Check That Login Is Handled By PAM Unix
-    ELSE
-        Check That SSH Connection Is Closed
-    END
+    Check That Login Is Handled By PAM Unix


### PR DESCRIPTION
Commit 9d7bb375 changed the expected Resolute/devel output to Connection closed, but current test runs show Password: instead. Restore the original PAM assertion.

The test has been failing consisently on resolute/devel, This PR is effectively a revert of 9d7bb375

e2e-tests: ssh_deny_login_if_prefix_not_allowed.robot
