### PR TITLE
authd-oidc-brokers/broker: fix cache consolidation on content mismatch

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -419,71 +419,91 @@ func (b *Broker) ensureCompatibilitySymlink(linkPath, target string) error {
 	return os.Symlink(relTarget, linkPath)
 }
 
-func consolidateKnownCacheFiles(sourceDir, targetDir string) error {
-	entries, err := os.ReadDir(sourceDir)
+// consolidateCacheDirs retains the contents of the newer cache directory and
+// removes the other directory.
+//
+// The "password" and "token.json" files are rewritten on every successful
+// login (password with a fresh random salt, token.json with refreshed
+// tokens, see internal/password and internal/token), so it is normal for a
+// file to exist in both directories with different content whenever both
+// have been used to authenticate. In that case there is no way to tell
+// which copy is "correct": we keep the copies from whichever directory was
+// written most recently and discard the others, since that reflects the
+// most recent successful authentication. The decision is made once for the
+// whole directory rather than per file, so that the password hash and the
+// token are never taken from different logins. If both directories were
+// written at the exact same time, targetDir wins.
+//
+// Nothing is modified until every entry has been validated, so that a
+// rejected entry leaves the cache untouched: callers fall back to
+// sourceDir when this returns an error, so a partial move would strip the
+// session of the very credentials it falls back to.
+func consolidateCacheDirs(sourceDir, targetDir string) error {
+	sourceEntries, err := os.ReadDir(sourceDir)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
+	targetEntries, err := os.ReadDir(targetDir)
+	if err != nil {
+		return err
+	}
 
-	knownCacheFiles := map[string]struct{}{"token.json": {}, "password": {}}
-	for _, entry := range entries {
-		if _, ok := knownCacheFiles[entry.Name()]; !ok {
-			return fmt.Errorf("unexpected cache entry %q", entry.Name())
+	sourceNewest, err := newestCacheEntryModTime(sourceEntries)
+	if err != nil {
+		return err
+	}
+	targetNewest, err := newestCacheEntryModTime(targetEntries)
+	if err != nil {
+		return err
+	}
+
+	if !sourceNewest.After(targetNewest) {
+		// targetDir is at least as recent as sourceDir: discard sourceDir entirely.
+		return os.RemoveAll(sourceDir)
+	}
+
+	// sourceDir is more recent: replace targetDir wholesale so that no
+	// target-only files from a previous login survive. Use a unique staging
+	// directory so an abandoned staging directory from an interrupted
+	// consolidation cannot block future attempts.
+	stagingDir, err := os.MkdirTemp(filepath.Dir(targetDir), filepath.Base(targetDir)+".staging-*")
+	if err != nil {
+		return err
+	}
+	stagedTargetDir := filepath.Join(stagingDir, filepath.Base(targetDir))
+	if err := os.Rename(targetDir, stagedTargetDir); err != nil {
+		return errors.Join(err, os.RemoveAll(stagingDir))
+	}
+	if err := os.Rename(sourceDir, targetDir); err != nil {
+		// Roll back: restore targetDir from the staging copy.
+		if rollbackErr := os.Rename(stagedTargetDir, targetDir); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("could not roll back target cache directory: %w", rollbackErr))
 		}
+		return errors.Join(err, os.RemoveAll(stagingDir))
+	}
+	return os.RemoveAll(stagingDir)
+}
+
+// newestCacheEntryModTime returns the most recent modification time among entries, which must all
+// be regular files (cache directories are never expected to contain subdirectories or symlinks).
+func newestCacheEntryModTime(entries []os.DirEntry) (time.Time, error) {
+	var newest time.Time
+	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {
-			return err
+			return time.Time{}, err
 		}
 		if !info.Mode().IsRegular() {
-			return fmt.Errorf("unexpected non-regular cache entry %q", entry.Name())
+			return time.Time{}, fmt.Errorf("unexpected non-regular cache entry %q", entry.Name())
 		}
-
-		targetPath := filepath.Join(targetDir, entry.Name())
-		targetInfo, err := os.Lstat(targetPath)
-		if errors.Is(err, os.ErrNotExist) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		if !targetInfo.Mode().IsRegular() {
-			return fmt.Errorf("target cache entry %q already exists and is not regular", entry.Name())
-		}
-
-		sourceContent, err := os.ReadFile(filepath.Join(sourceDir, entry.Name()))
-		if err != nil {
-			return err
-		}
-		targetContent, err := os.ReadFile(targetPath)
-		if err != nil {
-			return err
-		}
-		if !slices.Equal(sourceContent, targetContent) {
-			return fmt.Errorf("target cache entry %q already exists with different content", entry.Name())
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
 		}
 	}
-
-	for _, entry := range entries {
-		sourcePath := filepath.Join(sourceDir, entry.Name())
-		targetPath := filepath.Join(targetDir, entry.Name())
-		if _, err := os.Lstat(targetPath); errors.Is(err, os.ErrNotExist) {
-			if err := os.Rename(sourcePath, targetPath); err != nil {
-				return err
-			}
-			continue
-		} else if err != nil {
-			return err
-		}
-
-		if err := os.Remove(sourcePath); err != nil {
-			return err
-		}
-	}
-
-	return os.Remove(sourceDir)
+	return newest, nil
 }
 
 func (b *Broker) ensureUsernameCompatibilityPath(username, providerIDDir string) error {
@@ -506,7 +526,7 @@ func (b *Broker) ensureUsernameCompatibilityPath(username, providerIDDir string)
 	if !info.IsDir() {
 		return fmt.Errorf("path already exists and is not a directory or symlink")
 	}
-	if err := consolidateKnownCacheFiles(usernameDir, providerIDDir); err != nil {
+	if err := consolidateCacheDirs(usernameDir, providerIDDir); err != nil {
 		return err
 	}
 
@@ -568,7 +588,7 @@ func (b *Broker) redirectToExistingProviderIDDir(s *session, providerID, provide
 	log.Infof(context.Background(), "Redirecting cache for user %q to existing provider ID-based directory %q", s.username, providerIDDir)
 
 	if info, lstatErr := os.Lstat(s.userDataDir); lstatErr == nil && info.IsDir() {
-		if moveErr := consolidateKnownCacheFiles(s.userDataDir, providerIDDir); moveErr != nil {
+		if moveErr := consolidateCacheDirs(s.userDataDir, providerIDDir); moveErr != nil {
 			log.Warningf(context.Background(), "Could not consolidate cache directory %q into %q: %v", s.userDataDir, providerIDDir, moveErr)
 			return
 		}

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -484,7 +484,12 @@ func consolidateCacheDirs(sourceDir, targetDir string) error {
 		}
 		return errors.Join(err, os.RemoveAll(stagingDir))
 	}
-	return os.RemoveAll(stagingDir)
+	if err := os.RemoveAll(stagingDir); err != nil {
+		// The directory swap has already committed, so cleanup failure must not
+		// leave the session pointed at the removed source directory.
+		log.Warningf(context.Background(), "Could not remove staging cache directory %q: %v", stagingDir, err)
+	}
+	return nil
 }
 
 // newestCacheEntryModTime returns the most recent modification time among entries, which must all

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -4563,6 +4563,19 @@ func TestEnsureProviderIDCacheDir(t *testing.T) {
 		// directory existence check fails.
 		noExecIssuerDir        bool
 		providerIDTokenContent string
+		// providerIDTokenIsNewer makes the provider ID token file's mtime newer than the
+		// username token file's mtime (by default the username file is the newest).
+		providerIDTokenIsNewer bool
+		// usernameExtraFile is written into the username dir as a cache entry consolidation
+		// does not recognize.
+		usernameExtraFile string
+		// usernameExtraFileIsNewest pins usernameExtraFile's mtime to be the newest entry
+		// overall, making the username dir win consolidation regardless of the token mtimes.
+		// By default the extra file is pinned to be the oldest entry overall instead.
+		usernameExtraFileIsNewest bool
+		// createStaleStagingDir leaves behind the staging directory name used by
+		// the previous consolidation implementation.
+		createStaleStagingDir bool
 
 		wantProviderIDSet          bool
 		wantDataDirIsProviderIDDir bool
@@ -4648,18 +4661,93 @@ func TestEnsureProviderIDCacheDir(t *testing.T) {
 				"user@example.com":           "symlink -> provider-id-123",
 			},
 		},
-		"Does_not_consolidate_when_existing_provider_ID_cache_differs": {
+		"Consolidates_by_keeping_newest_file_when_existing_provider_ID_cache_differs_and_username_dir_is_newer": {
 			createProviderIDDir:        true,
 			providerIDTokenContent:     "different-token-marker",
 			createUsernameDir:          true,
+			wantProviderIDSet:          true,
+			wantDataDirIsProviderIDDir: true,
+			wantSymlinkAtUsername:      true,
 			wantProviderIDDirExists:    true,
-			wantUsernameDirExists:      true,
+			// The username token file is the newest one and therefore wins.
+			wantProviderIDTokenContent: "cached-token-marker",
+			wantIssuerTree: map[string]string{
+				"provider-id-123":            "dir",
+				"provider-id-123/token.json": "file",
+				"user@example.com":           "symlink -> provider-id-123",
+			},
+		},
+		"Consolidates_when_an_abandoned_staging_directory_exists": {
+			createProviderIDDir:        true,
+			providerIDTokenContent:     "different-token-marker",
+			createUsernameDir:          true,
+			createStaleStagingDir:      true,
+			wantProviderIDSet:          true,
+			wantDataDirIsProviderIDDir: true,
+			wantSymlinkAtUsername:      true,
+			wantProviderIDDirExists:    true,
+			wantProviderIDTokenContent: "cached-token-marker",
+			wantIssuerTree: map[string]string{
+				"provider-id-123":                    "dir",
+				"provider-id-123/token.json":         "file",
+				"provider-id-123.staging":            "dir",
+				"provider-id-123.staging/token.json": "file",
+				"user@example.com":                   "symlink -> provider-id-123",
+			},
+		},
+		"Consolidates_by_keeping_newest_file_when_existing_provider_ID_cache_differs_and_provider_ID_dir_is_newer": {
+			createProviderIDDir:        true,
+			providerIDTokenContent:     "different-token-marker",
+			createUsernameDir:          true,
+			providerIDTokenIsNewer:     true,
+			wantProviderIDSet:          true,
+			wantDataDirIsProviderIDDir: true,
+			wantSymlinkAtUsername:      true,
+			wantProviderIDDirExists:    true,
 			wantProviderIDTokenContent: "different-token-marker",
 			wantIssuerTree: map[string]string{
-				"provider-id-123":             "dir",
-				"provider-id-123/token.json":  "file",
-				"user@example.com":            "dir",
-				"user@example.com/token.json": "file",
+				"provider-id-123":            "dir",
+				"provider-id-123/token.json": "file",
+				"user@example.com":           "symlink -> provider-id-123",
+			},
+		},
+		"Consolidates_by_moving_the_whole_username_directory_when_its_unexpected_entry_is_newest": {
+			createProviderIDDir:        true,
+			providerIDTokenContent:     "different-token-marker",
+			createUsernameDir:          true,
+			usernameExtraFile:          "unexpected-entry",
+			usernameExtraFileIsNewest:  true,
+			wantProviderIDSet:          true,
+			wantDataDirIsProviderIDDir: true,
+			wantSymlinkAtUsername:      true,
+			wantProviderIDDirExists:    true,
+			// The username directory is newest overall (because of its unexpected entry) and
+			// therefore wins wholesale, including the token file and the unexpected entry.
+			wantProviderIDTokenContent: "cached-token-marker",
+			wantIssuerTree: map[string]string{
+				"provider-id-123":                  "dir",
+				"provider-id-123/token.json":       "file",
+				"provider-id-123/unexpected-entry": "file",
+				"user@example.com":                 "symlink -> provider-id-123",
+			},
+		},
+		"Consolidates_by_discarding_the_whole_username_directory_including_its_unexpected_entry": {
+			createProviderIDDir:        true,
+			providerIDTokenContent:     "different-token-marker",
+			createUsernameDir:          true,
+			providerIDTokenIsNewer:     true,
+			usernameExtraFile:          "unexpected-entry",
+			wantProviderIDSet:          true,
+			wantDataDirIsProviderIDDir: true,
+			wantSymlinkAtUsername:      true,
+			wantProviderIDDirExists:    true,
+			// The provider ID directory is newest overall, so the whole username directory,
+			// including its unexpected entry, is discarded rather than merged.
+			wantProviderIDTokenContent: "different-token-marker",
+			wantIssuerTree: map[string]string{
+				"provider-id-123":            "dir",
+				"provider-id-123/token.json": "file",
+				"user@example.com":           "symlink -> provider-id-123",
 			},
 		},
 		"Redirects_to_existing_provider_ID_directory_even_when_symlink_cannot_be_created": {
@@ -4745,6 +4833,42 @@ func TestEnsureProviderIDCacheDir(t *testing.T) {
 				require.NoError(t, os.MkdirAll(usernameDir, 0700), "Setup: creating the username dir")
 				require.NoError(t, os.WriteFile(filepath.Join(usernameDir, "token.json"), []byte(tokenContent), 0600),
 					"Setup: writing the username token file")
+			}
+			if tc.usernameExtraFile != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(usernameDir, tc.usernameExtraFile), []byte("extra"), 0600),
+					"Setup: writing the unexpected username cache file")
+			}
+			// Pin the token file mtimes instead of relying on the order in which they were
+			// written above, which filesystems with a coarse timestamp granularity do not
+			// necessarily preserve. By default the username token is the newest, simulating a
+			// login through the username directory after the provider ID directory was last
+			// written to; providerIDTokenIsNewer simulates the opposite.
+			older, newer := time.Now().Add(-time.Hour), time.Now()
+			usernameModTime, providerIDModTime := newer, older
+			if tc.providerIDTokenIsNewer {
+				usernameModTime, providerIDModTime = older, newer
+			}
+			if tc.createProviderIDDir {
+				require.NoError(t, os.Chtimes(filepath.Join(providerIDDir, "token.json"), providerIDModTime, providerIDModTime),
+					"Setup: setting the provider ID token file mtime")
+			}
+			if tc.createUsernameDir {
+				require.NoError(t, os.Chtimes(filepath.Join(usernameDir, "token.json"), usernameModTime, usernameModTime),
+					"Setup: setting the username token file mtime")
+			}
+			if tc.usernameExtraFile != "" {
+				extraModTime := older.Add(-time.Hour)
+				if tc.usernameExtraFileIsNewest {
+					extraModTime = newer.Add(time.Hour)
+				}
+				require.NoError(t, os.Chtimes(filepath.Join(usernameDir, tc.usernameExtraFile), extraModTime, extraModTime),
+					"Setup: setting the unexpected cache file mtime")
+			}
+			if tc.createStaleStagingDir {
+				stagingDir := providerIDDir + ".staging"
+				require.NoError(t, os.MkdirAll(stagingDir, 0700), "Setup: creating the abandoned staging dir")
+				require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "token.json"), []byte("stale"), 0600),
+					"Setup: writing the abandoned staging token")
 			}
 			if tc.usernameIsSymlink {
 				require.NoError(t, os.Symlink(providerIDDir, usernameDir), "Setup: creating the compatibility symlink")


### PR DESCRIPTION
`consolidateKnownCacheFiles()` refused to merge the legacy username-keyed cache directory into the provider ID-keyed directory whenever a known file existed in both locations with differing content. For `password` and `token.json`, however, differing content is the normal case once both directories have been used for login: `password` is hashed with a fresh random salt on every write, and `token.json` is rewritten on every online login.

As a result, the merge failed permanently, the username directory was never replaced with a compatibility symlink, and subsequent logins could authenticate against whichever stale copy the session happened to select.

Since there is no reliable way to determine which copy is authoritative, keep whichever file has the most recent modification time and discard the other, assuming it reflects the most recent successful authentication. This allows consolidation to complete instead of leaving the cache permanently split.

Fixes #1787
UDENG-11233