### PR TITLE
Prevent YARF build/runtime pywayland mismatch

### DIFF
--- a/e2e-tests/setup-yarf.sh
+++ b/e2e-tests/setup-yarf.sh
@@ -18,6 +18,31 @@ fi
 
 # Set up YARF in a virtual environment using uv
 cd "$YARF_DIR"
+
+# YARF generates Wayland bindings while it is built. Hatch uses an isolated
+# environment for this step, so its unpinned pywayland build dependency can
+# differ from the version installed for runtime from uv.lock. Newer
+# pywayland releases can generate bindings that are incompatible with older
+# runtime releases. That mismatch makes YARF fail while importing generated
+# code. Constrain the build dependency to the lockfile version so generated
+# code and runtime code always use the same pywayland API.
+PYWAYLAND_VERSION=$(
+    awk '
+        /^\[\[package\]\]$/ { in_package = 0 }
+        /^name = "pywayland"$/ { in_package = 1; next }
+        in_package && /^version = / {
+            gsub(/"/, "", $3)
+            print $3
+            exit
+        }
+    ' uv.lock
+)
+: "${PYWAYLAND_VERSION:?Could not find pywayland in uv.lock}"
+BUILD_CONSTRAINTS_FILE=$(mktemp)
+trap 'rm -f "$BUILD_CONSTRAINTS_FILE"' EXIT
+printf 'pywayland==%s\n' "$PYWAYLAND_VERSION" > "$BUILD_CONSTRAINTS_FILE"
+export UV_BUILD_CONSTRAINT="$BUILD_CONSTRAINTS_FILE"
+
 uv sync
 uv pip install '.[develop]'
 # We need pygobject in the Python environment for some tests


### PR DESCRIPTION
YARF generated Wayland bindings in an isolated build with the latest pywayland, while its locked runtime used 0.4.18. Constrain build dependencies from uv.lock so generated classes match runtime imports.

Fixes #1800