### PR TITLE
Show clock guidance for expired access tokens

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -27,6 +27,7 @@ import (
 	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/himmelblau"
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/tokenverify"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/token"
 	"github.com/canonical/authd/log"
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -1388,6 +1389,10 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		if err != nil {
 			log.Errorf(context.Background(), "Failed to refresh token: %s", err)
 
+			if isExpiredTokenError(err) {
+				return AuthDenied, errorMessage{Message: "Failed to refresh token. Please check your system time and try again."}
+			}
+
 			// Fall back to offline mode for transient network failures (e.g. timeout, DNS,
 			// connection refused). Unless provider authentication is forced.
 			var netErr net.Error
@@ -2552,4 +2557,13 @@ func errorMessageForDisplay(err error, fallback string) errorMessage {
 		return errorMessage{Message: forDisplayErr.Error()}
 	}
 	return errorMessage{Message: fallback}
+}
+
+func isExpiredTokenError(err error) bool {
+	if errors.Is(err, tokenverify.ErrTokenExpired) {
+		return true
+	}
+
+	var oidcExpiredErr *oidc.TokenExpiredError
+	return errors.As(err, &oidcExpiredErr)
 }

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -2383,7 +2383,8 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	// Update the raw ID token. Treat an absent, null, or empty id_token the same:
 	// keep the cached one rather than storing an empty value.
 	rawIDToken, _ := oauthToken.Extra("id_token").(string)
-	if rawIDToken == "" {
+	freshIDToken := rawIDToken != ""
+	if !freshIDToken {
 		log.Debug(context.Background(), "refreshed token does not contain an ID token, keeping the old one")
 		rawIDToken = oldToken.RawIDToken
 	}
@@ -2402,6 +2403,10 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 		// refresh token even if a later local validation step fails, otherwise the
 		// cache can be stranded with a refresh token the provider already invalidated.
 		cacheRotatedToken("user info refresh failure")
+		if !freshIDToken && isExpiredTokenError(err) {
+			// The cached ID token expired normally; don't hint at clock skew.
+			return oldToken, fmt.Errorf("cached ID token expired: %s", err)
+		}
 		return oldToken, err
 	}
 	if t.UserInfo.Gecos == "" {

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -24,6 +24,7 @@ import (
 	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/himmelblau"
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/tokenverify"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/testutils"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/token"
 	"github.com/canonical/authd/internal/testutils/golden"
@@ -3016,6 +3017,52 @@ func TestIsAuthenticatedPasswordRefreshPreservesRotationOnUserInfoError(t *testi
 		"a failed local validation must not replace the cached raw ID token")
 }
 
+// TestIsAuthenticatedPasswordRefreshReportsClockSkewForOIDCToken verifies that
+// the standard OIDC verifier's expiry error produces a useful lockscreen
+// message instead of the generic token-refresh failure.
+func TestIsAuthenticatedPasswordRefreshReportsClockSkewForOIDCToken(t *testing.T) {
+	t.Parallel()
+
+	const correctPassword = "password"
+	provider := &testutils.MockProvider{
+		GetGroupsFunc: func() ([]info.Group, error) {
+			return []info.Group{{Name: "remote-group"}}, nil
+		},
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			IDTokenClaims: []map[string]interface{}{{
+				"exp": time.Now().Add(-time.Hour).Unix(),
+			}},
+		},
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+
+	access, data, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access)
+
+	var payload struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t,
+		"Failed to refresh token. Please check your system time and try again.",
+		payload.Message,
+	)
+}
+
 // TestIsAuthenticatedPasswordEntraTokenRefreshRotatesRefreshToken verifies that a
 // successful Entra password token refresh on a returning login rotates the cached
 // refresh token (kept fresh on each login, like the device-auth flow) and that the
@@ -3107,7 +3154,7 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshUpdatesUserInfo(t *testing.T) {
 		"groups must be preserved from the cached token, not overwritten by the refresh")
 }
 
-func runReturningEntraPasswordLogin(t *testing.T, provider *mockEntraPasswordProvider) (*broker.Broker, string, string) {
+func runReturningEntraPasswordLogin(t *testing.T, provider *mockEntraPasswordProvider) (*broker.Broker, string, string, string) {
 	t.Helper()
 
 	const correctPassword = "password"
@@ -3125,10 +3172,10 @@ func runReturningEntraPasswordLogin(t *testing.T, provider *mockEntraPasswordPro
 
 	updateAuthModes(t, b, sessionID, authmodes.Password)
 	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
-	access, _, err := b.IsAuthenticated(sessionID, authData)
+	access, data, err := b.IsAuthenticated(sessionID, authData)
 	require.NoError(t, err)
 
-	return b, sessionID, access
+	return b, sessionID, access, data
 }
 
 // TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailure verifies
@@ -3146,7 +3193,7 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailure(t *
 		verifyAccessTokenErr: errors.New("token signature verification failed"),
 	}
 
-	b, sessionID, access := runReturningEntraPasswordLogin(t, provider)
+	b, sessionID, access, _ := runReturningEntraPasswordLogin(t, provider)
 	require.Equal(t, broker.AuthDenied, access,
 		"a refreshed token that fails signature verification must deny the returning login")
 
@@ -3154,6 +3201,34 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailure(t *
 	require.NoError(t, err)
 	require.Equal(t, "new-refresh-token", cached.Token.RefreshToken,
 		"a local verification failure must not discard an already-rotated refresh token")
+}
+
+// TestIsAuthenticatedPasswordEntraTokenRefreshReportsClockSkew verifies that an
+// expired refreshed access token produces a useful lockscreen message instead
+// of the generic token-refresh failure.
+func TestIsAuthenticatedPasswordEntraTokenRefreshReportsClockSkew(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraPasswordProvider{
+		MockProvider: &testutils.MockProvider{},
+		refreshResult: &oauth2.Token{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+		},
+		verifyAccessTokenErr: fmt.Errorf("verification failed: %w", tokenverify.ErrTokenExpired),
+	}
+
+	_, _, access, data := runReturningEntraPasswordLogin(t, provider)
+	require.Equal(t, broker.AuthDenied, access)
+
+	var payload struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t,
+		"Failed to refresh token. Please check your system time and try again.",
+		payload.Message,
+	)
 }
 
 // TestIsAuthenticatedPasswordEntraTokenRefreshVerificationHasOwnTimeout verifies
@@ -3212,7 +3287,7 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshPreservesRotationOnUserInfoErro
 		userInfoFromTokenErr: errors.New("missing preferred_username claim"),
 	}
 
-	b, sessionID, access := runReturningEntraPasswordLogin(t, provider)
+	b, sessionID, access, _ := runReturningEntraPasswordLogin(t, provider)
 	require.Equal(t, broker.AuthDenied, access,
 		"a refreshed token whose user info cannot be extracted must deny the returning login")
 

--- a/authd-oidc-brokers/internal/providers/msentraid/tokenverify/tokenverify.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/tokenverify/tokenverify.go
@@ -27,6 +27,9 @@ import (
 // error if it cannot be resolved.
 type KeyForKID func(kid string) (*rsa.PublicKey, error)
 
+// ErrTokenExpired identifies an access token whose expiry time has passed.
+var ErrTokenExpired = errors.New("token expired")
+
 // replaceNonceValue rewrites the value of the "nonce" field in headerJSON with
 // replacement, byte-for-byte, leaving every other byte untouched. Unlike a plain
 // substring replace, it anchors to the "nonce" key itself, so it cannot match a
@@ -213,9 +216,10 @@ func Verify(rawToken, expectedTenantID string, keyForKID KeyForKID) error {
 	if err != nil || exp == 0 {
 		return errors.New("token payload missing valid exp claim")
 	}
-	now := time.Now().Unix()
-	if now-60 > exp {
-		return fmt.Errorf("token expired at %d (now: %d)", exp, now)
+	now := time.Now()
+	if now.Unix()-60 > exp {
+		return fmt.Errorf("%w at %s (now: %s)", ErrTokenExpired,
+			time.Unix(exp, 0).Format(time.RFC3339), now.Format(time.RFC3339))
 	}
 	if claims.Tid != expectedTenantID {
 		return fmt.Errorf("token tenant %q does not match expected tenant %q", claims.Tid, expectedTenantID)

--- a/authd-oidc-brokers/internal/providers/msentraid/tokenverify/tokenverify_test.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/tokenverify/tokenverify_test.go
@@ -135,10 +135,15 @@ func TestVerify(t *testing.T) {
 		t.Parallel()
 		hdr, err := json.Marshal(map[string]any{"alg": "RS256", "kid": testKID})
 		require.NoError(t, err)
-		expiredPayload, err := json.Marshal(map[string]any{"tid": testTenant, "exp": time.Now().Unix() - 61})
+		exp := time.Now().Unix() - 2*60
+		expiredPayload, err := json.Marshal(map[string]any{"tid": testTenant, "exp": exp})
 		require.NoError(t, err)
 		tok := signToken(t, key, hdr, hdr, expiredPayload)
-		require.Error(t, tokenverify.Verify(tok, testTenant, resolver))
+		err = tokenverify.Verify(tok, testTenant, resolver)
+		require.ErrorIs(t, err, tokenverify.ErrTokenExpired)
+		require.Contains(t, err.Error(), time.Unix(exp, 0).Format(time.RFC3339))
+		require.NotContains(t, err.Error(), fmt.Sprintf("%d (now:", exp),
+			"expiry and current time should no longer be logged as Unix timestamps")
 	})
 
 	t.Run("Missing exp fails", func(t *testing.T) {


### PR DESCRIPTION
A system clock that runs ahead can make a freshly refreshed Entra access token appear expired. Keep the expiry diagnostics useful in the journal by logging RFC3339 timestamps, and show the user how to recover instead of returning only the generic refresh failure.

Closes #1822