### PR TITLE
ci: stop rewriting cached Debian OCI artifacts

### DIFF
--- a/.github/workflows/build-broker-snap.yaml
+++ b/.github/workflows/build-broker-snap.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Name of the broker snap to build'
         required: true
         type: string
+    outputs:
+      files-hash:
+        description: 'Hash of files that affect the broker snap build'
+        value: ${{ jobs.build-broker-snap.outputs.files-hash }}
 
 jobs:
   build-broker-snap:
@@ -17,6 +21,8 @@ jobs:
       contents: read
       # Needed to push/pull OCI artifact to/from ghcr.io
       packages: write
+    outputs:
+      files-hash: ${{ steps.files-hash.outputs.hash }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -82,17 +88,14 @@ jobs:
         run: mv "${{ steps.build-broker-snap.outputs.snap }}" "${{ inputs.broker }}.snap"
 
       - name: Upload snap as OCI artifact
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: |-
           set -euo pipefail
 
-          # Upload the snap to the OCI registry with the following tags:
-          # - The current commit hash. This is used by subsequent workflows to
-          #   download the snap for this run.
-          # - The hash of the files that affect the build. This allows us to
-          #   use it as a cache key, avoiding unnecessary rebuilds.
+          # Upload the snap under the hash of the files that affect the build.
+          # Subsequent jobs use this content-addressed tag to download it.
           OCI_REPO=ghcr.io/${{ github.repository }}/${{ inputs.broker }}-snap
           OCI_TAG=${{ steps.files-hash.outputs.hash }}
           oras push "${OCI_REPO}:${OCI_TAG}" \
             "${{ inputs.broker }}.snap" \
             --artifact-type application/vnd.snap
-          oras tag "${OCI_REPO}:${OCI_TAG}" "${{ github.sha }}"

--- a/.github/workflows/debian-build-test-and-sync.yaml
+++ b/.github/workflows/debian-build-test-and-sync.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       files-hash:
-        description: 'Hash of build-relevant files, used as cache key and concurrency group'
+        description: 'Hash of build-relevant files, used as OCI artifact tag and cache key'
         type: string
         required: true
       ubuntu-version:
@@ -52,7 +52,7 @@ jobs:
       - name: Download the Debian sources
         env:
           OCI_REPO: ghcr.io/${{ github.repository }}/authd-deb-sources-${{ inputs.ubuntu-version }}
-          OCI_TAG: ${{ github.sha }}
+          OCI_TAG: ${{ inputs.files-hash }}
         run: |
           set -euo pipefail
 
@@ -94,7 +94,7 @@ jobs:
       - name: Download the Debian sources
         env:
           OCI_REPO: ghcr.io/${{ github.repository }}/authd-deb-sources-${{ inputs.ubuntu-version }}
-          OCI_TAG: ${{ github.sha }}
+          OCI_TAG: ${{ inputs.files-hash }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       files-hash:
-        description: 'Hash of build-relevant files, used as cache key'
+        description: 'Hash of build-relevant files, used as OCI artifact tag and cache key'
         type: string
         required: true
       ubuntu-version:
@@ -237,14 +237,18 @@ jobs:
           echo "PKG_TARBALL=${PKG_TARBALL}" >> ${GITHUB_ENV}
 
       - name: Upload deb and sources as OCI artifacts
-        # Skip if the PR is from a fork, as we don't have the permission to
-        # upload to the OCI registry.
+        # Skip if the artifact was restored from the cache or if the PR is
+        # from a fork, as we don't have permission to upload to the OCI
+        # registry.
         if: >-
-          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-          github.event_name == 'push' ||
-          github.event_name == 'release' ||
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch'
+          steps.restore-cache.outputs.cache-hit != 'true' &&
+          (
+            (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+            github.event_name == 'push' ||
+            github.event_name == 'release' ||
+            github.event_name == 'schedule' ||
+            github.event_name == 'workflow_dispatch'
+          )
         run: |
           set -euo pipefail
           set -x
@@ -256,7 +260,6 @@ jobs:
             --artifact-type=application/vnd.debian.binary-package \
             --annotation "org.opencontainers.image.title=authd debian package" \
             --annotation "org.opencontainers.image.version=${{ env.PKG_VERSION }}"
-          oras tag "${OCI_REPO}:${OCI_TAG}" "${{ github.sha }}"
           rm "${{ env.PKG_DEB }}"
 
           OCI_REPO=ghcr.io/${{ github.repository }}/authd-deb-sources-${{ inputs.ubuntu-version }}
@@ -267,7 +270,6 @@ jobs:
             --artifact-type=application/vnd.debian.source-package \
             --annotation "org.opencontainers.image.title=authd source debian package" \
             --annotation "org.opencontainers.image.version=${{ env.PKG_VERSION }}"
-          oras tag "${OCI_REPO}:${OCI_TAG}" "${{ github.sha }}"
           rm "${{ env.PKG_DSC }}" \
              "${{ env.PKG_SOURCE_CHANGES }}" \
              "${{ env.PKG_TARBALL }}"

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       files-hash:
-        description: 'Hash of build-relevant files, used as cache key and concurrency group'
+        description: 'Hash of build-relevant files, used as OCI artifact tag and cache key'
         type: string
         required: true
       ubuntu-version:
@@ -177,6 +177,7 @@ jobs:
     with:
       ubuntu-version: ${{ inputs.ubuntu-version }}
       broker: ${{ matrix.broker }}
+      files-hash: ${{ inputs.files-hash }}
       broker-snap-channel: ${{ inputs.broker-snap-channel }}
       authd-ppa: ${{ inputs.authd-ppa }}
       e2e-tests: ${{ inputs.e2e-tests }}

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -143,6 +143,14 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+          if [ "${{ steps.restore-cache.outputs.cache-hit }}" = "true" ]; then
+            if oras manifest fetch --descriptor "${OCI_REPO}:${OCI_TAG}" >/dev/null; then
+              echo "VM image already exists in the OCI registry; skipping upload."
+              exit 0
+            fi
+            echo "VM image is not in the OCI registry; uploading the cached image."
+          fi
+
           # Push the qcow2 as a single layer. It used to be split into
           # many small chunks hoping unchanged chunks would be deduped
           # and skipped, but in practice each provisioning run bakes in

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -9,6 +9,10 @@ on:
       broker:
         required: true
         type: string
+      files-hash:
+        description: 'Hash of build-relevant files used to find the Debian artifact'
+        required: true
+        type: string
       broker-snap-channel:
         description: 'If set, download the broker snap from this Snap Store channel instead of building it from source'
         required: false
@@ -133,7 +137,7 @@ jobs:
         id: download-authd-deb
         env:
           OCI_REPO: ghcr.io/${{ github.repository }}/authd-deb-${{ inputs.ubuntu-version }}
-          OCI_TAG: ${{ github.sha }}
+          OCI_TAG: ${{ inputs.files-hash }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -113,7 +113,7 @@ jobs:
         if: inputs.broker-snap-channel == ''
         env:
           OCI_REPO: ghcr.io/${{ github.repository }}/${{ inputs.broker }}-snap
-          OCI_TAG: ${{ github.sha }}
+          OCI_TAG: ${{ needs.build-broker-snap.outputs.files-hash }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Avoid rewriting OCI artifacts, which creates extra GHCR versions and races with other workflows.

Closes #1806

e2e-tests: allowed_users.robot
e2e-brokers: msentraid