### PR TITLE
broker: preserve local password after device-registration invalidation

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -57,6 +57,10 @@ const (
 // (e.g. after token revocation, expiry, or password change).
 var reauthModes = []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}
 
+// Device and DeviceQr use the same device-code flow. Keep the generic form
+// first and offer QR rendering as the alternate presentation.
+var deviceRegistrationRecoveryModes = []string{authmodes.Device, authmodes.DeviceQr, authmodes.EntraAuth}
+
 // Config is the configuration for the broker.
 type Config struct {
 	ConfigFile string
@@ -102,10 +106,11 @@ type session struct {
 	lang       string
 	mode       string
 
-	selectedMode    string
-	authModes       []string
-	attemptsPerMode map[string]int
-	nextAuthModes   []string
+	selectedMode               string
+	authModes                  []string
+	attemptsPerMode            map[string]int
+	nextAuthModes              []string
+	localPasswordAuthenticated bool
 
 	oidcServer              *oidc.Provider
 	oauth2Config            oauth2.Config
@@ -939,7 +944,12 @@ func (b *Broker) authModeIsAvailable(session session, authMode string) bool {
 
 		isTokenForDeviceRegistration := dr.IsTokenForDeviceRegistration(authInfo)
 
-		if b.cfg.registerDevice && !isTokenForDeviceRegistration {
+		// A previous authenticated session invalidated its registration data
+		// after the token had already been verified. Keep local password
+		// available so passwordAuth can re-register the device online.
+		if b.cfg.registerDevice && !isTokenForDeviceRegistration &&
+			!authInfo.DeviceRegistrationDataInvalidated &&
+			!authInfo.DeviceRegistrationDataValidationPending {
 			// TODO: We might want to display a message to the user in this case
 			log.Noticef(context.Background(), "Token exists for user %q, but it cannot be used for device registration, so local password authentication is not available", session.username)
 			return false
@@ -1379,12 +1389,16 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	// live group lookup is unavailable.
 	var oldAuthInfo *token.AuthCachedInfo
 	var deviceRegistrationData []byte
+	deviceRegistrationRecovery := false
 	if cachedInfo, err := token.LoadAuthInfo(session.tokenPath); err == nil &&
 		b.cachedAuthInfoMatchesIdentity(session, authInfo, cachedInfo) {
 		oldAuthInfo = cachedInfo
 		deviceRegistrationData = cachedInfo.DeviceRegistrationData
+		deviceRegistrationRecovery = cachedInfo.DeviceRegistrationDataInvalidated &&
+			!cachedInfo.DeviceRegistrationDataValidationPending
 		authInfo.UserInfo.Groups = slices.Clone(oldAuthInfo.UserInfo.Groups)
 		authInfo.GroupsResolved = oldAuthInfo.GroupsResolved
+		authInfo.DeviceRegistrationDataInvalidated = oldAuthInfo.DeviceRegistrationDataInvalidated
 		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
 		authInfo.DeviceRegistrationDataValidationFailureSince = oldAuthInfo.DeviceRegistrationDataValidationFailureSince
 		// A live auth verifies the user, not the device object: keep the
@@ -1422,7 +1436,7 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
 		retryingDeviceRegistration := errors.As(err, &retryWithDeviceAuthErr)
 		if retryingDeviceRegistration && authInfo.DeviceRegistrationDataValidationPending {
-			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, reauthModes); expired {
+			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, deviceRegistrationRecoveryModes); expired {
 				return access, data
 			}
 			markDeviceRegistrationValidationFailure(authInfo)
@@ -1446,20 +1460,21 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		if retryingDeviceRegistration && reusedDeviceRegistration &&
 			!authInfo.DeviceRegistrationDataValidationPending {
 			log.Errorf(context.Background(), "Token acquisition failed: %s. Clearing stale device registration data and retrying authentication.", err)
-			authInfo.DeviceRegistrationData = nil
-			clearDeviceRegistrationValidationPending(authInfo)
+			invalidateDeviceRegistrationData(authInfo)
 			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
 				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
 				return AuthDenied, unexpectedErrMsg("failed to store token")
 			}
 
-			session.nextAuthModes = reauthModes
+			session.nextAuthModes = deviceRegistrationRecoveryModes
 			return AuthNext, errorMessage{Message: "Authentication failed due to a token issue. Please try again."}
 		}
 
-		// A group-fetch failure is not enough to deny a returning login when
-		// cached groups are available.
-		log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
+		if retryingDeviceRegistration && authInfo.DeviceRegistrationDataValidationPending {
+			log.Warningf(context.Background(), "Could not get groups after retrying device registration: %v. Using cached groups while device registration validation is pending.", err)
+		} else {
+			log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
+		}
 	} else {
 		authInfo.UserInfo.Groups = groups
 		authInfo.GroupsResolved = true
@@ -1479,6 +1494,13 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 	// Store the auth info in the session so that we can use it when handling the
 	// next IsAuthenticated call for the new password mode.
 	session.authInfo = authInfo
+	if deviceRegistrationRecovery && session.localPasswordAuthenticated {
+		return b.finishAuth(session, authInfo)
+	}
+	if deviceRegistrationRecovery && passwordFileExists(*session) {
+		session.nextAuthModes = []string{authmodes.Password}
+		return AuthNext, nil
+	}
 	session.nextAuthModes = []string{authmodes.NewPassword}
 
 	return AuthNext, nil
@@ -1494,6 +1516,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		log.Noticef(context.Background(), "Authentication failure: incorrect local password for user %q", session.username)
 		return AuthRetry, errorMessage{Message: "Incorrect password, please try again."}
 	}
+	session.localPasswordAuthenticated = true
 
 	authInfo, err := token.LoadAuthInfo(session.tokenPath)
 	if err != nil {
@@ -1595,94 +1618,165 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 
 	// If device registration is enabled, ensure that the device is registered.
 	// Skipped when offline: registration requires a live provider connection.
+	reusedDeviceRegistration := len(authInfo.DeviceRegistrationData) > 0 &&
+		!authInfo.DeviceRegistrationDataInvalidated &&
+		!authInfo.DeviceRegistrationDataValidationPending
+	_, canRegisterDevice := providers.ProviderAs[providers.DeviceRegisterer](b.provider)
+	canSilentlyRecoverDevice := b.cfg.registerDevice && !session.isOffline && canRegisterDevice
+	registrationRecoveryAttempted := false
+	registrationCleanup := func() {}
+	var access string
+	var data isAuthenticatedDataResponse
 	if !session.isOffline {
-		cleanup, access, data := b.maybeRegisterDevice(ctx, session, authInfo, authInfo.Token, authInfo.DeviceRegistrationData)
-		defer cleanup()
+		reenrollInvalidatedDevice := authInfo.DeviceRegistrationDataInvalidated &&
+			!authInfo.DeviceRegistrationDataValidationPending
+		registrationCleanup, access, data = b.maybeRegisterDevice(ctx, session, authInfo, authInfo.Token, authInfo.DeviceRegistrationData)
+		defer func() { registrationCleanup() }()
 		if access != "" {
-			return access, data
+			// A silent re-enrollment of invalidated registration data
+			// failed. Offer the interactive recovery flow instead of a bare
+			// denial, mirroring the stale-data re-enrollment path below.
+			if !reenrollInvalidatedDevice {
+				return access, data
+			}
+			log.Errorf(context.Background(), "Could not silently re-enroll invalidated device: %v", data)
+			session.nextAuthModes = deviceRegistrationRecoveryModes
+			return AuthNext, data
 		}
 	}
 
-	// Try to refresh the groups
-	groups, err := b.getGroups(ctx, session, authInfo)
-	if ctx.Err() != nil {
-		log.Noticef(context.Background(), "Authentication request cancelled for user %q", session.username)
-		return AuthCancelled, nil
-	}
-	if errors.Is(err, providerErrors.ErrDeviceDisabled) {
-		return b.denyDisabledDevice(session, authInfo)
-	}
-	if errors.Is(err, providerErrors.ErrInvalidRedirectURI) {
-		// Deny login if the redirect URI is invalid, so that users and administrators are aware of the issue.
-		log.Errorf(context.Background(), "Login denied: %s", err)
-		return AuthDenied, errorMessageForDisplay(err, "Invalid redirect URI")
-	}
-	var retryWithDeviceAuthError *providerErrors.RetryWithDeviceAuthError
-	if errors.As(err, &retryWithDeviceAuthError) {
-		if authInfo.DeviceRegistrationDataValidationPending {
-			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, reauthModes); expired {
-				return access, data
+	// Try to refresh the groups. A confirmed device-auth failure may still be
+	// recoverable with the cached refresh token, so the loop allows one fresh
+	// enrollment before falling back to interactive device authentication.
+	for {
+		groups, err := b.getGroups(ctx, session, authInfo)
+		if ctx.Err() != nil {
+			log.Noticef(context.Background(), "Authentication request cancelled for user %q", session.username)
+			return AuthCancelled, nil
+		}
+		if errors.Is(err, providerErrors.ErrDeviceDisabled) {
+			return b.denyDisabledDevice(session, authInfo)
+		}
+
+		if errors.Is(err, providerErrors.ErrInvalidRedirectURI) {
+			// Deny login if the redirect URI is invalid, so that users and administrators are aware of the issue.
+			log.Errorf(context.Background(), "Login denied: %s", err)
+			return AuthDenied, errorMessageForDisplay(err, "Invalid redirect URI")
+		}
+
+		var retryWithDeviceAuthError *providerErrors.RetryWithDeviceAuthError
+		if errors.As(err, &retryWithDeviceAuthError) {
+			if authInfo.DeviceRegistrationDataInvalidated || authInfo.DeviceRegistrationDataValidationPending {
+				if authInfo.DeviceRegistrationDataValidationPending {
+					if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, deviceRegistrationRecoveryModes); expired {
+						return access, data
+					}
+					markDeviceRegistrationValidationFailure(authInfo)
+					if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+						log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+						return AuthDenied, unexpectedErrMsg("failed to store token")
+					}
+				}
+				if !authInfo.GroupsResolved {
+					log.Errorf(context.Background(), "failed to get groups: %s", err)
+					return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
+				}
+				// Registration was retried or completed during this login, but the
+				// provider still rejected the device data. Keep the local login
+				// usable with cached groups and retain fresh registration data for
+				// validation on a later retry instead of re-enrolling on every
+				// unlock.
+				// The refresh above has already performed the online liveness and
+				// revocation check, so this relaxes only the device-registration
+				// gate.
+				log.Warningf(context.Background(), "Could not get groups after retrying device registration: %v. Using cached groups and keeping device registration pending.", err)
+				return b.finishAuth(session, authInfo)
 			}
-			markDeviceRegistrationValidationFailure(authInfo)
+
+			if canSilentlyRecoverDevice && reusedDeviceRegistration && !registrationRecoveryAttempted {
+				registrationRecoveryAttempted = true
+				log.Warningf(context.Background(), "Token acquisition failed with stale device registration: %v. Re-enrolling the device with the cached refresh token.", err)
+
+				// The first registration attempt reused the stale data and may
+				// still hold provider state needed by the Graph exchange.
+				registrationCleanup()
+				registrationCleanup = func() {}
+
+				invalidateDeviceRegistrationData(authInfo)
+				if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
+					log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
+					return AuthDenied, unexpectedErrMsg("failed to store token")
+				}
+
+				registrationCleanup, access, data = b.maybeRegisterDevice(ctx, session, authInfo, authInfo.Token, nil)
+				if access != "" {
+					log.Errorf(context.Background(), "Could not silently re-enroll device: %v", data)
+					session.nextAuthModes = deviceRegistrationRecoveryModes
+					return AuthNext, data
+				}
+
+				reusedDeviceRegistration = false
+				continue
+			}
+
+			log.Errorf(context.Background(), "Token acquisition failed: %s. Try again using the device code flow.", err)
+			// This error is only returned for a specific, known signal that the
+			// device's own registration/authentication is invalid in Entra ID
+			// (e.g. an administrator deleted the device object) -- see
+			// himmelblau.ErrDeviceAuthenticationFailed for caveats on that
+			// signal. In this case, the user can perform device code flow again
+			// to get a new token and register the device again, allowing the user
+			// to log in.
+			// We delete the device registration data to cause device code flow to re-register the device.
+			invalidateDeviceRegistrationData(authInfo)
 			if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
 				log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
 				return AuthDenied, unexpectedErrMsg("failed to store token")
 			}
+
+			session.nextAuthModes = deviceRegistrationRecoveryModes
+			msg := "Authentication failed due to a token issue. Please try again."
+			return AuthNext, errorMessage{Message: msg}
+		}
+
+		if err != nil {
+			// We couldn't fetch the groups, but we have valid cached ones. The live
+			// provider check (and force_access_check_with_provider enforcement) happens
+			// at the token refresh above, the same as the device-auth flow, so a
+			// group-fetch failure here falls back to cached groups for both flows.
 			if !authInfo.GroupsResolved {
 				log.Errorf(context.Background(), "failed to get groups: %s", err)
 				return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
 			}
-			log.Warningf(context.Background(), "Could not get groups after registering the device: %v. Using cached groups while registration validation is pending.", err)
-			return b.finishAuth(session, authInfo)
+			log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
+		} else {
+			authInfo.UserInfo.Groups = groups
+			authInfo.GroupsResolved = true
+			// A successful lookup is positive evidence that the device is
+			// valid again, so a persisted disabled-device flag can be dropped.
+			authInfo.DeviceIsDisabled = false
+			clearDeviceRegistrationValidationPending(authInfo)
 		}
 
-		log.Errorf(context.Background(), "Token acquisition failed: %s. Try again using the device code flow.", err)
-		// This error is only returned for a specific, known signal that the
-		// device's own registration/authentication is invalid in Entra ID
-		// (e.g. an administrator deleted the device object) -- see
-		// himmelblau.ErrDeviceAuthenticationFailed for caveats on that
-		// signal. In this case, the user can perform device code flow again
-		// to get a new token and register the device again, allowing the user
-		// to log in.
-		// We delete the device registration data to cause device code flow to re-register the device.
-		authInfo.DeviceRegistrationData = nil
-		clearDeviceRegistrationValidationPending(authInfo)
-		if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
-			log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
-			return AuthDenied, unexpectedErrMsg("failed to store token")
-		}
-
-		session.nextAuthModes = reauthModes
-		msg := "Authentication failed due to a token issue. Please try again."
-		return AuthNext, errorMessage{Message: msg}
+		return b.finishAuth(session, authInfo)
 	}
-	if err != nil {
-		// We couldn't fetch the groups, but we have valid cached ones. The live
-		// provider check (and force_access_check_with_provider enforcement) happens
-		// at the token refresh above, the same as the device-auth flow, so a
-		// group-fetch failure here falls back to cached groups for both flows.
-		if !authInfo.GroupsResolved {
-			log.Errorf(context.Background(), "failed to get groups: %s", err)
-			return AuthDenied, errorMessageForDisplay(err, "Failed to retrieve groups from Microsoft Graph API")
-		}
-		log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
-	} else {
-		authInfo.UserInfo.Groups = groups
-		authInfo.GroupsResolved = true
-		// A successful lookup is positive evidence that the device is
-		// valid again, so a persisted disabled-device flag can be dropped.
-		authInfo.DeviceIsDisabled = false
-		clearDeviceRegistrationValidationPending(authInfo)
-	}
+}
 
-	return b.finishAuth(session, authInfo)
+func invalidateDeviceRegistrationData(authInfo *token.AuthCachedInfo) {
+	authInfo.DeviceRegistrationData = nil
+	authInfo.DeviceRegistrationDataInvalidated = true
+	clearDeviceRegistrationValidationPending(authInfo)
 }
 
 func markDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
-	if len(authInfo.DeviceRegistrationData) > 0 {
-		authInfo.DeviceRegistrationDataValidationPending = true
-		authInfo.DeviceRegistrationDataValidationFailureSince = 0
+	if len(authInfo.DeviceRegistrationData) == 0 {
+		invalidateDeviceRegistrationData(authInfo)
+		return
 	}
+
+	authInfo.DeviceRegistrationDataInvalidated = false
+	authInfo.DeviceRegistrationDataValidationFailureSince = 0
+	authInfo.DeviceRegistrationDataValidationPending = true
 }
 
 func clearDeviceRegistrationValidationPending(authInfo *token.AuthCachedInfo) {
@@ -1701,8 +1795,7 @@ func recoverExpiredPendingRegistration(session *session, authInfo *token.AuthCac
 		return "", nil, false
 	}
 
-	authInfo.DeviceRegistrationData = nil
-	clearDeviceRegistrationValidationPending(authInfo)
+	invalidateDeviceRegistrationData(authInfo)
 	if cacheErr := token.CacheAuthInfo(session.tokenPath, authInfo); cacheErr != nil {
 		log.Errorf(context.Background(), "Failed to store token: %s", cacheErr)
 		return AuthDenied, unexpectedErrMsg("failed to store token"), true
@@ -2411,6 +2504,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 		authInfo.UserInfo.Groups = slices.Clone(oldAuthInfo.UserInfo.Groups)
 		authInfo.GroupsResolved = oldAuthInfo.GroupsResolved
 		authInfo.DeviceRegistrationData = oldAuthInfo.DeviceRegistrationData
+		authInfo.DeviceRegistrationDataInvalidated = oldAuthInfo.DeviceRegistrationDataInvalidated
 		authInfo.DeviceRegistrationDataValidationPending = oldAuthInfo.DeviceRegistrationDataValidationPending
 		authInfo.DeviceRegistrationDataValidationFailureSince = oldAuthInfo.DeviceRegistrationDataValidationFailureSince
 		authInfo.DeviceIsDisabled = oldAuthInfo.DeviceIsDisabled
@@ -2464,7 +2558,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 		var retryWithDeviceAuthErr *providerErrors.RetryWithDeviceAuthError
 		retryingDeviceRegistration := errors.As(err, &retryWithDeviceAuthErr)
 		if retryingDeviceRegistration && authInfo.DeviceRegistrationDataValidationPending {
-			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, reauthModes); expired {
+			if access, data, expired := recoverExpiredPendingRegistration(session, authInfo, deviceRegistrationRecoveryModes); expired {
 				return access, data
 			}
 			markDeviceRegistrationValidationFailure(authInfo)
@@ -2487,7 +2581,7 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 			// next login triggers a fresh device registration instead of
 			// repeatedly failing with the same error.
 			log.Warningf(context.Background(), "Could not get groups: %v. Clearing stale device registration data and using cached groups.", err)
-			authInfo.DeviceRegistrationData = nil
+			invalidateDeviceRegistrationData(authInfo)
 		default:
 			log.Warningf(context.Background(), "Could not get groups: %v. Using cached groups.", err)
 		}
@@ -3097,6 +3191,7 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	// persisted disabled-device flag until a group lookup proves the
 	// device is valid again.
 	t.DeviceIsDisabled = oldToken.DeviceIsDisabled
+	t.DeviceRegistrationDataInvalidated = oldToken.DeviceRegistrationDataInvalidated
 	t.DeviceRegistrationDataValidationPending = oldToken.DeviceRegistrationDataValidationPending
 	t.DeviceRegistrationDataValidationFailureSince = oldToken.DeviceRegistrationDataValidationFailureSince
 
@@ -3211,9 +3306,17 @@ func (b *Broker) maybeRegisterDevice(ctx context.Context, session *session, auth
 		return cleanup, "", nil
 	}
 
+	registrationWasInvalidated := authInfo.DeviceRegistrationDataInvalidated &&
+		!authInfo.DeviceRegistrationDataValidationPending
 	// MaybeRegisterDevice never mutates existingData, so comparing against
 	// the slice itself is enough to detect a fresh registration.
 	deviceRegistrationDataBeforeRegistration := existingData
+	if registrationWasInvalidated {
+		// An invalidated cache has no usable registration data and must be
+		// re-enrolled. Validation-pending data was freshly registered and
+		// should be retained for a later group lookup retry.
+		existingData = nil
+	}
 	var err error
 	authInfo.DeviceRegistrationData, cleanup, err = dr.MaybeRegisterDevice(ctx, regToken,
 		session.username,
@@ -3224,8 +3327,11 @@ func (b *Broker) maybeRegisterDevice(ctx context.Context, session *session, auth
 		log.Errorf(context.Background(), "error registering device: %s", err)
 		return func() {}, AuthDenied, errorMessage{Message: "Error registering device"}
 	}
-	if len(authInfo.DeviceRegistrationData) > 0 &&
-		!slices.Equal(authInfo.DeviceRegistrationData, deviceRegistrationDataBeforeRegistration) {
+	if len(authInfo.DeviceRegistrationData) > 0 {
+		authInfo.DeviceRegistrationDataInvalidated = false
+	}
+	if registrationWasInvalidated || (len(authInfo.DeviceRegistrationData) > 0 &&
+		!slices.Equal(authInfo.DeviceRegistrationData, deviceRegistrationDataBeforeRegistration)) {
 		markDeviceRegistrationValidationPending(authInfo)
 	}
 

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -212,6 +212,9 @@ type mockMFADeniedProvider struct {
 // enterpriseregistration.windows.net).
 type mockDeviceRegistrationFailProvider struct {
 	*mockEntraAuthProvider
+	// allowFreshRegistration lets a fresh registration succeed while true;
+	// fresh registrations fail while false (the zero value).
+	allowFreshRegistration bool
 }
 
 func (p *mockDeviceRegistrationFailProvider) MaybeRegisterDevice(_ context.Context, _ *oauth2.Token, _ string, _ string, oldData []byte) ([]byte, func(), error) {
@@ -219,6 +222,9 @@ func (p *mockDeviceRegistrationFailProvider) MaybeRegisterDevice(_ context.Conte
 	if len(oldData) > 0 {
 		// Re-use existing registration — failure is only on first registration.
 		return oldData, func() {}, nil
+	}
+	if p.allowFreshRegistration {
+		return []byte("device-registration-data"), func() {}, nil
 	}
 	return nil, func() {}, fmt.Errorf("failed to enroll device: Request failed: error sending request for url (https://enterpriseregistration.windows.net/EnrollmentServer/device/?api-version=2.0)")
 }
@@ -2786,6 +2792,23 @@ func advanceToEntraMFAWait(t *testing.T, b *broker.Broker, sessionID, key string
 	require.NoError(t, err)
 }
 
+func setupPasswordRecoverySession(
+	t *testing.T,
+	b *broker.Broker,
+	username string,
+	options tokenOptions,
+	registrationInvalidated bool,
+) (sessionID, key string) {
+	t.Helper()
+
+	sessionID, key = newSessionForTests(t, b, username, sessionmode.Login)
+	cachedInfo := generateCachedInfo(t, options)
+	cachedInfo.DeviceRegistrationDataInvalidated = registrationInvalidated
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), cachedInfo))
+	require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+	return sessionID, key
+}
+
 func advanceToEntraMFACode(t *testing.T, b *broker.Broker, sessionID, key string) {
 	t.Helper()
 
@@ -3599,20 +3622,255 @@ func TestIsAuthenticatedPasswordKeepsDeviceRegistrationOnMissingClientCredential
 		"returning logins after AADSTS7000218 must reuse the existing registration instead of enrolling another device")
 }
 
-// TestFinishEntraAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError
-// verifies that a confirmed device-authentication failure invalidates cached
-// registration data while preserving the returning user's cached groups.
-// AADSTS7000218, as reported in #1680, is not classified as this error.
-func TestFinishEntraAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError(t *testing.T) {
+func TestPasswordAuthPreservesInvalidatedRegistrationWhenRegistrationDisabled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		correctPassword = "password"
+		username        = "test-user@email.com"
+	)
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return cachedGroups, nil
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                       broker.Config{DataDir: t.TempDir()},
+		provider:                     provider,
+		ownerAllowed:                 true,
+		firstUserBecomesOwner:        true,
+		issuerURL:                    defaultIssuerURL,
+		registerDevice:               false,
+		forceAccessCheckWithProvider: true,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	cachedInfo := generateCachedInfo(t, tokenOptions{
+		username:             username,
+		issuer:               defaultIssuerURL,
+		obtainedViaEntraAuth: true,
+		groups:               cachedGroups,
+	})
+	cachedInfo.DeviceRegistrationDataInvalidated = true
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), cachedInfo))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.True(t, cached.DeviceRegistrationDataInvalidated,
+		"disabling registration must not discard the marker needed if registration is enabled again")
+}
+
+func TestIsAuthenticatedPasswordPersistsPendingAfterFreshRegistrationAndPlainGroupFailure(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, fmt.Errorf("graph configuration failure: %w", himmelblau.ErrMissingClientCredentials)
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                       broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:                 true,
+		firstUserBecomesOwner:        true,
+		provider:                     provider,
+		issuerURL:                    defaultIssuerURL,
+		registerDevice:               true,
+		forceAccessCheckWithProvider: true,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	cachedInfo := generateCachedInfo(t, tokenOptions{
+		username:                username,
+		issuer:                  defaultIssuerURL,
+		obtainedViaEntraAuth:    true,
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	})
+	cachedInfo.DeviceRegistrationDataInvalidated = true
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), cachedInfo))
+	require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"a plain group failure after re-registration should fall back to cached groups")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Equal(t, mockDeviceRegistrationData, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataInvalidated)
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"fresh registration must remain pending after a non-retry group failure")
+}
+
+// TestIsAuthenticatedPasswordKeepsLocalAuthWhenInvalidatedDeviceRegistrationRetryFails
+// verifies that a repeated RetryWithDeviceAuthError after re-registration does
+// not force the user back through MFA or re-enroll the device on every unlock.
+// Fresh registration data remains cached while validation is pending.
+func TestIsAuthenticatedPasswordKeepsLocalAuthWhenInvalidatedDeviceRegistrationRetryFails(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("device registration is still invalid")}
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+		registerDevice:        true,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	cachedInfo := generateCachedInfo(t, tokenOptions{
+		username:             username,
+		issuer:               defaultIssuerURL,
+		obtainedViaEntraAuth: true,
+		groups:               cachedGroups,
+	})
+	cachedInfo.DeviceRegistrationData = []byte("stale-device-registration-data")
+	cachedInfo.DeviceRegistrationDataInvalidated = true
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), cachedInfo))
+	require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, data, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"a repeated device-registration failure must not force MFA on every local-password unlock")
+
+	var payload struct {
+		UserInfo struct {
+			Groups []info.Group `json:"groups"`
+		} `json:"userinfo"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t, cachedGroups, payload.UserInfo.Groups,
+		"cached groups must be used when re-registration still fails")
+	require.Equal(t, 1, provider.registrationAttempts,
+		"the local-password retry must attempt device re-registration")
+	require.Empty(t, provider.registrationExistingData,
+		"re-registration must not reuse the stale device-registration data")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Equal(t, mockDeviceRegistrationData, cached.DeviceRegistrationData,
+		"fresh registration data must be retained after group validation fails")
+	require.False(t, cached.DeviceRegistrationDataInvalidated,
+		"successful registration must clear the invalidation marker")
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"fresh registration data must remain pending group validation")
+
+	modesSessionID, modesKey := newSessionForTests(t, b, username, sessionmode.Login)
+	modes, err := b.GetAuthenticationModes(modesSessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	var modeIDs []string
+	for _, mode := range modes {
+		modeIDs = append(modeIDs, mode["id"])
+	}
+	require.Contains(t, modeIDs, authmodes.Password,
+		"local password authentication must remain available while validation is pending")
+
+	updateAuthModes(t, b, modesSessionID, authmodes.Password)
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", modesKey))
+	access, _, err = b.IsAuthenticated(modesSessionID, passwordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"local password authentication should reuse the device instead of forcing MFA again")
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"repeated group failures must not enroll the device more than once")
+	require.Len(t, provider.registrationExistingDataCalls, 2)
+	require.Empty(t, provider.registrationExistingDataCalls[0],
+		"the invalidated cache must trigger one fresh enrollment")
+	require.Equal(t, mockDeviceRegistrationData, provider.registrationExistingDataCalls[1],
+		"later logins must reuse the fresh registration data")
+
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(modesSessionID))
+	require.NoError(t, err)
+	require.Equal(t, mockDeviceRegistrationData, cached.DeviceRegistrationData,
+		"fresh registration data must remain cached after repeated group failures")
+	require.False(t, cached.DeviceRegistrationDataInvalidated,
+		"successful registration must keep the invalidation marker clear")
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"registration validation must remain pending while group lookup fails")
+
+	provider.GetGroupsFunc = func() ([]info.Group, error) {
+		return cachedGroups, nil
+	}
+	recoverySessionID, recoveryKey := newSessionForTests(t, b, username, sessionmode.Login)
+	updateAuthModes(t, b, recoverySessionID, authmodes.Password)
+	recoveryAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", recoveryKey))
+	access, _, err = b.IsAuthenticated(recoverySessionID, recoveryAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"local authentication should clear validation pending after group lookup recovers")
+	require.Equal(t, 1, provider.registrationEnrollments,
+		"recovering group lookup must reuse the existing registration")
+
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(recoverySessionID))
+	require.NoError(t, err)
+	require.Equal(t, mockDeviceRegistrationData, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataValidationPending,
+		"successful group lookup must clear pending registration validation")
+}
+
+// TestFinishEntraAuthInvalidationPreservesLocalPasswordRecovery verifies that
+// AADSTS50155 invalidates stale registration data without removing local
+// password authentication, which silently enrolls a replacement device on the
+// next login. AADSTS7000218, as reported in #1680, is not this error.
+func TestFinishEntraAuthInvalidationPreservesLocalPasswordRecovery(t *testing.T) {
 	t.Parallel()
 
 	username := "test-user@email.com"
 	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
 	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	groupFetches := 0
+	var (
+		tokenPath             string
+		cachedGroupsAtLookup  []info.Group
+		cachedGroupsLookupErr error
+	)
 	provider := &mockEntraAuthProvider{
 		MockProvider: &testutils.MockProvider{
 			GetGroupsFunc: func() ([]info.Group, error) {
-				return nil, &providerErrors.RetryWithDeviceAuthError{Err: himmelblau.ErrDeviceAuthenticationFailed}
+				cached, cacheErr := token.LoadAuthInfo(tokenPath)
+				if cacheErr != nil {
+					cachedGroupsLookupErr = cacheErr
+				} else {
+					cachedGroupsAtLookup = cached.UserInfo.Groups
+				}
+				groupFetches++
+				if groupFetches == 1 {
+					return nil, &providerErrors.RetryWithDeviceAuthError{Err: himmelblau.ErrDeviceAuthenticationFailed}
+				}
+				return cachedGroups, nil
 			},
 		},
 		flowState: &himmelblau.MFAFlowState{},
@@ -3631,9 +3889,11 @@ func TestFinishEntraAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthEr
 		firstUserBecomesOwner: true,
 		provider:              provider,
 		issuerURL:             defaultIssuerURL,
+		registerDevice:        true,
 	})
 
 	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	tokenPath = b.TokenPathForSession(sessionID)
 	// isForDeviceRegistration seeds a non-empty (stale) DeviceRegistrationData;
 	// this is the cached token loaded as oldAuthInfo by entraAuth.
 	generateAndStoreCachedInfo(t, tokenOptions{
@@ -3657,12 +3917,48 @@ func TestFinishEntraAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthEr
 	}
 	require.NoError(t, json.Unmarshal([]byte(data), &payload))
 	require.Equal(t, cachedGroups, payload.UserInfo.Groups, "cached groups must still be used while the device is re-registered")
+	require.NoError(t, cachedGroupsLookupErr)
+	require.Equal(t, cachedGroups, cachedGroupsAtLookup,
+		"cached groups must be present when registration is persisted before group validation")
 
 	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
 	require.NoError(t, err)
 	require.Empty(t, cached.DeviceRegistrationData,
 		"stale DeviceRegistrationData must be cleared so the next login re-registers the device "+
 			"instead of repeatedly failing getGroups with the same stale data")
+	require.True(t, cached.DeviceRegistrationDataInvalidated,
+		"invalidated device registration data must keep local password authentication available while re-registration is pending")
+	require.False(t, cached.DeviceRegistrationDataValidationPending,
+		"stale registration data must be cleared before validation can become pending")
+
+	modesSessionID, modesKey := newSessionForTests(t, b, username, sessionmode.Login)
+	modes, err := b.GetAuthenticationModes(modesSessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	var modeIDs []string
+	for _, mode := range modes {
+		modeIDs = append(modeIDs, mode["id"])
+	}
+	require.Contains(t, modeIDs, authmodes.Password,
+		"local password authentication must remain available after stale device data is invalidated")
+
+	updateAuthModes(t, b, modesSessionID, authmodes.Password)
+	recoveryPasswordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", modesKey))
+	access, _, err = b.IsAuthenticated(modesSessionID, recoveryPasswordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"local password authentication should re-register the device instead of forcing MFA again")
+
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(modesSessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData,
+		"successful re-registration should restore device registration data")
+	require.False(t, cached.DeviceRegistrationDataInvalidated,
+		"successful re-registration should clear the invalidation marker")
+	require.False(t, cached.DeviceRegistrationDataValidationPending,
+		"successful group lookup should clear pending registration validation")
 }
 
 // TestFinishEntraAuthPreservesFreshDeviceRegistrationOnRetryWithDeviceAuthError
@@ -3864,6 +4160,62 @@ func TestFinishEntraAuthRejectsTerminalGroupErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFinishEntraAuthPersistsPendingAfterFreshRegistrationAndPlainGroupFailure(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, errors.New("temporary group lookup failure")
+			},
+		},
+		flowState: &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Please type in the code displayed on your authenticator app from your device:",
+			Method:            "PhoneAppOTP",
+			PollingIntervalMs: 5000,
+			MaxPollAttempts:   10,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+		registerDevice:        true,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuth)
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, _, err := b.IsAuthenticated(sessionID, passwordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+
+	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraMFACode))
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.EntraMFACode)
+	require.NoError(t, err)
+
+	otpAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "123456", key))
+	access, _, err = b.IsAuthenticated(sessionID, otpAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a first MFA login without cached groups should still be denied")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataInvalidated)
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"fresh registration must remain pending after a non-retry group failure")
+	require.False(t, cached.GroupsResolved,
+		"the cache must remain unresolved after a failed group lookup")
 }
 
 // TestIsAuthenticatedPasswordEntraTokenRefreshDetectsDisabledUser verifies that on a
@@ -4564,10 +4916,7 @@ func TestDeviceAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError(t
 		provider:              provider,
 		registerDevice:        true,
 		tokenHandlerOptions: &testutils.TokenHandlerOptions{
-			IDTokenClaims: []map[string]interface{}{
-				{"aud": consts.MicrosoftBrokerAppID},
-				{"aud": consts.MicrosoftBrokerAppID},
-			},
+			IDTokenClaims: []map[string]interface{}{{"aud": consts.MicrosoftBrokerAppID}},
 		},
 	})
 
@@ -4581,7 +4930,7 @@ func TestDeviceAuthClearsStaleDeviceRegistrationDataOnRetryWithDeviceAuthError(t
 	access, data, err := b.IsAuthenticated(sessionID, "{}")
 	require.NoError(t, err)
 	require.Equal(t, broker.AuthNext, access)
-	require.Equal(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(sessionID))
+	require.Equal(t, []string{authmodes.Device, authmodes.DeviceQr, authmodes.EntraAuth}, b.GetNextAuthModes(sessionID))
 	require.Contains(t, data, "token issue")
 
 	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
@@ -4630,6 +4979,296 @@ func TestDeviceAuthPersistsDisabledDeviceState(t *testing.T) {
 		"the disabled state must be persisted so offline logins are denied too")
 }
 
+func TestPasswordAuthSilentlyReRegistersDeletedDevice(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	newGroups := []info.Group{{Name: "new-group", UGID: "new-id"}}
+	groupFetches := 0
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				groupFetches++
+				if groupFetches == 1 {
+					return nil, &providerErrors.RetryWithDeviceAuthError{
+						Err: himmelblau.ErrDeviceAuthenticationFailed,
+					}
+				}
+				return newGroups, nil
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                       broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:                 true,
+		firstUserBecomesOwner:        true,
+		provider:                     provider,
+		registerDevice:               true,
+		forceAccessCheckWithProvider: true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{{"aud": consts.MicrosoftBrokerAppID}},
+		},
+	})
+
+	sessionID, key := setupPasswordRecoverySession(t, b, username, tokenOptions{
+		username:                username,
+		issuer:                  defaultIssuerURL,
+		obtainedViaEntraAuth:    true,
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, false)
+
+	modes, err := b.GetAuthenticationModes(sessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{
+		{"id": authmodes.Password, "label": authmodes.Label[authmodes.Password]},
+		{"id": authmodes.DeviceQr, "label": authmodes.Label[authmodes.DeviceQr]},
+	}, modes)
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.Password)
+	require.NoError(t, err)
+
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, data, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"silent device recovery should finish an existing local-password login")
+	require.Contains(t, data, "new-group")
+	require.Equal(t, 1, provider.registrationEnrollments)
+	require.Len(t, provider.registrationExistingDataCalls, 2)
+	require.Equal(t, []byte("device-registration-data"), provider.registrationExistingDataCalls[0])
+	require.Empty(t, provider.registrationExistingDataCalls[1])
+	require.Empty(t, b.GetNextAuthModes(sessionID))
+}
+
+func TestPasswordAuthFallsBackToDeviceAuthWhenSilentReenrollmentFails(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	getGroupsCalls := 0
+	provider := &mockDeviceRegistrationFailProvider{
+		mockEntraAuthProvider: &mockEntraAuthProvider{
+			MockProvider: &testutils.MockProvider{
+				GetGroupsFunc: func() ([]info.Group, error) {
+					getGroupsCalls++
+					if getGroupsCalls == 1 {
+						return nil, &providerErrors.RetryWithDeviceAuthError{
+							Err: himmelblau.ErrDeviceAuthenticationFailed,
+						}
+					}
+					return []info.Group{{Name: "new-group", UGID: "new-id"}}, nil
+				},
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{{"aud": consts.MicrosoftBrokerAppID}},
+		},
+		forceAccessCheckWithProvider: true,
+	})
+
+	sessionID, key := setupPasswordRecoverySession(t, b, username, tokenOptions{
+		username:                username,
+		issuer:                  defaultIssuerURL,
+		obtainedViaEntraAuth:    true,
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, false)
+
+	modes, err := b.GetAuthenticationModes(sessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{
+		{"id": authmodes.Password, "label": authmodes.Label[authmodes.Password]},
+		{"id": authmodes.DeviceQr, "label": authmodes.Label[authmodes.DeviceQr]},
+	}, modes)
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.Password)
+	require.NoError(t, err)
+
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, data, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Contains(t, data, "Error registering device")
+	require.Equal(t, []string{authmodes.Device, authmodes.DeviceQr, authmodes.EntraAuth}, b.GetNextAuthModes(sessionID))
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Empty(t, cached.DeviceRegistrationData)
+	require.True(t, cached.DeviceRegistrationDataInvalidated)
+
+	// The local password was already verified in this session, so completing
+	// the device flow must grant without asking for the password again.
+	provider.allowFreshRegistration = true
+	modes, err = b.GetAuthenticationModes(sessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{
+		{"id": authmodes.DeviceQr, "label": authmodes.Label[authmodes.DeviceQr]},
+		{"id": authmodes.EntraAuth, "label": authmodes.Label[authmodes.EntraAuth]},
+	}, modes)
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.DeviceQr)
+	require.NoError(t, err)
+
+	access, _, err = b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"device recovery must grant without asking for the local password again")
+
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataInvalidated)
+	require.False(t, cached.DeviceRegistrationDataValidationPending)
+	require.Equal(t, []info.Group{{Name: "new-group", UGID: "new-id"}}, cached.UserInfo.Groups)
+}
+
+func TestPasswordAuthFallsBackToDeviceAuthWhenReenrollingInvalidatedDeviceFails(t *testing.T) {
+	t.Parallel()
+
+	const username = "test-user@email.com"
+	cachedGroups := []info.Group{{Name: "cached-group", UGID: "cached-id"}}
+	provider := &mockDeviceRegistrationFailProvider{
+		mockEntraAuthProvider: &mockEntraAuthProvider{
+			MockProvider: &testutils.MockProvider{
+				GetGroupsFunc: func() ([]info.Group, error) {
+					return nil, &providerErrors.RetryWithDeviceAuthError{
+						Err: himmelblau.ErrDeviceAuthenticationFailed,
+					}
+				},
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                       broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:                 true,
+		firstUserBecomesOwner:        true,
+		provider:                     provider,
+		registerDevice:               true,
+		forceAccessCheckWithProvider: true,
+	})
+
+	sessionID, key := setupPasswordRecoverySession(t, b, username, tokenOptions{
+		username:                username,
+		issuer:                  defaultIssuerURL,
+		obtainedViaEntraAuth:    true,
+		isForDeviceRegistration: true,
+		groups:                  cachedGroups,
+	}, true)
+
+	modes, err := b.GetAuthenticationModes(sessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{
+		{"id": authmodes.Password, "label": authmodes.Label[authmodes.Password]},
+		{"id": authmodes.DeviceQr, "label": authmodes.Label[authmodes.DeviceQr]},
+	}, modes)
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.Password)
+	require.NoError(t, err)
+
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, data, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access,
+		"a failed silent re-enrollment of invalidated data must fall back to the recovery flow")
+	require.Contains(t, data, "Error registering device")
+	require.Equal(t, []string{authmodes.Device, authmodes.DeviceQr, authmodes.EntraAuth}, b.GetNextAuthModes(sessionID))
+
+	// The failed enrollment must leave the invalidated cache untouched.
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Equal(t, []byte("device-registration-data"), cached.DeviceRegistrationData)
+	require.True(t, cached.DeviceRegistrationDataInvalidated)
+}
+
+func TestDeviceAuthRecoveryRequiresLocalPasswordWhenEnteredDirectly(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return []info.Group{{Name: "new-group", UGID: "new-id"}}, nil
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	cachedInfo := generateCachedInfo(t, tokenOptions{isForDeviceRegistration: true})
+	cachedInfo.DeviceRegistrationDataInvalidated = true
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), cachedInfo))
+	require.NoError(t, password.HashAndStorePassword("password", b.PasswordFilepathForSession(sessionID)))
+
+	modes, err := b.GetAuthenticationModes(sessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{
+		{"id": authmodes.Password, "label": authmodes.Label[authmodes.Password]},
+		{"id": authmodes.DeviceQr, "label": authmodes.Label[authmodes.DeviceQr]},
+	}, modes)
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.DeviceQr)
+	require.NoError(t, err)
+
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.Password}, b.GetNextAuthModes(sessionID),
+		"direct device recovery must request the existing local password before granting")
+
+	modes, err = b.GetAuthenticationModes(sessionID, []map[string]string{
+		supportedUILayouts["form"],
+		supportedUILayouts["qrcode"],
+	})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{
+		{"id": authmodes.Password, "label": authmodes.Label[authmodes.Password]},
+	}, modes)
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.Password)
+	require.NoError(t, err)
+
+	wrongPassword := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "wrong-password", key))
+	access, data, err := b.IsAuthenticated(sessionID, wrongPassword)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthRetry, access)
+	require.Contains(t, data, "Incorrect password")
+
+	correctPassword := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, _, err = b.IsAuthenticated(sessionID, correctPassword)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"direct device recovery should grant after the existing local password is verified")
+}
+
 // TestDeviceAuthFallsBackToCachedGroupsOnGroupFetchError verifies that a
 // returning device-code login preserves access and registration state when a
 // group lookup fails for a reason that does not prove device invalidation.
@@ -4667,6 +5306,11 @@ func TestDeviceAuthFallsBackToCachedGroupsOnGroupFetchError(t *testing.T) {
 	require.Equal(t, broker.AuthNext, access)
 	require.Equal(t, []string{authmodes.NewPassword}, b.GetNextAuthModes(sessionID))
 
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.Equal(t, cachedGroups, cached.UserInfo.Groups,
+		"cached groups must survive the registration cache write before group validation")
+
 	updateAuthModes(t, b, sessionID, authmodes.NewPassword)
 	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "new-password", key))
 	access, data, err := b.IsAuthenticated(sessionID, authData)
@@ -4681,7 +5325,7 @@ func TestDeviceAuthFallsBackToCachedGroupsOnGroupFetchError(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(data), &payload))
 	require.Equal(t, cachedGroups, payload.UserInfo.Groups)
 
-	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	cached, err = token.LoadAuthInfo(b.TokenPathForSession(sessionID))
 	require.NoError(t, err)
 	require.NotEmpty(t, cached.DeviceRegistrationData,
 		"a non-device group error must preserve the existing registration")
@@ -4775,7 +5419,7 @@ func TestDeviceAuthReenrollsAfterPendingValidationFailureGracePeriod(t *testing.
 	access, _, err := b.IsAuthenticated(sessionID, "{}")
 	require.NoError(t, err)
 	require.Equal(t, broker.AuthNext, access)
-	require.Equal(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(sessionID))
+	require.ElementsMatch(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(sessionID))
 	require.Zero(t, provider.registrationEnrollments,
 		"an expired pending registration must be invalidated before a replacement is enrolled")
 
@@ -4902,7 +5546,7 @@ func TestDeviceAuthPersistsClearedValidationPendingAfterGroupSuccess(t *testing.
 	access, _, err = b.IsAuthenticated(retrySessionID, "{}")
 	require.NoError(t, err)
 	require.Equal(t, broker.AuthNext, access)
-	require.Equal(t, []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr}, b.GetNextAuthModes(retrySessionID))
+	require.Equal(t, []string{authmodes.Device, authmodes.DeviceQr, authmodes.EntraAuth}, b.GetNextAuthModes(retrySessionID))
 	require.Equal(t, 1, provider.registrationEnrollments,
 		"a later device-auth failure must invalidate the existing registration instead of enrolling during this flow")
 
@@ -4910,6 +5554,45 @@ func TestDeviceAuthPersistsClearedValidationPendingAfterGroupSuccess(t *testing.
 	require.NoError(t, err)
 	require.Empty(t, cached.DeviceRegistrationData)
 	require.False(t, cached.DeviceRegistrationDataValidationPending)
+}
+
+func TestDeviceAuthPersistsPendingAfterFreshRegistrationAndPlainGroupFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{
+			GetGroupsFunc: func() ([]info.Group, error) {
+				return nil, errors.New("temporary group lookup failure")
+			},
+		},
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		registerDevice:        true,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{
+				{"aud": consts.MicrosoftBrokerAppID},
+				{"aud": consts.MicrosoftBrokerAppID},
+			},
+		},
+	})
+
+	sessionID, _ := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	updateAuthModes(t, b, sessionID, authmodes.DeviceQr)
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a first device login without cached groups should still be denied")
+
+	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
+	require.NoError(t, err)
+	require.NotEmpty(t, cached.DeviceRegistrationData)
+	require.False(t, cached.DeviceRegistrationDataInvalidated)
+	require.True(t, cached.DeviceRegistrationDataValidationPending,
+		"fresh registration must remain pending after a non-retry group failure")
 }
 
 // TestIsAuthenticatedPhoneAppOTPRoutesToMFACode verifies that PhoneAppOTP

--- a/authd-oidc-brokers/internal/token/token.go
+++ b/authd-oidc-brokers/internal/token/token.go
@@ -23,6 +23,11 @@ type AuthCachedInfo struct {
 	// from the provider at least once. A group-fetch failure may only fall
 	// back to cached groups when this is set.
 	GroupsResolved bool
+	// DeviceRegistrationDataInvalidated is set when a provider rejects the
+	// cached registration data. It keeps local password authentication
+	// available while the next online authentication re-registers the device.
+	// Omitting false preserves the existing on-disk token format.
+	DeviceRegistrationDataInvalidated bool `json:",omitempty"`
 	// DeviceRegistrationDataValidationPending is set when fresh registration
 	// data was obtained but group lookup has not yet succeeded.
 	// The data is retained and reused until group lookup succeeds.

--- a/authd-oidc-brokers/internal/token/token_test.go
+++ b/authd-oidc-brokers/internal/token/token_test.go
@@ -126,7 +126,7 @@ func TestLoadAuthInfo(t *testing.T) {
 	}
 }
 
-func TestLoadAuthInfoLegacyTokenDefaultsValidationPendingToFalse(t *testing.T) {
+func TestLoadAuthInfoLegacyTokenDefaultsInvalidationMarkerToFalse(t *testing.T) {
 	t.Parallel()
 
 	tokenPath := filepath.Join(t.TempDir(), "parent", "token.json")
@@ -142,6 +142,8 @@ func TestLoadAuthInfoLegacyTokenDefaultsValidationPendingToFalse(t *testing.T) {
 	got, err := token.LoadAuthInfo(tokenPath)
 	require.NoError(t, err)
 	require.Equal(t, []byte("legacy-device-data"), got.DeviceRegistrationData)
+	require.False(t, got.DeviceRegistrationDataInvalidated,
+		"legacy caches without the marker must load as not invalidated")
 	require.False(t, got.DeviceRegistrationDataValidationPending,
 		"legacy caches without the field must load as not pending")
 	require.False(t, got.GroupsResolved,


### PR DESCRIPTION
After the provider confirms `AADSTS50155`, #1781 invalidates rejected device
registration data so the machine can enroll again. An invalidated cache alone
looked like a first login, which hid local-password authentication and could
force the user through another Entra password and MFA flow.

Persist an explicit invalidated-registration state so local-password
authentication remains available during recovery. After the local password is
verified:

- Try one silent replacement enrollment with the cached refresh token.
- Retry group lookup in the same authentication request.
- Grant immediately when replacement enrollment and lookup succeed.
- Keep fresh registration data validation-pending and use cached groups while
  Entra finishes propagating it.
- Fall back to device authentication when silent enrollment cannot complete.
- Remember that the local password was already verified so the fallback does
  not ask for it again in the same session.

Carry invalidated and validation-pending state through token refresh, device
authentication, and the unified `entra_auth` flow.

This recovery applies only to exact `AADSTS50155`. `AADSTS7000218` and unknown
Graph errors remain non-destructive as defined by #1781 and #1825.

## Verification

The manual scenario is:

1. Complete a healthy login with device registration enabled.
2. Set or retain the local password.
3. Delete the registered device in Entra and wait for deletion to propagate.
4. Authenticate with the local password.
5. Confirm one replacement enrollment occurs, the same login completes, and
   later unlocks continue to offer local-password authentication.

The automated coverage also exercises silent enrollment failure, device-flow
fallback, cached-group preservation, pending validation, and token refresh.

Closes #1790.

## Follow-up hardening

Two independent PAM sessions for the same user can overlap while replacing an
invalidated registration. Serializing the full per-user cache
read/enroll/write operation would guarantee only one replacement. This is not
an authentication bypass and is unlikely in the normal GDM flow, so it is
tracked separately unless strict single-device creation is required.

UDENG-11234
