### PR TITLE
e2e-tests: accept lower-confidence GDM username OCR

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -317,8 +317,9 @@ Start Log In With Remote User Through GDM: QR Code
     Move Pointer To Not listed
     Left Button Click
 
-    # Enter the username
-    Match Text    Username
+    # Enter the username. The field's placeholder text is lighter than normal
+    # text, so it often OCRs below the suite's global confidence threshold.
+    Match Text    Username    30    confidence=91
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
 
@@ -348,8 +349,9 @@ Log In With Remote User Through GDM: Local Password
     Wait Until GDM Login Screen Ready
     Move Pointer To Not listed
     Left Button Click
-    # Enter the username
-    Match Text    Username
+    # Enter the username. The field's placeholder text is lighter than normal
+    # text, so it often OCRs below the suite's global confidence threshold.
+    Match Text    Username    30    confidence=91
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
 


### PR DESCRIPTION
The GDM username placeholder is rendered in a lighter color, so RapidOCR can recognize it exactly while reporting confidence below the suite-wide threshold. Use a lower confidence threshold for these two username prompts.

Closes #1827

e2e-brokers: msentraid
e2e-tests: broker_disabled.robot
