### PR TITLE
e2e-tests: fix check user not match flakiness

### DIFF
--- a/e2e-tests/resources/authd.resource
+++ b/e2e-tests/resources/authd.resource
@@ -62,9 +62,35 @@ Check That User Is Redirected To Local Broker
     Match Text    Password:    120
 
 
+Get Journal Cursor
+    ${journal_cursor} =    SSH.Execute
+    ...    sudo journalctl --no-pager -n 1 --show-cursor | sed -n 's/^-- cursor: //p'
+    Should Not Be Empty    ${journal_cursor}
+    RETURN    ${journal_cursor}
+
+
 Check That Authenticated User Does Not Match Requested User
-    [Arguments]    ${requested_user}
-    Match Text    Authentication failure: requested username "${requested_user}" does not match the authenticated username    120
+    [Arguments]    ${requested_user}    ${journal_cursor}    ${console_log}
+    Wait Until Keyword Succeeds    30s    2s
+    ...    Check Journal For Username Mismatch Failure    ${requested_user}    ${journal_cursor}
+    Wait Until Keyword Succeeds    30s    2s
+    ...    Check Console For Username Mismatch Failure    ${requested_user}    ${console_log}
+
+
+Check Journal For Username Mismatch Failure
+    [Arguments]    ${requested_user}    ${journal_cursor}
+    ${log_line} =    SSH.Execute
+    ...    sudo journalctl --no-pager --after-cursor="${journal_cursor}" | grep -E 'Authentication failure: requested username "${requested_user}" does not match the authenticated (user|username) "' || true
+    Should Not Be Empty    ${log_line}
+    ...    No journal entry found for a username-mismatch authentication failure with requested user "${requested_user}"
+
+
+Check Console For Username Mismatch Failure
+    [Arguments]    ${requested_user}    ${console_log}
+    ${console_line} =    SSH.Execute
+    ...    grep -E -- 'Authentication failure: requested username "${requested_user}" does not match the authenticated (user|username) "' "${console_log}" || true
+    Should Not Be Empty    ${console_line}
+    ...    No username-mismatch authentication failure was sent to the terminal console
 
 
 Check That Remote User Can Run Sudo Commands

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -50,8 +50,8 @@ Log In With Remote User Through CLI: QR Code
 
 
 Start Log In With Remote User Through CLI: QR Code
-    [Arguments]    ${username}
-    Try machinectl login Prompt
+    [Arguments]    ${username}    ${console_log}=${EMPTY}
+    Try machinectl login Prompt    ${console_log}
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
 

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -247,9 +247,15 @@ Wait Until System Time Synced
 
 
 Try machinectl login Prompt
+    [Arguments]    ${console_log}=${EMPTY}
     VAR    ${tries}    3
     WHILE    ${tries} > 0
-        Hid.Type String    machinectl login
+        IF    '${console_log}' == ''
+            ${login_command} =    Set Variable    machinectl login
+        ELSE
+            ${login_command} =    Set Variable    script --quiet --flush --return --command 'machinectl login' '${console_log}'
+        END
+        Hid.Type String    ${login_command}
         Hid.Keys Combo    Return
         ${match} =     Run Keyword And Return Status
         ...    Match Text    ubuntu login:    120

--- a/e2e-tests/tests/deny_login_if_username_does_not_match.robot
+++ b/e2e-tests/tests/deny_login_if_username_does_not_match.robot
@@ -14,6 +14,7 @@ Test Teardown   utils.Test Teardown
 ${snapshot}    %{BROKER}-installed
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
+${console_log}    /tmp/authd-username-mismatch-console.log
 
 
 *** Test Cases ***
@@ -25,7 +26,9 @@ Test that login fails if usernames do not match
 
     # Fail to log in if usernames do not match
     Open Terminal
-    Start Log In With Remote User Through CLI: QR Code   different_user
+    ${journal_cursor} =    Get Journal Cursor
+    SSH.Execute    rm -f ${console_log}
+    Start Log In With Remote User Through CLI: QR Code    different_user    ${console_log}
     Select Provider
     Continue Log In With Remote User: Authenticate In External Browser
-    Check That Authenticated User Does Not Match Requested User    different_user
+    Check That Authenticated User Does Not Match Requested User    different_user    ${journal_cursor}    ${console_log}


### PR DESCRIPTION
Addressing "Check That Authenticated User Does Not Match Requested User" keyword flakiness due to OCR failures as described in https://github.com/canonical/authd/issues/1826

Issue:
OCR not able to reliably match the string 'Authentication failure: requested username "different_user" does not match the authenticated username'

Proposed fix:
Instead of relying on OCR match the Keyword will now retrieve the logs and look for the string to match. To reduce risk of collision with other tests, the keyword gets in input the cursor to journal that has to be retrieved by calling test

Closes #1826 
