### PR TITLE
fix(pam/integration-tests): resolve flaky TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -897,6 +897,12 @@ func cliChangePasswordWithRetry(t *testing.T, c *ptytest.Console, firstNew, firs
 	c.WaitFor(t, `Confirm password`)
 	cliSendPassword(t, c, firstConfirm)
 	c.WaitFor(t, errMsg)
+	// The snapshot at this point is flaky: depending on redraw timing, it may
+	// still carry leftover "*********"/"Confirm password:" content from the
+	// prior screen before settling into a clean "New password" + error view.
+	// Discard it; the next snapshot (after typing secondNew, with the same
+	// error still shown) is a stable superset of the same information.
+	c.DiscardLastSnapshot()
 	cliSendPassword(t, c, secondNew)
 	c.WaitFor(t, `Confirm password`)
 	cliSendPassword(t, c, secondNew)

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
@@ -54,14 +54,6 @@ Confirm password:
 Enter your new password
 
 New password:
->
-new password does not match criteria: must be 'authd2404'
-
-  Press escape key to go back to choose the provider
-────────────────────────────────────────────────────────────────────────────────
-Enter your new password
-
-New password:
 > *********
 new password does not match criteria: must be 'authd2404'
 
@@ -134,14 +126,6 @@ New password:
 > *********
 Confirm password:
 > *********
-
-  Press escape key to go back to user selection
-────────────────────────────────────────────────────────────────────────────────
-Enter your new password
-
-New password:
->
-new password does not match criteria: must be 'goodpass'
 
   Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
@@ -54,14 +54,6 @@ Confirm password:
 Enter your new password
 
 New password:
->
-Password entries don't match
-
-  Press escape key to go back to choose the provider
-────────────────────────────────────────────────────────────────────────────────
-Enter your new password
-
-New password:
 > *********
 Password entries don't match
 


### PR DESCRIPTION
## Summary

Fixes #1749, flaky `TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker`.

## Root cause

`cliChangePasswordWithRetry` in `pam/integration-tests/cli_test.go` does:

```go
c.WaitFor(t, `Confirm password`)
cliSendPassword(t, c, firstConfirm)
c.WaitFor(t, errMsg)          // <- snapshot taken here
cliSendPassword(t, c, secondNew)
```

`ptytest.Console.WaitFor` captures a snapshot of the *entire current buffer* the moment its pattern matches (`captureSnapshot(content)` in `ptytest.go`). Since the poll interval is 50ms, the buffer can contain more than just the newly matched content. If the terminal hasn't finished redrawing yet, the snapshot can pick up a leftover partially drawn frame (e.g. the previous `Confirm password: *********` line still present) before the screen settles into the clean "New password + rejection message" state. That extra content becomes its own distinct entry after golden dedup, producing exactly the extra frame described in the issue.

This is the same class of race already worked around elsewhere in this file, e.g. `Prevent_change_password_if_auth_fails` and the QR code flow in `cliAuthenticateWithQRCode`, both of which call `c.DiscardLastSnapshot()` for the same reason.

## Fix

Added `c.DiscardLastSnapshot()` right after the `errMsg` `WaitFor` in `cliChangePasswordWithRetry`, with a comment explaining why. This helper is shared by two subtests, `Retry_if_new_password_is_rejected_by_broker` and `Retry_if_password_confirmation_is_not_the_same`, so both goldens were regenerated. In both cases the diff only removes the same racy blank "New password" frame; nothing else changed.

## Testing

- Ran the target subtest 20x in a loop locally (`-count=1` per run, no `-race`), all passed, both before and after the fix. Unfortunately this means I wasn't able to locally reproduce the original flake, so I can't 100% confirm this closes the issue, but the mechanism matches the symptom in the issue exactly, and the fix follows an identical, already proven pattern elsewhere in the same file.
- Attempted to reproduce with `-race -count=15` as suggested, but the race instrumented `authd` binary crashes with SIGSEGV on startup in my local environment (WSL2) before the test scenario runs. This appears to be a local `-race` plus CGo/WSL2 environment issue unrelated to this change.
- Requesting CI (which runs the "Go Tests with Race Detector" job) to validate this fix under `-race` in a clean environment.

Happy to iterate further if CI still shows flakes after this change. @adombeck take a look at this when you get time.