### PR TITLE
e2e-tests: test entra + MFA authentication for GDM and polkit

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -340,6 +340,29 @@ Continue Log In With Remote User Through GDM: Define Local Password
     Wait Until Desktop Ready
 
 
+Log In With Remote User Through GDM: Entra Password
+    [Arguments]    ${username}
+    Start Log In With Remote User Through GDM: QR Code    ${username}
+    Select Broker Through GDM
+    Continue Log In With Remote User Through GDM: Entra Password
+
+
+Continue Log In With Remote User Through GDM: Entra Password
+    # With the device code flow disabled there is only one flow; the PAM module
+    # auto-selects it and goes directly to the Entra ID password prompt.
+    Match Text    Enter your Entra ID password:    30    similarity=90
+    Hid.Type String    %{E2E_PASSWORD}
+    Hid.Keys Combo    Return
+
+    # Wait for the MFA code prompt and enter a fresh TOTP code.
+    Match Text    Enter your MFA code:    120    similarity=88
+    ${totp_code} =    TOTP.Generate Totp Code
+    Hid.Type String    ${totp_code}
+    Hid.Keys Combo    Return
+
+    Wait Until Desktop Ready
+
+
 Log In With Remote User Through GDM: Local Password
     [Arguments]    ${username}    ${local_password}
     Wait Until GDM Login Screen Ready
@@ -490,3 +513,28 @@ Log In With Remote User Through CLI: Entra Passwordless TAP
 
     # No cached Entra password: chain into newpassword to set a local one.
     Continue Log In With Remote User Through CLI: Define Local Password    ${username}    ${local_password}
+
+Log In With Remote User Through Polkit: Entra Password
+    [Arguments]    ${username}
+
+    # Polkit auto-selects authentication via local password.
+    # Cancel it ('r') to go back to the authentication-flow menu and choose the
+    # Entra ID password + MFA flow instead.
+    Match Text    Enter your password    30
+    Hid.Type String    r
+    Hid.Keys Combo    Return
+
+    Match Text    Choose your authentication flow    30
+    Match Text    2. Entra ID authentication    15
+    Hid.Type String    2
+    Hid.Keys Combo    Return
+
+    Match Text    Enter your Entra ID password:    30    similarity=90
+    Hid.Type String    %{E2E_PASSWORD}
+    Hid.Keys Combo    Return
+
+    Match Text    Enter your MFA code:    30    similarity=88
+    ${totp_code} =    TOTP.Generate Totp Code
+    Hid.Type String    ${totp_code}
+    Hid.Keys Combo    Return
+    Match Text    @ubuntu:~$    10

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -301,13 +301,13 @@ Log In With Remote User Through SSH: Local Password
 
 Log In With Remote User Through GDM: QR Code
     [Arguments]    ${username}    ${local_password}
-    Start Log In With Remote User Through GDM: QR Code    ${username}
+    Start Log In With Remote User Through GDM    ${username}
     Select Broker Through GDM
     Continue Log In With Remote User: Authenticate In External Browser
     Continue Log In With Remote User Through GDM: Define Local Password    ${local_password}
 
 
-Start Log In With Remote User Through GDM: QR Code
+Start Log In With Remote User Through GDM
     [Arguments]    ${username}
     Wait Until GDM Login Screen Ready
     Move Pointer To Not listed
@@ -342,7 +342,7 @@ Continue Log In With Remote User Through GDM: Define Local Password
 
 Log In With Remote User Through GDM: Entra Password
     [Arguments]    ${username}
-    Start Log In With Remote User Through GDM: QR Code    ${username}
+    Start Log In With Remote User Through GDM    ${username}
     Select Broker Through GDM
     Continue Log In With Remote User Through GDM: Entra Password
 

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -326,6 +326,18 @@ Select Broker Through GDM
     Left Button Click
     Builtin.Sleep    1
 
+Enter Entra ID Password And MFA
+    # With the device code flow disabled there is only one flow; the PAM module
+    # auto-selects it and goes directly to the Entra ID password prompt.
+    Match Text    Enter your Entra ID password    30    similarity=90
+    Hid.Type String    %{E2E_PASSWORD}
+    Hid.Keys Combo    Return
+
+    # Wait for the MFA code prompt and enter a fresh TOTP code.
+    Match Text    Enter your MFA code    30    similarity=88
+    ${totp_code} =    TOTP.Generate Totp Code
+    Hid.Type String    ${totp_code}
+    Hid.Keys Combo    Return
 
 Continue Log In With Remote User Through GDM: Define Local Password
     [Arguments]    ${local_password}
@@ -348,17 +360,7 @@ Log In With Remote User Through GDM: Entra Password
 
 
 Continue Log In With Remote User Through GDM: Entra Password
-    # With the device code flow disabled there is only one flow; the PAM module
-    # auto-selects it and goes directly to the Entra ID password prompt.
-    Match Text    Enter your Entra ID password    30    similarity=90
-    Hid.Type String    %{E2E_PASSWORD}
-    Hid.Keys Combo    Return
-
-    # Wait for the MFA code prompt and enter a fresh TOTP code.
-    Match Text    Enter your MFA code    30    similarity=88
-    ${totp_code} =    TOTP.Generate Totp Code
-    Hid.Type String    ${totp_code}
-    Hid.Keys Combo    Return
+    Enter Entra ID Password And MFA
 
     Wait Until Desktop Ready
 
@@ -474,17 +476,7 @@ Log In With Remote User Through CLI: Entra Auth
     Match Text    2. ${PROVIDER_DISPLAY_NAME}
     Hid.Type String    2
 
-    # With the device code flow disabled there is only one flow; the PAM module
-    # auto-selects it and goes directly to the Entra ID password prompt.
-    Match Text    Enter your Entra ID password:    30    similarity=90
-    Hid.Type String    %{E2E_PASSWORD}
-    Hid.Keys Combo    Return
-
-    # Wait for the MFA code prompt and enter a fresh TOTP code.
-    Match Text    Enter your MFA code    30    similarity=88
-    ${totp_code} =    TOTP.Generate Totp Code
-    Hid.Type String    ${totp_code}
-    Hid.Keys Combo    Return
+    Enter Entra ID Password And MFA
 
     # Wait for the authenticated shell prompt.
     Match Text    ${username}@ubuntu:~$    30
@@ -529,12 +521,5 @@ Log In With Remote User Through Polkit: Entra Password
     Hid.Type String    2
     Hid.Keys Combo    Return
 
-    Match Text    Enter your Entra ID password    30    similarity=90
-    Hid.Type String    %{E2E_PASSWORD}
-    Hid.Keys Combo    Return
-
-    Match Text    Enter your MFA code    30    similarity=88
-    ${totp_code} =    TOTP.Generate Totp Code
-    Hid.Type String    ${totp_code}
-    Hid.Keys Combo    Return
+    Enter Entra ID Password And MFA
     Match Text    @ubuntu:~$    10

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -350,12 +350,12 @@ Log In With Remote User Through GDM: Entra Password
 Continue Log In With Remote User Through GDM: Entra Password
     # With the device code flow disabled there is only one flow; the PAM module
     # auto-selects it and goes directly to the Entra ID password prompt.
-    Match Text    Enter your Entra ID password:    30    similarity=90
+    Match Text    Enter your Entra ID password    30    similarity=90
     Hid.Type String    %{E2E_PASSWORD}
     Hid.Keys Combo    Return
 
     # Wait for the MFA code prompt and enter a fresh TOTP code.
-    Match Text    Enter your MFA code:    120    similarity=88
+    Match Text    Enter your MFA code    30    similarity=88
     ${totp_code} =    TOTP.Generate Totp Code
     Hid.Type String    ${totp_code}
     Hid.Keys Combo    Return
@@ -481,13 +481,13 @@ Log In With Remote User Through CLI: Entra Auth
     Hid.Keys Combo    Return
 
     # Wait for the MFA code prompt and enter a fresh TOTP code.
-    Match Text    Enter your MFA code:    120    similarity=88
+    Match Text    Enter your MFA code    30    similarity=88
     ${totp_code} =    TOTP.Generate Totp Code
     Hid.Type String    ${totp_code}
     Hid.Keys Combo    Return
 
     # Wait for the authenticated shell prompt.
-    Match Text    ${username}@ubuntu:~$    120
+    Match Text    ${username}@ubuntu:~$    30
 
 
 Log In With Remote User Through CLI: Entra Passwordless TAP
@@ -529,11 +529,11 @@ Log In With Remote User Through Polkit: Entra Password
     Hid.Type String    2
     Hid.Keys Combo    Return
 
-    Match Text    Enter your Entra ID password:    30    similarity=90
+    Match Text    Enter your Entra ID password    30    similarity=90
     Hid.Type String    %{E2E_PASSWORD}
     Hid.Keys Combo    Return
 
-    Match Text    Enter your MFA code:    30    similarity=88
+    Match Text    Enter your MFA code    30    similarity=88
     ${totp_code} =    TOTP.Generate Totp Code
     Hid.Type String    ${totp_code}
     Hid.Keys Combo    Return

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -417,11 +417,11 @@ Check That Login Is Handled By PAM Unix
 
 
 Check If User Was Added Properly
-    [Arguments]    ${username}
+    [Arguments]    ${username}    ${password}=${local_password}
     Wait Until Keyword Succeeds    30s    1s    Check User Information    ${username}
     IF    '${BROKER_SNAP_NAME}' == 'authd-msentraid'
         Wait Until Keyword Succeeds    120s    1s    Check User Groups    ${username}    ${remote_group}
-        Check That Remote User Can Run Sudo Commands    ${local_password}
+        Check That Remote User Can Run Sudo Commands    ${password}
     END
 
 Check User Groups

--- a/e2e-tests/tests/broker_disabled.robot
+++ b/e2e-tests/tests/broker_disabled.robot
@@ -22,7 +22,7 @@ Test that disabling broker prevents remote logins
     Disable Broker And Purge Config
 
     # Check that remote user is redirected to local broker when trying to log in through GDM
-    Start Log In With Remote User Through GDM: QR Code    ${username}
+    Start Log In With Remote User Through GDM    ${username}
     Check That User Is Redirected To Local Broker
     Escape Back to GDM Login Screen
 

--- a/e2e-tests/tests/login_entra_auth.robot
+++ b/e2e-tests/tests/login_entra_auth.robot
@@ -59,5 +59,6 @@ Test GDM login with Entra ID password and MFA
     ...    Entra ID password + MFA flow
 
     Log In With Remote User Through GDM: Entra Password    ${username}
+    Check If User Was Added Properly    ${username}
 
     Wait Until Keyword Succeeds    30s    3s    Check Home Directory    ${username}

--- a/e2e-tests/tests/login_entra_auth.robot
+++ b/e2e-tests/tests/login_entra_auth.robot
@@ -53,3 +53,11 @@ Test login with CLI using Entra auth and MFA
     # Verify the user was provisioned in the system.  NSS may be briefly
     # unavailable while authd commits the new user record, so retry.
     Wait Until Keyword Succeeds    30s    3s    Check Home Directory    ${username}
+
+Test GDM login with Entra ID password and MFA
+    [Documentation]    Verify that a user can log in via GDM using the direct
+    ...    Entra ID password + MFA flow
+
+    Log In With Remote User Through GDM: Entra Password    ${username}
+
+    Wait Until Keyword Succeeds    30s    3s    Check Home Directory    ${username}

--- a/e2e-tests/tests/polkit_pkexec.robot
+++ b/e2e-tests/tests/polkit_pkexec.robot
@@ -14,6 +14,20 @@ ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 
 
+*** Keywords ***
+Entra Polkit Test Setup
+    utils.Test Setup    snapshot=%{BROKER}-installed
+    Change Broker Configuration    register_device    true
+    Change Broker Configuration    entra_auth    true
+    Change Broker Configuration    device_code    false
+
+
+Check Marker File Is Root Owned
+    [Arguments]    ${marker_file}
+    ${owner} =    SSH.Execute    stat -c %u ${marker_file}
+    Should Be Equal As Integers    ${owner}    0
+
+
 *** Test Cases ***
 Test polkit authentication as authd user via pkexec after initial GDM login
     [Documentation]    Verify that pkexec authenticates the authd user through
@@ -30,6 +44,7 @@ Test polkit authentication as authd user via pkexec after initial GDM login
     # themselves rather than falling back to the local admin (ubuntu) user.
     SSH.Execute    sudo usermod -aG sudo ${username}
 
+    SSH.Execute    rm -f /tmp/polkit-authd-test
     Open Terminal
 
     # Run pkexec to create the marker file as root; this triggers the polkit agent.
@@ -43,8 +58,35 @@ Test polkit authentication as authd user via pkexec after initial GDM login
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
 
-    # Verify polkit granted access: the marker file must now exist as root-owned.
+    # Verify polkit granted access: the marker file must exist and be root-owned.
     Wait Until Keyword Succeeds    5s    1s
-    ...    SSH.Execute    test -f /tmp/polkit-authd-test
+    ...    Check Marker File Is Root Owned    /tmp/polkit-authd-test
 
+    Log Out
+
+Test polkit authentication as authd user via pkexec using Entra ID password and MFA after initial GDM login
+    [Tags]    requires:msentraid
+    [Setup]    Entra Polkit Test Setup
+    [Documentation]    Verify that pkexec authenticates the authd user through
+    ...    polkit using their Entra ID password + MFA flow.
+    ...
+    ...    The authd user is also added to the sudo group so that polkit prompts
+    ...    for their own credentials rather than falling back to the local admin
+    ...    (ubuntu) user.
+
+    Log In With Remote User Through GDM: Entra Password    ${username}
+
+    SSH.Execute    rm -f /tmp/polkit-authd-test-entra
+
+    Open Terminal
+
+    # Run pkexec to create the marker file as root; this triggers the polkit agent.
+    Hid.Type String    pkexec touch /tmp/polkit-authd-test-entra
+    Hid.Keys Combo    Return
+
+    Log In With Remote User Through Polkit: Entra Password    ${username}    
+
+    # Verify polkit granted access: the marker file must exist and be root-owned.
+    Wait Until Keyword Succeeds    30s    5s
+    ...    Check Marker File Is Root Owned    /tmp/polkit-authd-test-entra
     Log Out

--- a/e2e-tests/tests/polkit_pkexec.robot
+++ b/e2e-tests/tests/polkit_pkexec.robot
@@ -75,6 +75,7 @@ Test polkit authentication as authd user via pkexec using Entra ID password and 
     ...    (ubuntu) user.
 
     Log In With Remote User Through GDM: Entra Password    ${username}
+    Check If User Was Added Properly    ${username}    %{E2E_PASSWORD}
 
     SSH.Execute    rm -f /tmp/polkit-authd-test-entra
 


### PR DESCRIPTION
Add tests to check Entra ID + MFA authentication flow for GDM and polkit.

- Test GDM login with Entra ID password and MFA (login_entra_auth.robot)
- Test polkit authentication as authd user via pkexec using Entra ID password and MFA after initial GDM login (polkit_pkexec.robot)

UDENG-11240 

e2e-brokers: msentraid
e2e-tests: login_entra_auth.robot polkit_pkexec.robot