### PR TITLE
fix(broker): replay terminal auth on stale Entra MFA requests

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -101,6 +101,13 @@ type session struct {
 	mfaChallengeInfo   *himmelblau.MFAChallengeInfo
 	entraPasswordHash  string // pre-computed hash (not plaintext) for offline use
 
+	// completedMFAMode and completedMFAResponse record a terminal Entra MFA
+	// result after all finalization steps succeed. They let a late follow-up
+	// request for the same MFA mode replay the result without invoking the
+	// single-use MFA flow again.
+	completedMFAMode     string
+	completedMFAResponse isAuthenticatedDataResponse
+
 	isAuthenticating *isAuthenticatedCtx
 }
 
@@ -701,7 +708,7 @@ func (b *Broker) NewSession(username, lang, mode, providerID string) (sessionID,
 
 		// Attempt to migrate a legacy username-based cache directory to the provider ID-based layout.
 		// If the entry at the username path is already a compatibility symlink from a prior
-		// migration, resolve it and update paths.  If it is a real directory whose cached
+		// migration, resolve it and update paths. If it is a real directory whose cached
 		// token contains a provider ID, rename the directory and leave the symlink behind.
 		if linkInfo, lstatErr := os.Lstat(s.userDataDir); lstatErr == nil {
 			switch {
@@ -1595,6 +1602,20 @@ func clearEntraMFAState(session *session) {
 	himmelblau.FreeMFAFlowState(session.mfaFlowActive)
 	session.mfaFlowActive = nil
 	session.mfaChallengeInfo = nil
+	session.completedMFAMode = ""
+	session.completedMFAResponse = nil
+}
+
+// replayCompletedMFA returns the cached terminal result for mode if an Entra
+// MFA flow for that exact mode has already completed successfully. It is a
+// fallback for stale or duplicate client requests that arrive after the
+// single-use MFA flow state has been released.
+func replayCompletedMFA(session *session, mode string) (string, isAuthenticatedDataResponse, bool) {
+	if session.completedMFAMode != mode || session.completedMFAResponse == nil {
+		return "", nil, false
+	}
+	log.Debugf(context.Background(), "Stale %s request after successful authentication for user %q, replaying terminal result", mode, session.username)
+	return AuthGranted, session.completedMFAResponse, true
 }
 
 // cachedDeviceRegistrationData returns the device registration data from the
@@ -1615,6 +1636,9 @@ func (b *Broker) entraMFAWaitAuth(ctx context.Context, session *session) (string
 	}
 
 	if session.mfaFlowActive == nil {
+		if access, data, ok := replayCompletedMFA(session, authmodes.EntraMFAWait); ok {
+			return access, data
+		}
 		log.Error(context.Background(), "MFA wait mode selected but no active MFA flow")
 		return AuthDenied, unexpectedErrMsg("no active MFA flow")
 	}
@@ -1719,6 +1743,9 @@ func (b *Broker) entraMFACodeAuth(ctx context.Context, session *session, code st
 	}
 
 	if session.mfaFlowActive == nil {
+		if access, data, ok := replayCompletedMFA(session, authmodes.EntraMFACode); ok {
+			return access, data
+		}
 		log.Error(context.Background(), "MFA code mode selected but no active MFA flow")
 		return AuthDenied, unexpectedErrMsg("no active MFA flow")
 	}
@@ -1884,6 +1911,9 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 		}
 	}
 
+	session.completedMFAMode = session.selectedMode
+	session.completedMFAResponse = data
+	session.nextAuthModes = nil
 	return access, data
 }
 

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -5156,6 +5156,221 @@ func TestEntraMFACodeAuthNoActiveMFAFlow(t *testing.T) {
 	require.Equal(t, broker.AuthDenied, access, "entra_mfa_code with no active MFA flow must deny")
 }
 
+// TestIsAuthenticatedEntraMFAWaitStaleRequestReplaysTerminalSuccess verifies that
+// a stale/duplicate entra_mfa_wait call after successful authentication replays
+// AuthGranted idempotently, does not re-invoke AcquireTokenByMFAFlow, and does not
+// trigger an unexpected error (canonical/authd#1810).
+func TestIsAuthenticatedEntraMFAWaitStaleRequestReplaysTerminalSuccess(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraPasswordProvider{
+		MockProvider: &testutils.MockProvider{},
+		flowState:    &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Approve the sign-in request in Microsoft Authenticator",
+			PollingIntervalMs: 1,
+			MaxPollAttempts:   1,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	advanceToEntraMFAWait(t, b, sessionID, key)
+
+	// Initial authentication completes successfully.
+	access, data, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Empty(t, b.GetNextAuthModes(sessionID), "successful Entra MFA must clear stale follow-up modes")
+	require.Equal(t, 1, len(provider.recordedPollAttempts))
+
+	// Late/stale entra_mfa_wait call must replay AuthGranted quietly.
+	staleAccess, staleData, staleErr := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, staleErr)
+	require.Equal(t, broker.AuthGranted, staleAccess, "stale entra_mfa_wait call must return AuthGranted")
+	require.Equal(t, data, staleData, "stale entra_mfa_wait call must replay the original terminal response")
+	require.Equal(t, 1, len(provider.recordedPollAttempts), "AcquireTokenByMFAFlow must not be called again on stale request")
+}
+
+func TestIsAuthenticatedEntraMFACompletionClearedWhenNewFlowStarts(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraPasswordProvider{
+		MockProvider: &testutils.MockProvider{},
+		flowState:    &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Approve the sign-in request in Microsoft Authenticator",
+			PollingIntervalMs: 1,
+			MaxPollAttempts:   1,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	advanceToEntraMFAWait(t, b, sessionID, key)
+
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+
+	// Starting another password + MFA flow must clear the previous terminal
+	// result before the new flow is selected.
+	updateAuthModes(t, b, sessionID, authmodes.EntraPassword)
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, _, err = b.IsAuthenticated(sessionID, passwordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraMFAWait}, b.GetNextAuthModes(sessionID))
+
+	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraMFAWait))
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.EntraMFAWait)
+	require.NoError(t, err)
+	access, _, err = b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Equal(t, []int{1, 1}, provider.recordedPollAttempts,
+		"the second MFA flow must call the provider instead of replaying the first result")
+}
+
+// TestIsAuthenticatedEntraMFACodeStaleRequestReplaysTerminalSuccess verifies that
+// a stale/duplicate entra_mfa_code call after successful authentication replays
+// AuthGranted idempotently, does not re-invoke AcquireTokenByMFAFlow, and does not
+// trigger an unexpected error (canonical/authd#1810).
+func TestIsAuthenticatedEntraMFACodeStaleRequestReplaysTerminalSuccess(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraPasswordProvider{
+		MockProvider: &testutils.MockProvider{},
+		flowState:    &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message: "Enter your MFA code",
+			Method:  "PhoneAppOTP",
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+
+	updateAuthModes(t, b, sessionID, authmodes.EntraPassword)
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	access, _, err := b.IsAuthenticated(sessionID, passwordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+
+	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraMFACode))
+	_, err = b.SelectAuthenticationMode(sessionID, authmodes.EntraMFACode)
+	require.NoError(t, err)
+
+	codeAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "123456", key))
+	access, data, err := b.IsAuthenticated(sessionID, codeAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Equal(t, 1, len(provider.recordedChallengeData))
+
+	// Late/stale entra_mfa_code call must replay AuthGranted quietly.
+	staleAccess, staleData, staleErr := b.IsAuthenticated(sessionID, codeAuthData)
+	require.NoError(t, staleErr)
+	require.Equal(t, broker.AuthGranted, staleAccess, "stale entra_mfa_code call must return AuthGranted")
+	require.Equal(t, data, staleData, "stale entra_mfa_code call must replay the original terminal response")
+	require.Equal(t, 1, len(provider.recordedChallengeData), "AcquireTokenByMFAFlow must not be called again on stale code request")
+}
+
+func TestIsAuthenticatedEntraMFAStaleRequestDoesNotReplayFailedFinalization(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		forceAccessCheckWithProvider bool
+		failurePath                  func(*broker.Broker, string) string
+	}{
+		"Token_cache_failure": {
+			forceAccessCheckWithProvider: true,
+			failurePath: func(b *broker.Broker, sessionID string) string {
+				return b.TokenPathForSession(sessionID)
+			},
+		},
+		"Password_store_failure": {
+			failurePath: func(b *broker.Broker, sessionID string) string {
+				return b.PasswordFilepathForSession(sessionID)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			username := "test-user@email.com"
+			mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+			provider := &mockEntraPasswordProvider{
+				MockProvider: &testutils.MockProvider{},
+				flowState:    &himmelblau.MFAFlowState{},
+				challengeInfo: &himmelblau.MFAChallengeInfo{
+					Message:           "Approve the sign-in request in Microsoft Authenticator",
+					PollingIntervalMs: 1,
+					MaxPollAttempts:   1,
+				},
+				mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+			}
+
+			b := newBrokerForTests(t, &brokerForTestConfig{
+				Config:                       broker.Config{DataDir: t.TempDir()},
+				forceAccessCheckWithProvider: tc.forceAccessCheckWithProvider,
+				ownerAllowed:                 true,
+				firstUserBecomesOwner:        true,
+				provider:                     provider,
+				issuerURL:                    defaultIssuerURL,
+			})
+
+			sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+			advanceToEntraMFAWait(t, b, sessionID, key)
+
+			failurePath := tc.failurePath(b, sessionID)
+			require.NoError(t, os.MkdirAll(filepath.Dir(failurePath), 0700))
+			require.NoError(t, os.Mkdir(failurePath, 0700))
+
+			access, _, err := b.IsAuthenticated(sessionID, "{}")
+			require.NoError(t, err)
+			require.Equal(t, broker.AuthDenied, access, "finalization failure must deny the original request")
+
+			staleAccess, staleData, err := b.IsAuthenticated(sessionID, "{}")
+			require.NoError(t, err)
+			require.Equal(t, broker.AuthDenied, staleAccess,
+				"a failed finalization must not leave a replayable granted result")
+			require.Contains(t, staleData, "no active MFA flow")
+		})
+	}
+}
+
 // TestIsAuthenticatedEntraMFAUsesVerifiedAccessTokenIdentity verifies that
 // first-login identity comes from UserInfoFromAccessToken after VerifyAccessToken,
 // not from OAuth token extras that may have been sourced from an unverified
@@ -5360,6 +5575,49 @@ func TestIsAuthenticatedEntraMFACodeMaxAttemptsLockout(t *testing.T) {
 	require.Len(t, provider.recordedChallengeData, broker.MaxAuthAttempts,
 		"each wrong code submission must reuse the same MFA flow")
 	require.NoFileExists(t, b.PasswordFilepathForSession(sessionID), "a max-tries lockout must not cache an offline password")
+}
+
+// TestIsAuthenticatedEntraMFAModeMismatchDoesNotReplay verifies that a completed
+// entra_mfa_wait flow does not replay AuthGranted if a subsequent request arrives
+// for a different mode like entra_mfa_code.
+func TestIsAuthenticatedEntraMFAModeMismatchDoesNotReplay(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraPasswordProvider{
+		MockProvider: &testutils.MockProvider{},
+		flowState:    &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Approve the sign-in request in Microsoft Authenticator",
+			PollingIntervalMs: 1,
+			MaxPollAttempts:   1,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	advanceToEntraMFAWait(t, b, sessionID, key)
+
+	// Complete initial entra_mfa_wait authentication
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+
+	// Attempting entra_mfa_code on a session completed under entra_mfa_wait must deny
+	updateAuthModes(t, b, sessionID, authmodes.EntraMFACode)
+	mismatchedAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "123456", key))
+	staleAccess, _, staleErr := b.IsAuthenticated(sessionID, mismatchedAuthData)
+	require.NoError(t, staleErr)
+	require.Equal(t, broker.AuthDenied, staleAccess, "mismatched MFA mode must return AuthDenied")
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
### Summary
When an Entra ID authentication succeeds through MFA (`entra_mfa_wait` or `entra_mfa_code`), `clearEntraMFAState()` is invoked to free the underlying C memory, setting `mfaFlowActive = nil`. A late or duplicate polling/code request arriving shortly after `AuthGranted` was encountering `mfaFlowActive == nil` and falling through to an error branch, returning an unexpected error ("no active MFA flow").

This PR introduces a safe replay mechanism that records the completed MFA mode and response upon successful finalization, allowing subsequent duplicate requests for that exact MFA mode to replay `AuthGranted` idempotently without re-invoking the single-use MFA flow.

### Changes
* **Session State Tracking:** Added `completedMFAMode` and `completedMFAResponse` to the `session` struct to record terminal Entra MFA results.
* **Flow-Specific Finalization:** Scoped terminal state recording strictly to `finishEntraAuth`, keeping the shared `finishAuth` helper generic and unaffected.
* **Centralized Replay Helper:** Added `replayCompletedMFA()` to validate that incoming duplicate requests match the completed mode before returning the cached `AuthGranted` payload.
* **Guarded Execution:** Replay checks in `entraMFAWaitAuth` and `entraMFACodeAuth` execute only after provider validation and when `session.mfaFlowActive == nil`.
* **State Reset:** Updated `clearEntraMFAState()` to clear `completedMFAMode` and `completedMFAResponse` on cancellation, restart, or terminal failure.
* **Preserved Error Routing:** Maintained `AADSTS500121` handling in `routeMFAInitError` with a retry delay notice when previous MFA requests were abandoned.
* **Unit Tests:** Added regression tests covering stale wait replays, stale code replays, and mode mismatch denials (`TestIsAuthenticatedEntraMFA*`).

### Related Issues
Closes #1810