### PR TITLE
broker: avoid invalid Entra defaults on upgrades

### DIFF
--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/export_test.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/export_test.go
@@ -75,9 +75,7 @@ issuer = %s
 client_id = client_id
 
 [flows]
-# These tests don't exercise the entra_auth flow, and the default
-# (enabled) would fail startup validation under the withmsentraid tag
-# because no client_secret or register_device is configured here.
+# These tests don't exercise the entra_auth flow.
 entra_auth = false
 `, providerURL)
 	err = os.WriteFile(p, []byte(brokerCfg), 0600)

--- a/authd-oidc-brokers/conf/variants/msentraid/broker.conf
+++ b/authd-oidc-brokers/conf/variants/msentraid/broker.conf
@@ -100,17 +100,18 @@ client_id = <CLIENT_ID>
 [flows]
 ## Control which authentication flows are offered to users.
 ##
-## device_code: When true (default), users can authenticate with the
+## device_code: When true (the default), users can authenticate with the
 ## device code flow (scanning a QR code or visiting a URL and entering
 ## a code).
 #device_code = true
 
-## entra_auth: When true (default), users can authenticate with the
+## entra_auth: When true, users can authenticate with the
 ## Microsoft Entra ID direct-auth flow.
 ## When the user has enrolled passwordless methods (FIDO2 security keys,
 ## Microsoft Authenticator, or a Temporary Access Pass), the flow negotiates
 ## those automatically; otherwise it falls back to password + MFA.
 ##
-## Note: If both device_code and entra_auth are disabled, the broker
-## considers the configuration invalid and will fail to start.
-#entra_auth = true
+## If this option is omitted, it defaults to the value of register_device for
+## compatibility with existing configurations. Keep it disabled by default in
+## new configurations until the required group lookup setup is complete.
+entra_auth = false

--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -151,11 +151,14 @@ type flowsConfig struct {
 	EntraAuth  bool
 }
 
-// defaultFlowsConfig returns the default flows configuration (all modes enabled).
-func defaultFlowsConfig() flowsConfig {
+// defaultFlowsConfig returns the defaults for flow settings omitted from the
+// configuration. Device-code authentication stays enabled for compatibility.
+// Entra authentication follows register_device so existing configurations keep
+// using it when device registration was enabled.
+func defaultFlowsConfig(registerDevice bool) flowsConfig {
 	return flowsConfig{
 		DeviceAuth: true,
-		EntraAuth:  true,
+		EntraAuth:  registerDevice,
 	}
 }
 
@@ -390,7 +393,7 @@ func parseConfig(cfg configFile, dropInCfgs []configFile, p provider) (userConfi
 		uc.registerDevice, _ = entraID.Key(registerDeviceKey).Bool()
 	}
 
-	uc.flows, err = parseFlowsConfig(iniCfg.Section(flowsSection))
+	uc.flows, err = parseFlowsConfig(iniCfg.Section(flowsSection), uc.registerDevice)
 	if err != nil {
 		return userConfig{}, err
 	}
@@ -481,9 +484,10 @@ func (uc *userConfig) registerOwner(cfgPath, userName string) error {
 	return nil
 }
 
-// parseFlowsConfig parses the [flows] section and returns a flowsConfig with defaults for missing keys.
-func parseFlowsConfig(section *ini.Section) (flowsConfig, error) {
-	fc := defaultFlowsConfig()
+// parseFlowsConfig parses the [flows] section and returns a flowsConfig with
+// defaults for missing keys.
+func parseFlowsConfig(section *ini.Section, registerDevice bool) (flowsConfig, error) {
+	fc := defaultFlowsConfig(registerDevice)
 
 	if section == nil {
 		return fc, nil
@@ -492,7 +496,7 @@ func parseFlowsConfig(section *ini.Section) (flowsConfig, error) {
 	if section.HasKey(flowsDeviceAuthKey) {
 		val, err := section.Key(flowsDeviceAuthKey).Bool()
 		if err != nil {
-			log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (true)", flowsDeviceAuthKey, flowsSection)
+			log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (%t)", flowsDeviceAuthKey, flowsSection, fc.DeviceAuth)
 		} else {
 			fc.DeviceAuth = val
 		}
@@ -501,7 +505,7 @@ func parseFlowsConfig(section *ini.Section) (flowsConfig, error) {
 	if section.HasKey(flowsEntraAuthKey) {
 		val, err := section.Key(flowsEntraAuthKey).Bool()
 		if err != nil {
-			log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (true)", flowsEntraAuthKey, flowsSection)
+			log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (%t)", flowsEntraAuthKey, flowsSection, fc.EntraAuth)
 		} else {
 			fc.EntraAuth = val
 		}

--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -8,11 +8,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"text/template"
 	"unicode"
 
+	"github.com/canonical/authd/authd-oidc-brokers/internal/broker/authmodes"
 	"github.com/canonical/authd/log"
 	"gopkg.in/ini.v1"
 )
@@ -108,6 +110,7 @@ var (
 
 type provider interface {
 	NormalizeUsername(username string) string
+	SupportedOnlineAuthModes() []string
 }
 
 // configFile holds the path and content of a configuration file.
@@ -393,7 +396,7 @@ func parseConfig(cfg configFile, dropInCfgs []configFile, p provider) (userConfi
 		uc.registerDevice, _ = entraID.Key(registerDeviceKey).Bool()
 	}
 
-	uc.flows, err = parseFlowsConfig(iniCfg.Section(flowsSection), uc.registerDevice)
+	uc.flows, err = parseFlowsConfig(iniCfg.Section(flowsSection), uc.registerDevice, p)
 	if err != nil {
 		return userConfig{}, err
 	}
@@ -486,35 +489,63 @@ func (uc *userConfig) registerOwner(cfgPath, userName string) error {
 
 // parseFlowsConfig parses the [flows] section and returns a flowsConfig with
 // defaults for missing keys.
-func parseFlowsConfig(section *ini.Section, registerDevice bool) (flowsConfig, error) {
+func parseFlowsConfig(section *ini.Section, registerDevice bool, p provider) (flowsConfig, error) {
 	fc := defaultFlowsConfig(registerDevice)
 
-	if section == nil {
-		return fc, nil
-	}
+	if section != nil {
+		if section.HasKey(flowsDeviceAuthKey) {
+			val, err := section.Key(flowsDeviceAuthKey).Bool()
+			if err != nil {
+				log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (%t)", flowsDeviceAuthKey, flowsSection, fc.DeviceAuth)
+			} else {
+				fc.DeviceAuth = val
+			}
+		}
 
-	if section.HasKey(flowsDeviceAuthKey) {
-		val, err := section.Key(flowsDeviceAuthKey).Bool()
-		if err != nil {
-			log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (%t)", flowsDeviceAuthKey, flowsSection, fc.DeviceAuth)
-		} else {
-			fc.DeviceAuth = val
+		if section.HasKey(flowsEntraAuthKey) {
+			val, err := section.Key(flowsEntraAuthKey).Bool()
+			if err != nil {
+				log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (%t)", flowsEntraAuthKey, flowsSection, fc.EntraAuth)
+			} else {
+				fc.EntraAuth = val
+			}
 		}
 	}
 
-	if section.HasKey(flowsEntraAuthKey) {
-		val, err := section.Key(flowsEntraAuthKey).Bool()
-		if err != nil {
-			log.Warningf(context.Background(), "invalid value for %q in [%s] section, using default (%t)", flowsEntraAuthKey, flowsSection, fc.EntraAuth)
-		} else {
-			fc.EntraAuth = val
-		}
-	}
-
-	if !fc.DeviceAuth && !fc.EntraAuth {
-		return flowsConfig{}, fmt.Errorf("invalid [%s] configuration: all authentication flows are disabled; at least one of the %q or %q flows must be enabled",
-			flowsSection, flowsDeviceAuthKey, flowsEntraAuthKey)
+	supportedModes := p.SupportedOnlineAuthModes()
+	if !hasEnabledSupportedFlow(fc, supportedModes) {
+		return flowsConfig{}, invalidFlowsConfigError(supportedModes)
 	}
 
 	return fc, nil
+}
+
+func hasEnabledSupportedFlow(fc flowsConfig, supportedModes []string) bool {
+	deviceAuthSupported := slices.Contains(supportedModes, authmodes.Device) || slices.Contains(supportedModes, authmodes.DeviceQr)
+	entraAuthSupported := slices.Contains(supportedModes, authmodes.EntraAuth)
+
+	return (fc.DeviceAuth && deviceAuthSupported) || (fc.EntraAuth && entraAuthSupported)
+}
+
+// Keep the error provider-specific so it only suggests flows the broker can
+// actually offer, such as not mentioning Entra authentication for Google.
+func invalidFlowsConfigError(supportedModes []string) error {
+	var flowKeys []string
+	if slices.Contains(supportedModes, authmodes.Device) || slices.Contains(supportedModes, authmodes.DeviceQr) {
+		flowKeys = append(flowKeys, flowsDeviceAuthKey)
+	}
+	if slices.Contains(supportedModes, authmodes.EntraAuth) {
+		flowKeys = append(flowKeys, flowsEntraAuthKey)
+	}
+
+	switch len(flowKeys) {
+	case 0:
+		return fmt.Errorf("invalid [%s] configuration: all supported authentication flows are disabled", flowsSection)
+	case 1:
+		return fmt.Errorf("invalid [%s] configuration: no supported authentication flows are enabled; the %q flow must be enabled",
+			flowsSection, flowKeys[0])
+	default:
+		return fmt.Errorf("invalid [%s] configuration: no supported authentication flows are enabled; at least one of the %q or %q flows must be enabled",
+			flowsSection, flowKeys[0], flowKeys[1])
+	}
 }

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -10,10 +10,20 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/canonical/authd/authd-oidc-brokers/internal/broker/authmodes"
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/google"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/testutils"
 	"github.com/canonical/authd/internal/testutils/golden"
 	"github.com/stretchr/testify/require"
 )
+
+type configTestProvider struct {
+	*testutils.MockProvider
+}
+
+func (p *configTestProvider) SupportedOnlineAuthModes() []string {
+	return []string{authmodes.Device, authmodes.DeviceQr, authmodes.EntraAuth}
+}
 
 var configTypes = map[string]string{
 	"valid": `
@@ -142,20 +152,23 @@ func TestParseConfig(t *testing.T) {
 	tests := map[string]struct {
 		configType string
 		dropInType string
+		provider   provider
 
 		wantErr                         bool
 		wantErrContainsDropInConfigPath bool
+		wantErrContains                 string
 	}{
 		"Successfully_parse_config_file":                           {},
 		"Successfully_parse_config_file_with_optional_values":      {configType: "valid+optional"},
 		"Successfully_parse_config_file_with_register_device":      {configType: "valid+register_device"},
-		"Successfully_parse_config_file_with_flow_values":          {configType: "valid+one_flow_disabled"},
+		"Successfully_parse_config_file_with_flow_values":          {configType: "valid+one_flow_disabled", provider: &configTestProvider{MockProvider: &testutils.MockProvider{}}},
 		"Warns_and_uses_default_for_invalid_device_code_value":     {configType: "invalid_device_code_value"},
 		"Warns_and_uses_default_for_invalid_entra_auth_flow_value": {configType: "invalid_entra_auth_value"},
 		"Successfully_parse_config_with_drop_in_files":             {dropInType: "valid"},
 		"Successfully_parse_config_with_flow_drop_in_files": {
 			configType: "valid+flows_disabled",
 			dropInType: "flows",
+			provider:   &configTestProvider{MockProvider: &testutils.MockProvider{}},
 		},
 		"Successfully_parse_config_when_placeholders_are_overridden_by_drop_in": {
 			configType: "template",
@@ -164,7 +177,7 @@ func TestParseConfig(t *testing.T) {
 
 		"Do_not_fail_if_values_contain_a_single_template_delimiter": {configType: "singles"},
 
-		"Error_if_all_flows_are_disabled":                                                   {configType: "valid+flows_disabled", wantErr: true},
+		"Error_if_all_flows_are_disabled":                                                   {configType: "valid+flows_disabled", wantErr: true, wantErrContains: `the "device_code" flow must be enabled`},
 		"Error_if_file_does_not_exist":                                                      {configType: "inexistent", wantErr: true},
 		"Error_if_file_is_unreadable":                                                       {configType: "unreadable", wantErr: true},
 		"Error_if_file_is_not_updated":                                                      {configType: "template", wantErr: true},
@@ -241,16 +254,23 @@ func TestParseConfig(t *testing.T) {
 				require.NoError(t, err, "Setup: Failed to write drop-in file")
 			}
 
-			cfg, err := parseConfigFromPath(confPath, p)
+			configProvider := tc.provider
+			if configProvider == nil {
+				configProvider = p
+			}
+			cfg, err := parseConfigFromPath(confPath, configProvider)
 			if tc.wantErr {
 				require.Error(t, err)
+				if tc.wantErrContains != "" {
+					require.ErrorContains(t, err, tc.wantErrContains)
+				}
 				if tc.wantErrContainsDropInConfigPath {
 					require.ErrorContains(t, err, filepath.Join(dropInDir, "00-drop-in.conf"))
 				}
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, cfg.provider, p)
+			require.Equal(t, cfg.provider, configProvider)
 
 			outDir := t.TempDir()
 			// Write the names and values of all fields in the config to a file. We can't use the json or yaml
@@ -328,6 +348,40 @@ register_device = %t
 			cfg, err := parseConfig(configFile{content: []byte(config)}, nil, &testutils.MockProvider{})
 			require.NoError(t, err)
 			require.Equal(t, tc.want, cfg.flows)
+		})
+	}
+}
+
+func TestParseFlowsConfigErrorUsesProviderSupportedModes(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"all supported flows disabled": `
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+
+[flows]
+device_code = false
+entra_auth = false
+`,
+		"unsupported flow enabled": `
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+
+[flows]
+device_code = false
+entra_auth = true
+`,
+	}
+
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseConfig(configFile{content: []byte(config)}, nil, google.New())
+			require.ErrorContains(t, err, `the "device_code" flow must be enabled`)
 		})
 	}
 }

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -278,6 +278,60 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+func TestParseFlowsConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		registerDevice bool
+		omitFlows      bool
+		flows          string
+		want           flowsConfig
+	}{
+		"Entra_auth_follows_register_device_when_section_is_omitted": {
+			registerDevice: true,
+			omitFlows:      true,
+			want:           flowsConfig{DeviceAuth: true, EntraAuth: true},
+		},
+		"Entra_auth_is_disabled_when_register_device_is_disabled": {
+			omitFlows: true,
+			want:      flowsConfig{DeviceAuth: true, EntraAuth: false},
+		},
+		"Explicit_false_overrides_register_device": {
+			registerDevice: true,
+			flows:          "entra_auth = false",
+			want:           flowsConfig{DeviceAuth: true, EntraAuth: false},
+		},
+		"Explicit_true_overrides_register_device": {
+			flows: "entra_auth = true",
+			want:  flowsConfig{DeviceAuth: true, EntraAuth: true},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			flowsSection := fmt.Sprintf("\n[flows]\n%s", tc.flows)
+			if tc.omitFlows {
+				flowsSection = ""
+			}
+			config := fmt.Sprintf(`
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+
+[msentraid]
+register_device = %t
+
+%s
+`, tc.registerDevice, flowsSection)
+			cfg, err := parseConfig(configFile{content: []byte(config)}, nil, &testutils.MockProvider{})
+			require.NoError(t, err)
+			require.Equal(t, tc.want, cfg.flows)
+		})
+	}
+}
+
 var testParseUserConfigTypes = map[string]string{
 	"All_are_allowed": `
 [oidc]
@@ -610,16 +664,28 @@ func TestBrokerConfFilesHaveNoUnknownSettings(t *testing.T) {
 	t.Parallel()
 	p := &testutils.MockProvider{}
 
-	confFiles := map[string]string{
-		"google":    "../../conf/variants/google/broker.conf",
-		"msentraid": "../../conf/variants/msentraid/broker.conf",
-		"oidc":      "../../conf/variants/oidc/broker.conf",
+	confFiles := map[string]struct {
+		path      string
+		wantFlows flowsConfig
+	}{
+		"google": {
+			path:      "../../conf/variants/google/broker.conf",
+			wantFlows: defaultFlowsConfig(false),
+		},
+		"msentraid": {
+			path:      "../../conf/variants/msentraid/broker.conf",
+			wantFlows: defaultFlowsConfig(false),
+		},
+		"oidc": {
+			path:      "../../conf/variants/oidc/broker.conf",
+			wantFlows: defaultFlowsConfig(false),
+		},
 	}
 
-	for name, confFile := range confFiles {
+	for name, tc := range confFiles {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			content, err := os.ReadFile(confFile)
+			content, err := os.ReadFile(tc.path)
 			require.NoError(t, err, "Setup: Failed to read broker.conf")
 
 			// Replace template placeholders with valid dummy values so that
@@ -635,8 +701,9 @@ func TestBrokerConfFilesHaveNoUnknownSettings(t *testing.T) {
 			err = os.WriteFile(confPath, []byte(replaced), 0600)
 			require.NoError(t, err, "Setup: Failed to write config file")
 
-			_, err = parseConfigFromPath(confPath, p)
+			cfg, err := parseConfigFromPath(confPath, p)
 			require.NoError(t, err, "The %s broker.conf should not have unknown settings", name)
+			require.Equal(t, tc.wantFlows, cfg.flows, "The %s broker.conf should use the expected flow defaults", name)
 		})
 	}
 }

--- a/authd-oidc-brokers/internal/broker/export_test.go
+++ b/authd-oidc-brokers/internal/broker/export_test.go
@@ -24,7 +24,7 @@ func SetFIDODeviceWaitTimeout(d time.Duration) (restore func()) {
 
 func (cfg *Config) Init() {
 	cfg.ownerMutex = &sync.RWMutex{}
-	cfg.flows = defaultFlowsConfig()
+	cfg.flows = defaultFlowsConfig(false)
 }
 
 func (cfg *Config) SetClientID(clientID string) {
@@ -93,9 +93,10 @@ func (cfg *Config) SetAllowedSSHSuffixes(allowedSSHSuffixes []string) {
 }
 
 func (cfg *Config) SetFlows(deviceAuth, entraAuth bool) {
-	cfg.flows = defaultFlowsConfig()
-	cfg.flows.DeviceAuth = deviceAuth
-	cfg.flows.EntraAuth = entraAuth
+	cfg.flows = flowsConfig{
+		DeviceAuth: deviceAuth,
+		EntraAuth:  entraAuth,
+	}
 }
 
 func (cfg *Config) SetProvider(provider provider) {

--- a/authd-oidc-brokers/internal/broker/helper_test.go
+++ b/authd-oidc-brokers/internal/broker/helper_test.go
@@ -101,6 +101,9 @@ func newBrokerForTests(t *testing.T, cfg *brokerForTestConfig) (b *broker.Broker
 	}
 	if cfg.deviceAuthFlowDisabled || cfg.entraAuthFlowDisabled {
 		cfg.SetFlows(!cfg.deviceAuthFlowDisabled, !cfg.entraAuthFlowDisabled)
+	} else {
+		// Most broker tests exercise the authentication flows explicitly.
+		cfg.SetFlows(true, true)
 	}
 	if cfg.homeBaseDir != "" {
 		cfg.SetHomeBaseDir(cfg.homeBaseDir)

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file_with_optional_values/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file_with_optional_values/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[@issuer.url.com]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[groups offline_access some_other_scope]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_drop_in_placeholder_is_overridden_by_later_drop_in/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_drop_in_placeholder_is_overridden_by_later_drop_in/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_placeholders_are_overridden_by_drop_in/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_placeholders_are_overridden_by_drop_in/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_with_drop_in_files/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_with_drop_in_files/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[@issuer.url.com]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[groups offline_access some_other_scope]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Warns_and_uses_default_for_invalid_device_code_value/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Warns_and_uses_default_for_invalid_device_code_value/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[]
-flows={true true}
+flows={true false}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Warns_and_uses_default_for_invalid_entra_auth_flow_value/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Warns_and_uses_default_for_invalid_entra_auth_flow_value/config.txt
@@ -13,4 +13,4 @@ allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
 extraScopes=[]
-flows={true true}
+flows={true false}

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -504,20 +504,19 @@ and enters a code to complete authentication.
 :sync: msentraid
 
 The `[flows]` section of the broker configuration file controls which
-authentication flows are offered to the user at login. By default, both
-Entra authentication and device code flow
-(browser-based) are enabled.
+authentication flows are offered to the user at login.
+
+### Entra authentication flow
+
+If `entra_auth` is omitted, it follows the `register_device` setting: it is
+enabled when device registration is enabled and disabled otherwise. New Entra
+broker configurations explicitly set `entra_auth = false`. After enabling
+device registration or configuring a client secret, enable the flow explicitly:
 
 ```ini
 [flows]
-## Enable Entra authentication (default: true)
-#entra_auth = true
-
-## Enable browser-based device code flow (default: true)
-#device_code = true
+entra_auth = true
 ```
-
-### Entra authentication flow
 
 When `entra_auth` is enabled, users can sign in with their Entra ID password
 followed by an MFA challenge, such as a number-matching prompt or a one-time
@@ -541,9 +540,12 @@ this password is stored for subsequent offline logins.
 
 ### Device code flow
 
-When `device_code` is enabled, the user is presented with a device code and
-a URL to visit in a browser to complete authentication. This is the standard
-OAuth 2.0 Device Authorization Grant flow.
+The `device_code` flow is enabled by default. When it is enabled, the user is
+presented with a device code and a URL to visit in a browser to complete
+authentication. This is the standard OAuth 2.0 Device Authorization Grant flow.
+
+At least one authentication flow must be enabled. A configuration that
+explicitly disables both flows is invalid, and the broker fails to start.
 ::::
 
 ::::{tab-item} Keycloak

--- a/docs/reference/authentication-flows.md
+++ b/docs/reference/authentication-flows.md
@@ -25,9 +25,16 @@ Microsoft Entra ID supports the following authentication flows:
   For offline login, it stores only a salted hash of the Entra ID or local
   password. See [Stored secrets](/explanation/security.md#stored-secrets).
 
-Both flows are enabled by default and can be individually configured using the
-`[flows]` section of the broker configuration file. See
+The device code flow is enabled by default. If `entra_auth` is omitted, its
+default follows `register_device`: it is enabled when device registration is
+enabled and disabled otherwise. New Entra broker configurations explicitly set
+`entra_auth = false`; enable it only after enabling device registration or
+configuring a client secret. Both flows can be individually configured using
+the `[flows]` section of the broker configuration file. See
 [Configure authentication flows](ref::config-auth-flows) for details.
+
+At least one authentication flow must be enabled. A configuration that
+explicitly disables both flows is invalid, and the broker fails to start.
 
 The **Entra authentication** flow has additional requirements for resolving group
 membership, depending on whether device registration is enabled. Enabling it

--- a/docs/reference/group-management.md
+++ b/docs/reference/group-management.md
@@ -57,6 +57,6 @@ scope, so the groups are resolved in one of two ways:
   the app registration to hold the `GroupMember.Read.All` **Application**
   permission with tenant admin consent.
 
-If neither device registration nor a client secret is available, the
-**Entra authentication** flow is disabled at startup, because group membership
-could not be resolved.
+If neither device registration nor a client secret is available while the
+**Entra authentication** flow is enabled, the broker fails to start because
+group membership cannot be resolved.

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -22,39 +22,6 @@ Enable Edge Broker
     SSH.Execute    snap refresh ${BROKER_SNAP_NAME} --edge
 
 
-Disable Entra Auth Via Drop In
-    [Documentation]    Disables the Entra direct-auth flow via a drop-in, for the
-    ...                migration tests: the edge broker refuses to start when the
-    ...                flow is enabled without register_device or a client_secret,
-    ...                which the migration setup doesn't configure.
-    ...
-    ...                Must run AFTER Enable Edge Broker. The flow key was renamed
-    ...                (entra_password -> entra_auth) and the broker fails on
-    ...                unknown config keys, so the drop-in must use whichever key
-    ...                the refreshed snap understands, detected from its shipped
-    ...                config template. That template only exists after the refresh;
-    ...                writing the drop-in before it would have to guess the key.
-    ...                No-op for brokers without Entra flows.
-    # TODO(stable-release): Remove this migration-only compatibility override
-    #                       once the renamed entra_auth key is available in
-    #                       Edge and stable, so the snapshots no longer bridge
-    #                       the entra_password -> entra_auth schema transition.
-    IF    '%{BROKER}' != 'authd-msentraid'    RETURN
-    ${key} =    Run Keyword And Ignore Error    SSH.Execute
-    ...    grep -m1 -oE '^#?[[:space:]]*entra_(auth|password)[[:space:]]*=' /snap/${BROKER_SNAP_NAME}/current/conf/broker.conf.orig | grep -oE 'entra_[a-z]+'
-    Should Be Equal    ${key}[0]    PASS
-    ...    msg=No entra_auth/entra_password key found in the refreshed snap's config template
-    SSH.Execute    mkdir -p ${BROKER_CFG_DIR}
-    SSH.Execute    install -m 0600 /dev/null ${BROKER_CFG_DIR}/99-disable-entra-auth.conf
-    SSH.Execute    printf '[flows]\n%s = false\n' '${key}[1]' > ${BROKER_CFG_DIR}/99-disable-entra-auth.conf
-    # The refresh happened before the drop-in existed, so restart explicitly
-    # to make the broker re-read its configuration.
-    SSH.Execute    snap restart ${BROKER_SNAP_NAME}
-    # authd may have skipped the broker while its first post-refresh startup
-    # failed, so reload its broker manager after the override is active.
-    SSH.Execute    systemctl restart authd.service
-
-
 Disable Broker And Purge Config
     SSH.Execute    snap stop ${BROKER_SNAP_NAME}
     SSH.Execute    rm ${AUTHD_BROKER_CFG}

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -41,15 +41,6 @@ Test login after upgrading authd and broker to edge channel
     Enable Edge Broker
     Update Authd
 
-    # TODO(stable-release): Remove this temporary compatibility step together
-    #                       with the Disable Entra Auth Via Drop In keyword
-    #                       once Edge and stable use the same entra_auth key.
-    # Disable the Entra direct-auth flow on the edge broker: it refuses to
-    # start with the flow enabled but without register_device or a
-    # client_secret, which are both not configured. Must run after the
-    # refresh; see the keyword's documentation.
-    Disable Entra Auth Via Drop In
-
     # Log in with remote user with local password after upgrading
     Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -39,15 +39,6 @@ Test login with broker on edge channel
     # Switch to edge channel for the broker snap
     Enable Edge Broker
 
-    # TODO(stable-release): Remove this temporary compatibility step together
-    #                       with the Disable Entra Auth Via Drop In keyword
-    #                       once Edge and stable use the same entra_auth key.
-    # Disable the Entra direct-auth flow on the edge broker: it refuses to
-    # start with the flow enabled but without register_device or a
-    # client_secret, which are both not configured. Must run after the
-    # refresh; see the keyword's documentation.
-    Disable Entra Auth Via Drop In
-
     # Log in with remote user with local password after upgrading
     Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}

--- a/e2e-tests/vm/provision-authd.sh
+++ b/e2e-tests/vm/provision-authd.sh
@@ -222,7 +222,8 @@ function install_broker() {
 			-e "s|<ISSUER_ID>|${issuer_id}|g" \
 			-e "s|<CLIENT_ID>|${client_id}|g" \
 			-e "s|<CLIENT_SECRET>|${client_secret}|g" \
-			-e "s/^#\(entra_auth\|entra_password\) = .*/\1 = false/" \
+			-e "s/^#*device_code = .*/device_code = true/" \
+			-e "s/^#*entra_auth = .*/entra_auth = false/" \
 			/var/snap/${broker}/current/broker.conf
 		echo 'verbosity: 2' > /var/snap/${broker}/current/${broker}.yaml
 		systemctl restart authd.service


### PR DESCRIPTION
## Summary

After an upgrade, a broker configuration that omits `[flows]` can fail to
start when the old implicit `entra_auth` default is unusable: `register_device`
is disabled and no client secret is configured.

This change:

- Keeps `device_code` enabled when it is omitted, preserving stable login
  behavior.
- Derives omitted `entra_auth` from `register_device`: it is enabled when
  device registration is enabled and disabled otherwise.
- Ships new Entra templates with explicit `entra_auth = false`.
- Keeps configurations that explicitly disable both flows invalid.
- Covers stable-to-edge migrations and documents the compatibility behavior.
- Keeps migration e2e tests working with the released edge broker by disabling
  its legacy `entra_password` flow after refresh and restarting `authd` so its
  broker manager re-discovers the repaired broker; remove this shim once edge
  uses `entra_auth`.

Existing configurations that omit `entra_auth` and have `register_device = true`
retain the Entra flow. Configurations that relied only on a client secret must
explicitly set `entra_auth = true`.

Google IAM and generic OIDC continue to use the device-code default without a
`[flows]` section. The D-Bus and API surfaces are unchanged.

Closes #1764

UDENG-11238
