### PR TITLE
docs: Remove Commands section from login-gdm.md

### DIFF
--- a/docs/howto/login-gdm.md
+++ b/docs/howto/login-gdm.md
@@ -30,25 +30,3 @@ From a second device, flash the QR code or type the URL in a web browser, then f
 Upon successful authentication, the user is prompted to enter a local password. This password can be used for offline authentication.
 
 ![Prompt to create local password on successful authentication.](../assets/gdm-pass.png)
-
-## Commands
-
-### authd
-
-`authd` is socket-activated. It means that the service starts on-demand when it receives a request on a socket.
-
-If you want to restart the service, you can stop it with `sudo systemctl stop authd` and it will restart automatically on the next message it receives.
-
-Run `/usr/libexec/authd --help` to display the entire help.
-
-## Broker management
-
-The broker is managed through the `snap` command.
-
-The main operation is to restart the broker to reload the configuration when it has changed. You can reload the broker with the command:
-
-```shell
-sudo snap restart authd-msentraid
-```
-
-> If you are using a different broker to `msentraid`, make sure to change the snap name when running this command.


### PR DESCRIPTION
The Commands section was out of place in the "Log in with GDM" howto.
