### PR TITLE
msentraid: show MFA digit to enter in dedicated label in polkit dialog

### DIFF
--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -154,7 +154,7 @@ func TestNativeAuthenticate(t *testing.T) {
 			},
 			test: func(t *testing.T, c *ptytest.Console) {
 				t.Helper()
-				c.WaitFor(t, `Gimme your password:`)
+				c.WaitFor(t, `Gimme your password`)
 				c.SendLine(t, "goodpass")
 				nativeWaitForResult(t, c)
 			},
@@ -231,7 +231,7 @@ func TestNativeAuthenticate(t *testing.T) {
 			clientOptions: clientOptions{PamServiceName: "polkit-1"},
 			test: func(t *testing.T, c *ptytest.Console) {
 				t.Helper()
-				c.WaitFor(t, `Gimme your password:`)
+				c.WaitFor(t, `Gimme your password`)
 				c.SendLine(t, "r")
 				c.WaitFor(t, `Choose your authentication flow:`)
 				sendEchoedLine(t, c, "7")
@@ -239,7 +239,7 @@ func TestNativeAuthenticate(t *testing.T) {
 				sendEchoedLine(t, c, "2")
 				c.WaitFor(t, `Choose action:`)
 				sendEchoedLine(t, c, "1")
-				c.WaitFor(t, `Enter your one time credential:`)
+				c.WaitFor(t, `Enter your one time credential`)
 				sendEchoedLine(t, c, "temporary pass00")
 				nativeWaitForResult(t, c)
 			},
@@ -326,7 +326,7 @@ func TestNativeAuthenticate(t *testing.T) {
 				for _, username := range []string{upper, mixed} {
 					ctx.run(t, nativePtySessionSpec{action: pam_test.RunnerActionLogin, username: username}, func(t *testing.T, c *ptytest.Console) {
 						t.Helper()
-						nativeWaitForLoginPasswordPrompt(t, c)
+						nativeWaitForLoginPasswordPrompt(t, c, `Gimme your password:`)
 						c.SendLine(t, "authd2404")
 						nativeWaitForResult(t, c)
 					})
@@ -871,7 +871,7 @@ func TestNativeChangeAuthTok(t *testing.T) {
 			expectedUser: testUserNameFull(t, examplebroker.UserIntegrationAuthModesPrefix, "password,mandatoryreset-integration-polkit"),
 			test: func(t *testing.T, c *ptytest.Console) {
 				t.Helper()
-				c.WaitFor(t, `Gimme your password:`)
+				c.WaitFor(t, `Gimme your password`)
 				c.SendLine(t, "goodpass")
 				nativeChangePassword(t, c, "authd2404", "authd2404")
 				nativeWaitForChangeAuthTokResult(t, c)
@@ -880,7 +880,7 @@ func TestNativeChangeAuthTok(t *testing.T) {
 				t.Helper()
 				ctx.run(t, nativePtySessionSpec{action: pam_test.RunnerActionLogin, clientOptions: ctx.baseSpec.clientOptions}, func(t *testing.T, c *ptytest.Console) {
 					t.Helper()
-					nativeWaitForLoginPasswordPrompt(t, c)
+					nativeWaitForLoginPasswordPrompt(t, c, `Gimme your password`)
 					c.SendLine(t, "authd2404")
 					nativeWaitForResult(t, c)
 				})
@@ -1090,7 +1090,7 @@ func nativeReloginAfterPasswordChange(t *testing.T, ctx *nativePtyTestContext) {
 	t.Helper()
 	ctx.run(t, nativePtySessionSpec{action: pam_test.RunnerActionLogin, username: ctx.baseSpec.username}, func(t *testing.T, c *ptytest.Console) {
 		t.Helper()
-		nativeWaitForLoginPasswordPrompt(t, c)
+		nativeWaitForLoginPasswordPrompt(t, c, `Gimme your password:`)
 		c.SendLine(t, "authd2404")
 		nativeWaitForResult(t, c)
 	})
@@ -1151,13 +1151,16 @@ func nativeChangePassword(t *testing.T, c *ptytest.Console, newPassword string, 
 	c.SendLine(t, confirm)
 }
 
-func nativeWaitForLoginPasswordPrompt(t *testing.T, c *ptytest.Console) {
+// nativeWaitForLoginPasswordPrompt waits for the login password prompt.
+// Pass a colon-less pattern for the polkit service's blanked-out prompt
+// (see nativemodel.go's polkitServiceName handling).
+func nativeWaitForLoginPasswordPrompt(t *testing.T, c *ptytest.Console, passwordPrompt string) {
 	t.Helper()
 
-	matched := c.WaitFor(t, `Choose your provider:|Gimme your password:`)
+	matched := c.WaitFor(t, `Choose your provider:|`+passwordPrompt)
 	if strings.Contains(matched, `Choose your provider:`) {
 		sendEchoedLine(t, c, "2")
-		c.WaitFor(t, `Gimme your password:`)
+		c.WaitFor(t, passwordPrompt)
 	}
 }
 

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method_in_polkit
@@ -1,4 +1,5 @@
-Gimme your password:
+Gimme your password
+
 >
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
@@ -1,5 +1,7 @@
+Gimme your password
+
 Enter 'r' to cancel the request and go back to select the authentication flow
-Gimme your password:
+
 >
   1. Password authentication
   2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@example.com
@@ -20,8 +22,10 @@ Choose action:
 Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
+Enter your one time credential
+
 Enter 'r' to cancel the request and go back to select the authentication flow
-Enter your one time credential:
+
 > temporary pass00
   PAM_AUTHTOK: "temporary pass00"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
@@ -1,4 +1,5 @@
-Gimme your password:
+Gimme your password
+
 >
 Enter your new password:
 >
@@ -10,8 +11,10 @@ PAM ChangeAuthTok()
   User: "user-auth-modes-password,mandatoryreset-integration-polkit-testnativechangeauthtok@example.com"
   Result: success
 
+Gimme your password
+
 Enter 'r' to cancel the request and go back to select the authentication flow
-Gimme your password:
+
 >
   PAM_AUTHTOK: "authd2404"
 PAM Authenticate()

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -43,6 +43,10 @@ const (
 	nativeCancelKey = "r"
 
 	polkitServiceName = "polkit-1"
+	// prompt that will appear in polkit agents when the user is expected to enter a password.
+	// This is a workaround for polkit agents that keep the previous input hint visible even when not expecting user input, which can be confusing.
+	// By using a blank prompt, we avoid showing any misleading hints.
+	polkitBlankPrompt = " "
 )
 
 type inputPromptStyle int
@@ -370,7 +374,11 @@ func (m nativeModel) promptForInput(style pam.Style, inputStyle inputPromptStyle
 		case inputPromptStyleInline:
 			format = "%s: "
 		case inputPromptStyleMultiLine:
-			format = "%s:\n> "
+			if m.serviceName == polkitServiceName && prompt == polkitBlankPrompt {
+				format = "%s\n> "
+			} else {
+				format = "%s:\n> "
+			}
 		}
 	}
 
@@ -654,6 +662,17 @@ func (m nativeModel) handleFormChallenge(hasWait bool) tea.Cmd {
 		})
 	}
 
+	// For wait-only forms (no entry field), display the message and wait for authentication without prompting for user input.
+	// Input text box is still present but not interactable (cannot be removed due to GNOME shell limitation)
+	// This is used for MFA challenges as in MS Entra flow where the user has to approve the sign-in in their authenticator app.
+	if m.serviceName == polkitServiceName && hasWait && m.uiLayout.GetEntry() == "" {
+		info := m.formatInfo(authMode, prompt)
+		if cmd := maybeSendPamError(m.sendInfo(info)); cmd != nil {
+			return cmd
+		}
+		return sendAuthWaitCommand()
+	}
+
 	var instructions string
 	if m.canGoBack() {
 		instructions = "Enter '%[1]s' to cancel the request and %[2]s"
@@ -674,6 +693,19 @@ func (m nativeModel) handleFormChallenge(hasWait bool) tea.Cmd {
 	if goBackLabel := m.goBackActionLabel(); goBackLabel != "" {
 		instructions = fmt.Sprintf(instructions, nativeCancelKey, m.goBackActionLabel())
 	}
+
+	if m.serviceName == polkitServiceName {
+		// Polkit agents keep the previous input hint visible while showing
+		// information messages. Keep that hint blank and show the form label
+		// as information instead.
+		if instructions == "" {
+			instructions = prompt
+		} else {
+			instructions = fmt.Sprintf("%s\n\n%s", prompt, instructions)
+		}
+		prompt = polkitBlankPrompt
+	}
+
 	info := m.formatInfo(authMode, instructions)
 	if cmd := maybeSendPamError(m.sendInfo(info)); cmd != nil {
 		return cmd

--- a/pam/internal/adapter/nativemodel_test.go
+++ b/pam/internal/adapter/nativemodel_test.go
@@ -1,10 +1,40 @@
 package adapter
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/canonical/authd/internal/brokers/layouts"
+	"github.com/canonical/authd/internal/brokers/layouts/entries"
+	"github.com/canonical/authd/internal/proto/authd"
+	"github.com/canonical/authd/pam/internal/pam_test"
+	"github.com/canonical/authd/pam/internal/proto"
+	"github.com/msteinert/pam/v2"
 	"github.com/stretchr/testify/require"
 )
+
+// recordedConv is one recorded call to [recordingConvHandler.RespondPAM].
+type recordedConv struct {
+	style  pam.Style
+	prompt string
+}
+
+// recordingConvHandler is a [pam.ConversationHandler] double that records
+// every text conversation call it receives and replies with a canned value.
+type recordingConvHandler struct {
+	calls []recordedConv
+	reply string
+	err   error
+}
+
+func (h *recordingConvHandler) RespondPAM(style pam.Style, prompt string) (string, error) {
+	h.calls = append(h.calls, recordedConv{style, prompt})
+	return h.reply, h.err
+}
+
+func (h *recordingConvHandler) RespondPAMBinary(pam.BinaryPointer) (pam.BinaryPointer, error) {
+	return nil, errors.New("binary conversation not supported in this test")
+}
 
 func TestNativeModelFormatInfo(t *testing.T) {
 	t.Parallel()
@@ -42,6 +72,152 @@ func TestNativeModelFormatInfo(t *testing.T) {
 
 			m := nativeModel{serviceName: tc.serviceName}
 			require.Equal(t, tc.want, m.formatInfo(tc.title, tc.message))
+		})
+	}
+}
+
+func TestNativeModelHandleFormChallenge(t *testing.T) {
+	t.Parallel()
+
+	const waitLabel = "Open your Authenticator app, and enter the number '60' to sign in."
+
+	tests := map[string]struct {
+		label                string
+		entry                string
+		hasWait              bool
+		serviceName          string
+		userSelectionAllowed bool
+		currentStage         proto.Stage
+		convReply            string
+		convErr              error
+
+		wantCallStyles []pam.Style
+		wantInfoMsg    string
+		wantPrompt     string
+		wantWait       bool
+		wantSecret     string
+		wantPamError   bool
+	}{
+		"Wait_only_form_sends_info_and_waits_without_prompting": {
+			label:          waitLabel,
+			hasWait:        true,
+			serviceName:    polkitServiceName,
+			wantCallStyles: []pam.Style{pam.TextInfo},
+			wantInfoMsg:    waitLabel,
+			wantWait:       true,
+		},
+		"Wait_only_form_with_go_back_available_still_waits": {
+			label:                waitLabel,
+			hasWait:              true,
+			serviceName:          polkitServiceName,
+			userSelectionAllowed: true,
+			currentStage:         proto.Stage_challenge,
+			wantCallStyles:       []pam.Style{pam.TextInfo},
+			wantInfoMsg:          waitLabel,
+			wantWait:             true,
+		},
+		"Wait_only_form_on_native_falls_back_to_prompting_for_empty_response": {
+			label:          waitLabel,
+			hasWait:        true,
+			wantCallStyles: []pam.Style{pam.TextInfo, pam.PromptEchoOn},
+			wantInfoMsg:    "Press Enter to wait for authentication",
+			wantWait:       true,
+		},
+		"Form_with_entry_and_wait_still_prompts_for_secret": {
+			label:          "Enter your password",
+			entry:          entries.CharsPassword,
+			hasWait:        true,
+			convReply:      "hunter2",
+			wantCallStyles: []pam.Style{pam.TextInfo, pam.PromptEchoOff},
+			wantSecret:     "hunter2",
+		},
+		"Polkit_form_shows_label_as_info_and_keeps_input_hint_empty": {
+			label:          "Enter your Entra ID password",
+			entry:          entries.CharsPassword,
+			serviceName:    polkitServiceName,
+			convReply:      "hunter2",
+			wantCallStyles: []pam.Style{pam.TextInfo, pam.PromptEchoOff},
+			wantInfoMsg:    "Enter your Entra ID password",
+			wantPrompt:     " \n> ",
+			wantSecret:     "hunter2",
+		},
+		"SendInfo_error_is_propagated_instead_of_waiting": {
+			label:          waitLabel,
+			hasWait:        true,
+			convErr:        errors.New("conversation boom"),
+			wantCallStyles: []pam.Style{pam.TextInfo},
+			wantPamError:   true,
+		},
+		"Wait_only_form_on_polkit_sendInfo_error_returns_pam_error": {
+			label:          waitLabel,
+			hasWait:        true,
+			serviceName:    polkitServiceName,
+			convErr:        errors.New("conversation boom"),
+			wantCallStyles: []pam.Style{pam.TextInfo},
+			wantPamError:   true,
+		},
+		"Missing_label_returns_pam_error_without_any_conversation": {
+			label:          "",
+			hasWait:        true,
+			wantCallStyles: nil,
+			wantPamError:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := &recordingConvHandler{reply: tc.convReply, err: tc.convErr}
+			m := nativeModel{
+				pamMTx:               pam_test.NewModuleTransactionDummy(handler),
+				serviceName:          tc.serviceName,
+				interactive:          true,
+				userSelectionAllowed: tc.userSelectionAllowed,
+				currentStage:         tc.currentStage,
+				uiLayout: &authd.UILayout{
+					Type:  layouts.Form,
+					Label: &tc.label,
+					Entry: &tc.entry,
+				},
+			}
+
+			cmd := m.handleFormChallenge(tc.hasWait)
+			require.NotNil(t, cmd)
+			msg := cmd()
+
+			var gotStyles []pam.Style
+			for _, c := range handler.calls {
+				gotStyles = append(gotStyles, c.style)
+			}
+			require.Equal(t, tc.wantCallStyles, gotStyles)
+
+			if tc.wantInfoMsg != "" {
+				require.Contains(t, handler.calls[0].prompt, tc.wantInfoMsg)
+			}
+			if tc.wantPrompt != "" {
+				require.Equal(t, tc.wantPrompt, handler.calls[len(handler.calls)-1].prompt)
+			}
+
+			switch {
+			case tc.wantPamError:
+				_, ok := msg.(pamError)
+				require.True(t, ok, "want a pamError, got %#v", msg)
+
+			case tc.wantWait:
+				gotEvent, ok := msg.(isAuthenticatedRequested)
+				require.True(t, ok, "want isAuthenticatedRequested, got %#v", msg)
+				waitItem, ok := gotEvent.item.(*authd.IARequest_AuthenticationData_Wait)
+				require.True(t, ok, "want a Wait authentication item, got %#v", gotEvent.item)
+				require.Equal(t, layouts.True, waitItem.Wait)
+
+			case tc.wantSecret != "":
+				gotEvent, ok := msg.(isAuthenticatedRequested)
+				require.True(t, ok, "want isAuthenticatedRequested, got %#v", msg)
+				secretItem, ok := gotEvent.item.(*authd.IARequest_AuthenticationData_Secret)
+				require.True(t, ok, "want a Secret authentication item, got %#v", gotEvent.item)
+				require.Equal(t, tc.wantSecret, secretItem.Secret)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Issue:
While trying to authenticate with Microsoft Entra password in a polkit dialog the message containing the digit to be used in the Authenticator app is written inside a input text box. As result of this, the digit is not readable.

Proposed solution:
Move the message to a show label so that it is correctly fully displayed.

Known limitations:
authd has no way to tell the agent how to build the UI and can only feed information. Therefore the input box used to insert the Entra password will be present even while waiting for the MFA challenge. It is to be considered that the input text box is not interactable in this phase and it could be used again by the user only when the MFA challenge fails.

Closes #1697 

UDENG-10996