### PR TITLE
broker: allow local password after token verification failure

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1448,7 +1449,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 				session.nextAuthModes = reauthModes
 				return AuthNext, errorMessage{Message: "Your password was changed remotely. Please re-authenticate."}
 			}
-			if b.provider.IsTokenExpiredError(retrieveErr) {
+			if b.provider.IsTokenExpiredError(retrieveErr) && b.cfg.forceAccessCheckWithProvider {
 				log.Noticef(context.Background(), "Refresh token expired for user %q, re-authentication required", session.username)
 				session.nextAuthModes = reauthModes
 				return AuthNext, errorMessage{Message: "Refresh token expired, please authenticate again."}
@@ -1468,17 +1469,37 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 			}
 		}
 		if err != nil {
-			log.Errorf(context.Background(), "Failed to refresh token: %s", err)
-
-			// Fall back to offline mode for transient network failures (e.g. timeout, DNS,
-			// connection refused). Unless provider authentication is forced.
+			var authoritativeErr *providerErrors.AuthoritativeError
+			var nonAuthoritativeErr *providerErrors.NonAuthoritativeError
 			var netErr net.Error
-			if errors.As(err, &netErr) && !b.cfg.forceAccessCheckWithProvider {
-				log.Warningf(context.Background(), "Network error during token refresh for user %q, skipping token refresh", session.username)
+			switch {
+			case errors.As(err, &authoritativeErr):
+				// Preserve a displayable authoritative error and deny instead of
+				// falling back to cached credentials.
+				return AuthDenied, errorMessageForDisplay(err, "Failed to refresh token")
+			case isConfigurationRetrieveError(retrieveErr):
+				return AuthDenied, errorMessageForDisplay(err, "Failed to refresh token")
+			case isTransientRetrieveError(retrieveErr):
+				log.Warningf(context.Background(), "Transient token endpoint error during token refresh for user %q: %s", session.username, err)
+			case retrieveErr != nil && b.provider.IsTokenExpiredError(retrieveErr):
+				log.Warningf(context.Background(), "Expired refresh token during token refresh for user %q; using cached credentials when provider access checks are optional", session.username)
+			case errors.As(err, &netErr):
+				log.Warningf(context.Background(), "Network error during token refresh for user %q: %s", session.username, err)
+			case errors.As(err, &nonAuthoritativeErr):
+				log.Warningf(context.Background(), "Non-authoritative error during token refresh for user %q: %s", session.username, err)
+			default:
+				log.Warningf(context.Background(), "Unclassified error during token refresh for user %q: %s", session.username, err)
+			}
+
+			// Fall back to offline mode only for failures known not to establish
+			// that cached access is invalid. Unless provider authentication is
+			// forced, local password authentication remains sufficient.
+			if !b.cfg.forceAccessCheckWithProvider {
+				log.Warningf(context.Background(), "Token refresh failed for user %q, skipping token refresh", session.username)
 				authInfo = oldAuthInfo
 				session.isOffline = true
 			} else {
-				return AuthDenied, errorMessage{Message: "Failed to refresh token"}
+				return AuthDenied, errorMessageForDisplay(err, "Failed to refresh token")
 			}
 		}
 	}
@@ -2368,6 +2389,25 @@ func isAADSTSGrantRevokedError(err *oauth2.RetrieveError) bool {
 	return strings.HasPrefix(err.ErrorDescription, "AADSTS50173:")
 }
 
+func isConfigurationRetrieveError(err *oauth2.RetrieveError) bool {
+	return err != nil && err.ErrorCode == "invalid_client"
+}
+
+func isTransientRetrieveError(err *oauth2.RetrieveError) bool {
+	if err == nil {
+		return false
+	}
+
+	switch err.ErrorCode {
+	case "server_error", "temporarily_unavailable":
+		return true
+	case "":
+		return err.Response != nil && err.Response.StatusCode >= http.StatusInternalServerError && err.Response.StatusCode < 600
+	default:
+		return false
+	}
+}
+
 // isFIDOMethod returns true if the MFA method is a FIDO/security key method.
 func isFIDOMethod(method string) bool {
 	method = strings.ToLower(method)
@@ -2716,9 +2756,9 @@ func (b *Broker) updateSession(sessionID string, session session) error {
 // liveness/revocation check on a returning login. The provider performs a public
 // refresh (no client_secret) as the Microsoft Broker App; on success the rotated
 // refresh token replaces the cached one (kept fresh on each login, like the
-// device-auth refresh). Errors are returned unwrapped so the caller classifies them
-// with the same checks it uses for device-auth (IsUserDisabledError → AADSTS50057,
-// IsTokenExpiredError → AADSTS50173, isAADSTSGrantRevokedError, net.Error → offline).
+// device-auth refresh). Explicit disabled, expired, and revoked errors are
+// handled before network and explicitly non-authoritative failures fall back to
+// offline mode when provider access checks are optional.
 func (b *Broker) refreshEntraToken(ctx context.Context, session *session, oldToken *token.AuthCachedInfo) (*token.AuthCachedInfo, error) {
 	ep, ok := providers.ProviderAs[himmelblau.EntraAuthProvider](b.provider)
 	if !ok {
@@ -2727,7 +2767,7 @@ func (b *Broker) refreshEntraToken(ctx context.Context, session *session, oldTok
 		// deployment is misconfigured: fail the login rather than skipping the
 		// liveness/revocation check, which would let a deleted/disabled user keep
 		// logging in with the cached token.
-		return nil, fmt.Errorf("provider does not implement EntraAuthProvider; cannot refresh entra_auth token for user %q", oldToken.UserInfo.Name)
+		return nil, &providerErrors.AuthoritativeError{Err: fmt.Errorf("provider does not implement EntraAuthProvider; cannot refresh entra_auth token for user %q", oldToken.UserInfo.Name)}
 	}
 	refreshCtx, cancel := context.WithTimeout(ctx, maxRequestDuration)
 	defer cancel()
@@ -2758,12 +2798,12 @@ func (b *Broker) refreshEntraToken(ctx context.Context, session *session, oldTok
 		// rotated token even though this login is denied, otherwise a local issue
 		// such as clock skew can strand the cache with a dead refresh token.
 		cacheRotatedToken("verification failure")
-		return oldToken, fmt.Errorf("access token verification failed: %w", err)
+		return oldToken, &providerErrors.NonAuthoritativeError{Err: fmt.Errorf("access token verification failed: %w", err)}
 	}
 	userInfo, err := ep.UserInfoFromAccessToken(newTok.AccessToken)
 	if err != nil {
 		cacheRotatedToken("user info extraction failure")
-		return oldToken, fmt.Errorf("could not refresh user info from the refreshed Entra token: %w", err)
+		return oldToken, &providerErrors.NonAuthoritativeError{Err: fmt.Errorf("could not refresh user info from the refreshed Entra token: %w", err)}
 	}
 	// getUserInfo (the device-auth refresh path) re-checks this on every refresh,
 	// not just on first login; do the same here so a refreshed Entra token can't
@@ -2831,7 +2871,7 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 		// refresh token even if a later local validation step fails, otherwise the
 		// cache can be stranded with a refresh token the provider already invalidated.
 		cacheRotatedToken("user info refresh failure")
-		return oldToken, err
+		return oldToken, &providerErrors.NonAuthoritativeError{Err: err}
 	}
 	if t.UserInfo.Gecos == "" {
 		t.UserInfo.Gecos = oldToken.UserInfo.Gecos
@@ -2891,7 +2931,7 @@ func (b *Broker) getUserInfo(ctx context.Context, session *session, token *oauth
 			return info.User{}, fmt.Errorf("could not decode UserInfo endpoint claims: %w", err)
 		}
 		if subClaimCheck.Sub != "" && subClaimCheck.Sub != idToken.Subject {
-			return info.User{}, fmt.Errorf("userinfo sub %q does not match ID token sub %q: rejecting potential identity substitution", subClaimCheck.Sub, idToken.Subject)
+			return info.User{}, &providerErrors.AuthoritativeError{Err: fmt.Errorf("userinfo sub %q does not match ID token sub %q: rejecting potential identity substitution", subClaimCheck.Sub, idToken.Subject)}
 		}
 
 		// Merge ID token claims with UserInfo claims.

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -1254,25 +1254,28 @@ func TestIsAuthenticated(t *testing.T) {
 			getGroupsFails:    true,
 		},
 		"Authenticating_with_password_when_refresh_token_is_expired_results_in_device_auth_as_next_mode": {
-			firstMode:         authmodes.Password,
-			token:             &tokenOptions{refreshTokenExpired: true},
-			wantNextAuthModes: []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr},
-			wantSecondCall:    true,
-			secondMode:        authmodes.DeviceQr,
+			firstMode:                    authmodes.Password,
+			forceAccessCheckWithProvider: true,
+			token:                        &tokenOptions{refreshTokenExpired: true},
+			wantNextAuthModes:            []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr},
+			wantSecondCall:               true,
+			secondMode:                   authmodes.DeviceQr,
 		},
 		"Authenticating_with_password_when_refresh_token_is_expired_due_to_inactivity_results_in_device_auth_as_next_mode": {
-			firstMode:         authmodes.Password,
-			token:             &tokenOptions{refreshTokenInactiveExpired: true},
-			wantNextAuthModes: []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr},
-			wantSecondCall:    true,
-			secondMode:        authmodes.DeviceQr,
+			firstMode:                    authmodes.Password,
+			forceAccessCheckWithProvider: true,
+			token:                        &tokenOptions{refreshTokenInactiveExpired: true},
+			wantNextAuthModes:            []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr},
+			wantSecondCall:               true,
+			secondMode:                   authmodes.DeviceQr,
 		},
 		"Authenticating_with_password_when_refresh_token_is_expired_due_to_ca_sign_in_frequency_results_in_device_auth_as_next_mode": {
-			firstMode:         authmodes.Password,
-			token:             &tokenOptions{refreshTokenStale: true},
-			wantNextAuthModes: []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr},
-			wantSecondCall:    true,
-			secondMode:        authmodes.DeviceQr,
+			firstMode:                    authmodes.Password,
+			forceAccessCheckWithProvider: true,
+			token:                        &tokenOptions{refreshTokenStale: true},
+			wantNextAuthModes:            []string{authmodes.EntraAuth, authmodes.Device, authmodes.DeviceQr},
+			wantSecondCall:               true,
+			secondMode:                   authmodes.DeviceQr,
 		},
 		"Authenticating_with_password_when_no_refresh_token_results_in_device_auth_as_next_mode": {
 			firstMode:         authmodes.Password,
@@ -1393,8 +1396,9 @@ func TestIsAuthenticated(t *testing.T) {
 
 		"Error_when_mode_is_password_and_token_does_not_exist": {firstMode: authmodes.Password},
 		"Error_when_mode_is_password_but_server_returns_error": {
-			firstMode: authmodes.Password,
-			token:     &tokenOptions{expired: true},
+			firstMode:                    authmodes.Password,
+			forceAccessCheckWithProvider: true,
+			token:                        &tokenOptions{expired: true},
 			customHandlers: map[string]testutils.EndpointHandler{
 				"/token": testutils.BadRequestHandler(),
 			},
@@ -3470,12 +3474,127 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshDetectsDisabledUser(t *testing.
 	require.True(t, cached.UserIsDisabled, "UserIsDisabled must be cached after an AADSTS50057 refresh rejection")
 }
 
-// TestIsAuthenticatedPasswordRefreshPreservesRotationOnUserInfoError verifies
-// that the generic OIDC refresh path preserves a rotated refresh token even if
-// a later local validation step (here: ID-token verification in getUserInfo)
-// fails. Otherwise the cache can be stranded with a refresh token the provider
-// already invalidated server-side.
-func TestIsAuthenticatedPasswordRefreshPreservesRotationOnUserInfoError(t *testing.T) {
+func TestIsAuthenticatedPasswordRefreshFallsBackOnTransientRetrieveError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]*oauth2.RetrieveError{
+		"server_error": {
+			ErrorCode: "server_error",
+		},
+		"temporarily_unavailable": {
+			ErrorCode: "temporarily_unavailable",
+		},
+		"http_5xx": {
+			Response: &http.Response{StatusCode: http.StatusBadGateway},
+		},
+	}
+
+	for name, refreshErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &mockEntraAuthProvider{
+				MockProvider: &testutils.MockProvider{GetGroupsFunc: func() ([]info.Group, error) {
+					return []info.Group{{Name: "cached-group"}}, nil
+				}},
+				refreshErr: refreshErr,
+			}
+
+			b, sessionID, access, _ := runReturningEntraAuthLogin(t, provider, false)
+			require.Equal(t, broker.AuthGranted, access,
+				"a transient token endpoint failure must use cached credentials")
+
+			offline, err := b.IsOffline(sessionID)
+			require.NoError(t, err)
+			require.True(t, offline, "a transient token endpoint failure must mark the session offline")
+		})
+	}
+}
+
+func TestIsAuthenticatedPasswordRefreshFallsBackOnExpiredRetrieveError(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{},
+		refreshErr: &oauth2.RetrieveError{
+			ErrorCode:        "invalid_grant",
+			ErrorDescription: "Session not active",
+		},
+	}
+
+	b, sessionID, access, _ := runReturningEntraAuthLogin(t, provider, false)
+	require.Equal(t, broker.AuthGranted, access,
+		"an expired refresh token must use cached credentials when provider access checks are optional")
+
+	offline, err := b.IsOffline(sessionID)
+	require.NoError(t, err)
+	require.True(t, offline, "an expired refresh token must mark the session offline")
+}
+
+func TestIsAuthenticatedPasswordRefreshHandlesUnknownRetrieveError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		forceAccessCheckWithProvider bool
+		wantAccess                   string
+		wantOffline                  bool
+	}{
+		"optional_provider_check": {
+			wantAccess:  broker.AuthGranted,
+			wantOffline: true,
+		},
+		"forced_provider_check": {
+			forceAccessCheckWithProvider: true,
+			wantAccess:                   broker.AuthDenied,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &mockEntraAuthProvider{
+				MockProvider: &testutils.MockProvider{},
+				refreshErr: &oauth2.RetrieveError{
+					ErrorCode: "unexpected_error",
+				},
+			}
+
+			b, sessionID, access, _ := runReturningEntraAuthLogin(t, provider, tc.forceAccessCheckWithProvider)
+			require.Equal(t, tc.wantAccess, access)
+
+			offline, err := b.IsOffline(sessionID)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOffline, offline)
+		})
+	}
+}
+
+func TestIsAuthenticatedPasswordRefreshDeniesConfigurationRetrieveError(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{},
+		refreshErr: &oauth2.RetrieveError{
+			ErrorCode: "invalid_client",
+		},
+	}
+
+	b, sessionID, access, _ := runReturningEntraAuthLogin(t, provider, false)
+	require.Equal(t, broker.AuthDenied, access,
+		"a configuration token endpoint failure must not use cached credentials")
+
+	offline, err := b.IsOffline(sessionID)
+	require.NoError(t, err)
+	require.False(t, offline, "a configuration token endpoint failure must not mark the session offline")
+}
+
+// TestIsAuthenticatedPasswordRefreshFallsBackOnUserInfoError verifies that the
+// generic OIDC refresh path permits a returning login when an optional local
+// validation step (here: ID-token verification in getUserInfo) fails, while
+// preserving the rotated refresh token. Otherwise the cache can be stranded
+// with a refresh token the provider already invalidated server-side.
+func TestIsAuthenticatedPasswordRefreshFallsBackOnUserInfoError(t *testing.T) {
 	t.Parallel()
 
 	const correctPassword = "password"
@@ -3513,8 +3632,8 @@ func TestIsAuthenticatedPasswordRefreshPreservesRotationOnUserInfoError(t *testi
 
 	access, _, err := b.IsAuthenticated(sessionID, authData)
 	require.NoError(t, err)
-	require.Equal(t, broker.AuthDenied, access,
-		"a refreshed token whose ID token cannot be verified must deny the returning login")
+	require.Equal(t, broker.AuthGranted, access,
+		"a local verification failure must not block a returning login when provider access checks are optional")
 
 	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
 	require.NoError(t, err)
@@ -3615,16 +3734,17 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshUpdatesUserInfo(t *testing.T) {
 		"groups must be preserved from the cached token, not overwritten by the refresh")
 }
 
-func runReturningEntraAuthLogin(t *testing.T, provider *mockEntraAuthProvider) (*broker.Broker, string, string) {
+func runReturningEntraAuthLogin(t *testing.T, provider *mockEntraAuthProvider, forceAccessCheckWithProvider bool) (*broker.Broker, string, string, string) {
 	t.Helper()
 
 	const correctPassword = "password"
 	b := newBrokerForTests(t, &brokerForTestConfig{
-		Config:                broker.Config{DataDir: t.TempDir()},
-		ownerAllowed:          true,
-		firstUserBecomesOwner: true,
-		provider:              provider,
-		issuerURL:             defaultIssuerURL,
+		Config:                       broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:                 true,
+		firstUserBecomesOwner:        true,
+		forceAccessCheckWithProvider: forceAccessCheckWithProvider,
+		provider:                     provider,
+		issuerURL:                    defaultIssuerURL,
 	})
 
 	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
@@ -3633,35 +3753,68 @@ func runReturningEntraAuthLogin(t *testing.T, provider *mockEntraAuthProvider) (
 
 	updateAuthModes(t, b, sessionID, authmodes.Password)
 	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
-	access, _, err := b.IsAuthenticated(sessionID, authData)
+	access, data, err := b.IsAuthenticated(sessionID, authData)
 	require.NoError(t, err)
 
-	return b, sessionID, access
+	return b, sessionID, access, data
 }
 
-// TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailure verifies
-// that if the refreshed Entra password token fails signature verification the
-// returning login is denied — mirroring the first-login deny path in
-// TestIsAuthenticatedEntraAuthDeniesOnAccessTokenVerificationFailure.
-func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailure(t *testing.T) {
+// TestIsAuthenticatedPasswordEntraTokenRefreshFallsBackOnVerificationFailure verifies
+// that a local password remains sufficient when an optional provider check cannot
+// verify the refreshed Entra access token. The ForDisplayError is intentionally
+// not authoritative, so the optional fallback remains available.
+func TestIsAuthenticatedPasswordEntraTokenRefreshFallsBackOnVerificationFailure(t *testing.T) {
 	t.Parallel()
 
 	provider := &mockEntraAuthProvider{
 		MockProvider: &testutils.MockProvider{GetGroupsFunc: func() ([]info.Group, error) {
 			return []info.Group{{Name: "remote-group"}}, nil
 		}},
-		refreshResult:        &oauth2.Token{AccessToken: "new-access-token", RefreshToken: "new-refresh-token"},
-		verifyAccessTokenErr: errors.New("token signature verification failed"),
+		refreshResult: &oauth2.Token{AccessToken: "new-access-token", RefreshToken: "new-refresh-token"},
+		verifyAccessTokenErr: &providerErrors.ForDisplayError{
+			Message: "temporary token verification failure",
+			Err:     errors.New("token signature verification failed"),
+		},
 	}
 
-	b, sessionID, access := runReturningEntraAuthLogin(t, provider)
-	require.Equal(t, broker.AuthDenied, access,
-		"a refreshed token that fails signature verification must deny the returning login")
+	b, sessionID, access, _ := runReturningEntraAuthLogin(t, provider, false)
+	require.Equal(t, broker.AuthGranted, access,
+		"a local password must remain sufficient when the optional token verification fails")
 
 	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
 	require.NoError(t, err)
 	require.Equal(t, "new-refresh-token", cached.Token.RefreshToken,
 		"a local verification failure must not discard an already-rotated refresh token")
+}
+
+// TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailureWhenForced
+// verifies that force_access_check_with_provider makes the same verification
+// failure deny the returning login.
+func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnVerificationFailureWhenForced(t *testing.T) {
+	t.Parallel()
+
+	const verificationMsg = "temporary token verification failure"
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{GetGroupsFunc: func() ([]info.Group, error) {
+			return []info.Group{{Name: "remote-group"}}, nil
+		}},
+		refreshResult: &oauth2.Token{AccessToken: "new-access-token", RefreshToken: "new-refresh-token"},
+		verifyAccessTokenErr: &providerErrors.ForDisplayError{
+			Message: verificationMsg,
+			Err:     errors.New("token signature verification failed"),
+		},
+	}
+
+	_, _, access, data := runReturningEntraAuthLogin(t, provider, true)
+	require.Equal(t, broker.AuthDenied, access,
+		"a forced provider check must deny when token verification fails")
+
+	var payload struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	require.Equal(t, verificationMsg, payload.Message,
+		"a forced provider check must preserve a displayable refresh error")
 }
 
 // TestIsAuthenticatedPasswordEntraTokenRefreshVerificationHasOwnTimeout verifies
@@ -3705,11 +3858,12 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshVerificationHasOwnTimeout(t *te
 		"verification should get a fresh timeout instead of sharing the refresh context")
 }
 
-// TestIsAuthenticatedPasswordEntraTokenRefreshPreservesRotationOnUserInfoError
-// verifies that a local failure after a successful Entra refresh still persists
-// the rotated refresh token. Otherwise the cache can be stranded with a refresh
-// token that Entra already invalidated server-side.
-func TestIsAuthenticatedPasswordEntraTokenRefreshPreservesRotationOnUserInfoError(t *testing.T) {
+// TestIsAuthenticatedPasswordEntraTokenRefreshFallsBackOnUserInfoError verifies
+// that a local failure after a successful Entra refresh still permits a returning
+// login when provider access checks are optional, while persisting the rotated
+// refresh token. Otherwise the cache can be stranded with a refresh token that
+// Entra already invalidated server-side.
+func TestIsAuthenticatedPasswordEntraTokenRefreshFallsBackOnUserInfoError(t *testing.T) {
 	t.Parallel()
 
 	provider := &mockEntraAuthProvider{
@@ -3720,9 +3874,9 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshPreservesRotationOnUserInfoErro
 		userInfoFromTokenErr: errors.New("missing preferred_username claim"),
 	}
 
-	b, sessionID, access := runReturningEntraAuthLogin(t, provider)
-	require.Equal(t, broker.AuthDenied, access,
-		"a refreshed token whose user info cannot be extracted must deny the returning login")
+	b, sessionID, access, _ := runReturningEntraAuthLogin(t, provider, false)
+	require.Equal(t, broker.AuthGranted, access,
+		"a local user-info failure must not block a returning login when provider access checks are optional")
 
 	cached, err := token.LoadAuthInfo(b.TokenPathForSession(sessionID))
 	require.NoError(t, err)
@@ -3770,6 +3924,73 @@ func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesOnUsernameMismatch(t *tes
 	require.NoError(t, err)
 	require.Equal(t, "new-refresh-token", cached.Token.RefreshToken,
 		"a local username verification failure must not discard an already-rotated refresh token")
+}
+
+// TestIsAuthenticatedPasswordRefreshDeniesOnUserInfoSubMismatch verifies that
+// the OIDC Core identity-binding check cannot be downgraded to an offline login
+// when provider access checks are optional.
+func TestIsAuthenticatedPasswordRefreshDeniesOnUserInfoSubMismatch(t *testing.T) {
+	t.Parallel()
+
+	const correctPassword = "password"
+	const listenAddress = "127.0.0.1:31318"
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		listenAddress:         listenAddress,
+		customHandlers: map[string]testutils.EndpointHandler{
+			"/userinfo": testutils.UserInfoHandler(map[string]interface{}{
+				"sub":             "victim-provider-id",
+				"must-have-claim": "present",
+			}),
+		},
+		tokenHandlerOptions: &testutils.TokenHandlerOptions{
+			DeleteClaims: []string{"must-have-claim"},
+			IDTokenClaims: []map[string]interface{}{
+				{"sub": "attacker-provider-id"},
+			},
+		},
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	seeded := generateCachedInfo(t, tokenOptions{})
+	require.NoError(t, token.CacheAuthInfo(b.TokenPathForSession(sessionID), seeded))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a UserInfo subject mismatch must deny the returning login rather than use cached credentials")
+}
+
+// TestIsAuthenticatedPasswordEntraTokenRefreshDeniesWhenProviderCapabilityIsMissing
+// verifies that a cached Entra token is not treated as an ordinary OIDC token
+// when the configured provider can no longer refresh it through the Entra API.
+func TestIsAuthenticatedPasswordEntraTokenRefreshDeniesWhenProviderCapabilityIsMissing(t *testing.T) {
+	t.Parallel()
+
+	const correctPassword = "password"
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              &testutils.MockProvider{},
+		issuerURL:             defaultIssuerURL,
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{obtainedViaEntraAuth: true}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthDenied, access,
+		"a cached Entra token must not fall back when its refresh capability is unavailable")
 }
 
 // TestDeviceAuthClearsDeviceRegistrationDataWhenRegistrationDisabled verifies that

--- a/authd-oidc-brokers/internal/providers/errors/errors.go
+++ b/authd-oidc-brokers/internal/providers/errors/errors.go
@@ -33,7 +33,8 @@ func (e *RetryWithDeviceCodeFlowError) Unwrap() error {
 	return e.Err
 }
 
-// ForDisplayError is an error type for errors that are meant to be displayed to the user.
+// ForDisplayError wraps an error with a message that is safe to display to the user.
+// It does not indicate whether a caller may fall back to cached data.
 type ForDisplayError struct {
 	Message string
 	Err     error
@@ -44,6 +45,43 @@ func (e *ForDisplayError) Error() string {
 }
 
 func (e *ForDisplayError) Unwrap() error {
+	return e.Err
+}
+
+// AuthoritativeError marks an error as an authoritative provider result, such
+// as an identity or configuration failure. Callers can use errors.As to
+// distinguish it from a transient failure. It may be wrapped by a
+// ForDisplayError when the result should also be shown to the user.
+type AuthoritativeError struct {
+	Err error
+}
+
+func (e *AuthoritativeError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "authoritative provider error"
+}
+
+func (e *AuthoritativeError) Unwrap() error {
+	return e.Err
+}
+
+// NonAuthoritativeError marks a refresh failure for which cached credentials
+// may be used when provider access checks are optional. It may be wrapped by a
+// ForDisplayError when the failure should also be shown to the user.
+type NonAuthoritativeError struct {
+	Err error
+}
+
+func (e *NonAuthoritativeError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "non-authoritative provider error"
+}
+
+func (e *NonAuthoritativeError) Unwrap() error {
 	return e.Err
 }
 

--- a/authd-oidc-brokers/internal/providers/errors/errors_test.go
+++ b/authd-oidc-brokers/internal/providers/errors/errors_test.go
@@ -52,3 +52,63 @@ func TestRetryWithDeviceAuthError(t *testing.T) {
 		require.Equal(t, original, target)
 	})
 }
+
+func TestAuthoritativeError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Error_returns_wrapped_error_message_when_error_is_set", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("inner error")
+		err := &providerErrors.AuthoritativeError{Err: inner}
+		require.Equal(t, "inner error", err.Error())
+	})
+
+	t.Run("Error_returns_default_message_when_error_is_nil", func(t *testing.T) {
+		t.Parallel()
+
+		err := &providerErrors.AuthoritativeError{}
+		require.Equal(t, "authoritative provider error", err.Error())
+	})
+
+	t.Run("Unwrap_returns_wrapped_error", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("inner error")
+		err := &providerErrors.AuthoritativeError{Err: inner}
+		require.Equal(t, inner, err.Unwrap())
+		require.ErrorIs(t, err, inner)
+	})
+
+	t.Run("Unwrap_returns_nil_when_no_wrapped_error", func(t *testing.T) {
+		t.Parallel()
+
+		err := &providerErrors.AuthoritativeError{}
+		require.Nil(t, err.Unwrap())
+	})
+
+	t.Run("errors_As_matches_AuthoritativeError", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("cause")
+		original := &providerErrors.AuthoritativeError{Err: inner}
+		var target *providerErrors.AuthoritativeError
+		require.ErrorAs(t, original, &target)
+		require.Equal(t, original, target)
+	})
+}
+
+func TestNonAuthoritativeError(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New("inner error")
+	err := &providerErrors.NonAuthoritativeError{Err: inner}
+	require.Equal(t, "inner error", err.Error())
+	require.ErrorIs(t, err, inner)
+
+	var target *providerErrors.NonAuthoritativeError
+	require.ErrorAs(t, err, &target)
+	require.Equal(t, err, target)
+	require.Nil(t, (&providerErrors.NonAuthoritativeError{}).Unwrap())
+	require.Equal(t, "non-authoritative provider error", (&providerErrors.NonAuthoritativeError{}).Error())
+}

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -58,13 +58,17 @@ func (p GenericProvider) GetUserInfo(claimer info.Claimer, _ bool) (info.User, e
 	if !present {
 		return info.User{}, &providerErrors.ForDisplayError{
 			Message: "Authentication failure: email not verified",
-			Err:     providerErrors.NewMissingClaimError("email_verified"),
+			Err: &providerErrors.AuthoritativeError{
+				Err: providerErrors.NewMissingClaimError("email_verified"),
+			},
 		}
 	}
 	if verified, ok := rawEmailVerified.(bool); !ok || !verified {
 		return info.User{}, &providerErrors.ForDisplayError{
 			Message: "Authentication failure: email not verified",
-			Err:     errors.New("email_verified claim value is false or malformed"),
+			Err: &providerErrors.AuthoritativeError{
+				Err: errors.New("email_verified claim value is false or malformed"),
+			},
 		}
 	}
 
@@ -92,7 +96,10 @@ func (p GenericProvider) NormalizeUsername(username string) string {
 func (p GenericProvider) VerifyUsername(requestedUsername, username string) error {
 	if p.NormalizeUsername(requestedUsername) != p.NormalizeUsername(username) {
 		msg := fmt.Sprintf("Authentication failure: requested username %q does not match the authenticated user %q", requestedUsername, username)
-		return &providerErrors.ForDisplayError{Message: msg}
+		return &providerErrors.ForDisplayError{
+			Message: msg,
+			Err:     &providerErrors.AuthoritativeError{},
+		}
 	}
 	return nil
 }

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider_test.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider_test.go
@@ -2,6 +2,7 @@ package genericprovider_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -16,10 +17,11 @@ func TestGetUserInfo(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		claims      map[string]interface{}
-		wantUser    info.User
-		wantErr     bool
-		wantErrType error
+		claims            map[string]interface{}
+		wantUser          info.User
+		wantErr           bool
+		wantErrType       func(error) bool
+		wantAuthoritative bool
 	}{
 		"Successfully_get_user_info_with_all_fields": {
 			claims: map[string]interface{}{
@@ -59,8 +61,12 @@ func TestGetUserInfo(t *testing.T) {
 				"sub":   "sub123",
 				"email": "user@example.com",
 			},
-			wantErr:     true,
-			wantErrType: &providerErrors.MissingClaimError{Claim: "email_verified"},
+			wantErr: true,
+			wantErrType: func(err error) bool {
+				var target *providerErrors.MissingClaimError
+				return errors.As(err, &target)
+			},
+			wantAuthoritative: true,
 		},
 		"Error_when_email_is_not_verified": {
 			claims: map[string]interface{}{
@@ -68,8 +74,12 @@ func TestGetUserInfo(t *testing.T) {
 				"sub":            "sub123",
 				"email_verified": false,
 			},
-			wantErr:     true,
-			wantErrType: &providerErrors.ForDisplayError{},
+			wantErr: true,
+			wantErrType: func(err error) bool {
+				var target *providerErrors.ForDisplayError
+				return errors.As(err, &target)
+			},
+			wantAuthoritative: true,
 		},
 	}
 
@@ -86,7 +96,11 @@ func TestGetUserInfo(t *testing.T) {
 			if tc.wantErr {
 				require.Error(t, err)
 				if tc.wantErrType != nil {
-					require.ErrorAs(t, err, &tc.wantErrType)
+					require.True(t, tc.wantErrType(err), "error has an unexpected type")
+				}
+				if tc.wantAuthoritative {
+					var authoritativeErr *providerErrors.AuthoritativeError
+					require.True(t, errors.As(err, &authoritativeErr))
 				}
 				return
 			}
@@ -111,6 +125,46 @@ func (m *mockIDToken) Claims(v interface{}) error {
 	}
 
 	return nil
+}
+
+func TestVerifyUsername(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		requestedUsername string
+		username          string
+
+		wantErr bool
+	}{
+		"Success_when_usernames_match": {
+			requestedUsername: "user@example.com",
+			username:          "user@example.com",
+		},
+		"Error_when_usernames_do_not_match": {
+			requestedUsername: "user@example.com",
+			username:          "other@example.com",
+			wantErr:           true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := genericprovider.New()
+			err := p.VerifyUsername(tc.requestedUsername, tc.username)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				var displayErr *providerErrors.ForDisplayError
+				require.ErrorAs(t, err, &displayErr)
+				var authoritativeErr *providerErrors.AuthoritativeError
+				require.True(t, errors.As(err, &authoritativeErr))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestIsTokenExpiredError(t *testing.T) {

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -286,7 +286,12 @@ func (p *Provider) GetGroups(
 		}
 		if errors.Is(err, himmelblau.ErrInvalidRedirectURI) {
 			msg := "Token acquisition failed: The app is misconfigured in Microsoft Entra (the redirect URI is missing or invalid). Please contact your administrator."
-			return nil, &providerErrors.ForDisplayError{Message: msg, Err: fmt.Errorf("%w: %w", providerErrors.ErrInvalidRedirectURI, err)}
+			return nil, &providerErrors.ForDisplayError{
+				Message: msg,
+				Err: &providerErrors.AuthoritativeError{
+					Err: fmt.Errorf("%w: %w", providerErrors.ErrInvalidRedirectURI, err),
+				},
+			}
 		}
 		var tokenAcquisitionError himmelblau.TokenAcquisitionError
 		if errors.As(err, &tokenAcquisitionError) {
@@ -528,6 +533,8 @@ func (p *Provider) fetchUserGroups(token *jwt.Token, msgraphHost string) ([]info
 	// Check if the token has the GroupMember.Read.All scope
 	if !slices.Contains(scopes, "GroupMember.Read.All") {
 		msg := "Error: the Microsoft Entra ID app is missing the GroupMember.Read.All permission"
+		// Returning logins may use cached groups when group lookup fails, so this
+		// message is displayable but is not an authoritative authentication result.
 		return nil, &providerErrors.ForDisplayError{Message: msg}
 	}
 
@@ -863,7 +870,10 @@ func (p *Provider) VerifyAccessToken(ctx context.Context, issuerURL, accessToken
 func (p *Provider) VerifyUsername(requestedUsername, authenticatedUsername string) error {
 	if p.NormalizeUsername(requestedUsername) != p.NormalizeUsername(authenticatedUsername) {
 		msg := fmt.Sprintf("Authentication failure: requested username %q does not match the authenticated username %q", requestedUsername, authenticatedUsername)
-		return &providerErrors.ForDisplayError{Message: msg}
+		return &providerErrors.ForDisplayError{
+			Message: msg,
+			Err:     &providerErrors.AuthoritativeError{},
+		}
 	}
 
 	// Check that the usernames only contain the characters allowed by the Microsoft Entra username policy
@@ -873,11 +883,17 @@ func (p *Provider) VerifyUsername(requestedUsername, authenticatedUsername strin
 		// If this error occurs, we should investigate and probably relax the username policy, so we ask the user
 		// explicitly to report this error.
 		msg := fmt.Sprintf("Authentication failure: the authenticated username %q contains invalid characters. Please report this error on https://github.com/canonical/authd/issues", authenticatedUsername)
-		return &providerErrors.ForDisplayError{Message: msg}
+		return &providerErrors.ForDisplayError{
+			Message: msg,
+			Err:     &providerErrors.AuthoritativeError{},
+		}
 	}
 	if !usernameRegexp.MatchString(requestedUsername) {
 		msg := fmt.Sprintf("Authentication failure: requested username %q contains invalid characters", requestedUsername)
-		return &providerErrors.ForDisplayError{Message: msg}
+		return &providerErrors.ForDisplayError{
+			Message: msg,
+			Err:     &providerErrors.AuthoritativeError{},
+		}
 	}
 
 	return nil

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -71,12 +71,28 @@ authd uses libpwquality to enforce password complexity requirements. See the
 
 If the identity provider is reachable during login, authd verifies that the user
 is still allowed to authenticate with the identity provider. If the user's
-account has been disabled or removed, login is denied.
+account has been disabled or removed, login is denied. If the check fails for a
+non-authoritative reason, such as a network or token verification error, authd
+continues with the local password by default. Authoritative identity or
+configuration failures still deny login. When forced provider authentication is
+enabled, non-authoritative failures also deny login.
 
-By default, if the identity provider cannot be reached (for example, due to
-network issues), users can still log in with their local password. This is to
-prevent accidental lockouts, but it also allows users whose access has been
-revoked at the identity provider to log in while the provider is unreachable.
+By default, this prevents accidental lockouts, but it also allows users whose
+access has been revoked at the identity provider to log in while the provider
+cannot confirm that revocation.
+
+The refresh result determines the authentication response as follows:
+
+| Refresh result | Provider check optional (`false`) | Provider check forced (`true`) |
+| --- | --- | --- |
+| User or device is disabled | `AuthDenied`; cache the disabled state | `AuthDenied` |
+| Refresh grant was revoked or the remote password changed | `AuthNext`; invalidate cached credentials and require re-authentication | `AuthNext`; require re-authentication |
+| Refresh token is expired | `AuthGranted`; use cached credentials and mark the session offline | `AuthNext`; require re-authentication |
+| Network or temporary provider error | `AuthGranted`; use cached credentials and mark the session offline | `AuthDenied` |
+| Non-authoritative token verification or user-info failure | `AuthGranted`; use cached credentials and mark the session offline | `AuthDenied`; preserve a safe display message when available |
+| Unknown or unclassified refresh error | `AuthGranted`; treat the check as best effort and use cached credentials | `AuthDenied` |
+| Known authoritative identity or configuration error | `AuthDenied`; do not use cached credentials | `AuthDenied` |
+| No cached refresh token | `AuthNext`; require re-authentication | `AuthNext`; require re-authentication |
 
 To enforce verification with the identity provider even when it is unreachable,
 enable the [force_access_check_with_provider](ref::config-force-provider-auth)

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -247,9 +247,10 @@ client_secret = <CLIENT_SECRET>
 (ref::config-force-provider-auth)=
 ## Force remote access check with the identity provider
 
-By default, remote authentication with the identity provider only happens if
-there is a working internet connection and the provider is reachable during
-login.
+By default, the provider access check during remote login is best effort. A
+valid local password is sufficient when the check cannot be completed for a
+reason that does not indicate revoked access, such as a network or token
+verification error.
 
 To ensure that user access permissions are always checked with the identity
 provider during login, even when the provider is unreachable, enable the check

--- a/e2e-tests/resources/authd.resource
+++ b/e2e-tests/resources/authd.resource
@@ -39,15 +39,16 @@ Change Password
 
 
 Try Log In With Remote User
-    [Arguments]    ${username}
-    Try machinectl login Prompt
+    [Arguments]    ${username}    ${prompt_timeout}=30
+    Try machinectl login Prompt    ${prompt_timeout}
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
 
 
 # Conditional checks
 Check That Remote User Has No Available Authentication Modes
-    Match Text    Error connecting to provider. Check your network connection.    120
+    [Arguments]    ${timeout}=30
+    Match Text    Error connecting to provider. Check your network connection.    ${timeout}
 
 
 Check That Log In Fails Because Authd Is Disabled

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -247,7 +247,7 @@ Update Authd
 
 
 Sync System Time
-    ${output} =    SSH.Execute    nm-online -q && systemctl restart systemd-timesyncd
+    ${output} =    SSH.Execute    nm-online -q && (systemctl reset-failed systemd-timesyncd.service 2>/dev/null || true) && timedatectl set-ntp true
     Log    ${output}    level=DEBUG
     ${output} =   SSH.Execute    timedatectl show -p NTPSynchronized | grep -q NTPSynchronized=yes
     Log    ${output}    level=DEBUG
@@ -263,7 +263,7 @@ Set Guest Clock In Future
     Set Test Variable    ${guest_clock_changed}    ${True}
     ${change_guest_clock_command}=    Catenate    SEPARATOR=&&
     ...    timedatectl set-ntp false
-    ...    systemctl stop systemd-timesyncd.service
+    ...    (systemctl stop systemd-timesyncd.service 2>/dev/null || true)
     ...    timedatectl set-time "$(date -d '+1 day' '+%Y-%m-%d %H:%M:%S')"
     ...    date --iso-8601=seconds
     ${clock}=    SSH.Execute    ${change_guest_clock_command}
@@ -273,8 +273,8 @@ Set Guest Clock In Future
 Restore Guest Clock
     [Documentation]    Re-enables guest time synchronization and waits for it to catch up.
     ${restore_guest_clock_command}=    Catenate    SEPARATOR=&&
+    ...    (systemctl reset-failed systemd-timesyncd.service 2>/dev/null || true)
     ...    timedatectl set-ntp true
-    ...    systemctl restart systemd-timesyncd.service
     SSH.Execute    ${restore_guest_clock_command}
     Wait Until System Time Synced
 

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -20,6 +20,7 @@ ${SUITE_OUTPUT_DIR}    ${OUTPUT_DIR}/${SUITE_NAME.rsplit('.')[-1]}
 ${YARF_IMAGE_DIR}    ${SUITE_OUTPUT_DIR}/screenshots
 ${OCR_CONFIDENCE_THRESHOLD}    94
 ${OCR_SIMILARITY_THRESHOLD}    92
+${guest_clock_changed}    ${False}
 
 
 *** Keywords ***
@@ -255,6 +256,27 @@ Sync System Time
 Wait Until System Time Synced
     Wait Until Keyword Succeeds    1 min    1 sec
     ...    Sync System Time
+
+
+Set Guest Clock In Future
+    [Documentation]    Stops guest time synchronization and moves the guest clock one day ahead.
+    Set Test Variable    ${guest_clock_changed}    ${True}
+    ${change_guest_clock_command}=    Catenate    SEPARATOR=&&
+    ...    timedatectl set-ntp false
+    ...    systemctl stop systemd-timesyncd.service
+    ...    timedatectl set-time "$(date -d '+1 day' '+%Y-%m-%d %H:%M:%S')"
+    ...    date --iso-8601=seconds
+    ${clock}=    SSH.Execute    ${change_guest_clock_command}
+    Log    Guest clock is ${clock}
+
+
+Restore Guest Clock
+    [Documentation]    Re-enables guest time synchronization and waits for it to catch up.
+    ${restore_guest_clock_command}=    Catenate    SEPARATOR=&&
+    ...    timedatectl set-ntp true
+    ...    systemctl restart systemd-timesyncd.service
+    SSH.Execute    ${restore_guest_clock_command}
+    Wait Until System Time Synced
 
 
 Try machinectl login Prompt

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -280,12 +280,13 @@ Restore Guest Clock
 
 
 Try machinectl login Prompt
+    [Arguments]    ${prompt_timeout}=120
     VAR    ${tries}    3
     WHILE    ${tries} > 0
         Hid.Type String    machinectl login
         Hid.Keys Combo    Return
         ${match} =     Run Keyword And Return Status
-        ...    Match Text    ubuntu login:    120
+        ...    Match Text    ubuntu login:    ${prompt_timeout}
         IF   '${match}' == 'True'
             BREAK
         END

--- a/e2e-tests/tests/force_access_check_with_provider.robot
+++ b/e2e-tests/tests/force_access_check_with_provider.robot
@@ -6,7 +6,7 @@ Resource        resources/broker.resource
 # Test Tags       robot:exit-on-failure
 
 Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
-Test Teardown   utils.Test Teardown
+Test Teardown   Test Teardown And Restore Guest Clock
 
 
 *** Variables ***
@@ -14,17 +14,35 @@ ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 
 
+*** Keywords ***
+Login Remote User Through CLI
+    Log In
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    Log Out From Terminal Session
+    Close Focused Window
+
+Unlock Session With Local Password
+    [Arguments]    ${local_password}
+    Match Text    Enter your password    30
+    Hid.Type String    ${local_password}
+    Hid.Keys Combo    Return
+    Wait Until Desktop Ready
+
+
+Test Teardown And Restore Guest Clock
+    IF    ${guest_clock_changed}
+        Run Keyword And Continue On Failure    Restore Guest Clock
+    END
+    utils.Test Teardown
+
+
 *** Test Cases ***
 Test second login succeeds with force_access_check_with_provider enabled
     [Documentation]    Verify that a registered user can log in with their local password
     ...    when force_access_check_with_provider is enabled and the identity provider is reachable.
 
-    Log In
-
-    Open Terminal
-    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
-    Log Out From Terminal Session
-    Close Focused Window
+    Login Remote User Through CLI
 
     Change Broker Configuration    force_access_check_with_provider    true
 
@@ -36,12 +54,7 @@ Test second login fails with force_access_check_with_provider enabled offline
     [Documentation]    Verify that a registered user cannot log in when
     ...    force_access_check_with_provider is enabled and the identity provider is unreachable.
 
-    Log In
-
-    Open Terminal
-    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
-    Log Out From Terminal Session
-    Close Focused Window
+    Login Remote User Through CLI
 
     Change Broker Configuration    force_access_check_with_provider    true
 
@@ -51,3 +64,58 @@ Test second login fails with force_access_check_with_provider enabled offline
     Open Terminal
     Try Log In With Remote User    ${username}
     Check That Remote User Has No Available Authentication Modes
+
+
+Test fresh GDM login falls back to local password when token verification fails due to network issues
+    [Documentation]    Verify that a registered user can start a fresh GDM login with their
+    ...    local password when optional provider token verification fails.
+
+    Login Remote User Through CLI
+    Log Out
+
+    Change Broker Configuration    force_access_check_with_provider    false
+    Block Network Access To Identity Provider
+
+    Log In With Remote User Through GDM: Local Password    ${username}    ${local_password}
+
+
+Test locked session unlock falls back to local password when token verification fails due to network issues
+    [Documentation]    Verify that a registered user can unlock a locked session with their
+    ...    local password when optional provider token verification fails.
+
+    Log In With Remote User Through GDM: QR Code    ${username}    ${local_password}
+
+    Change Broker Configuration    force_access_check_with_provider    false
+    Block Network Access To Identity Provider
+    
+    SSH.Execute    loginctl lock-sessions
+    Hid.Keys Combo    Return
+
+    Unlock Session With Local Password    ${local_password}
+    
+
+Test fresh GDM login falls back to local password when token verification fails due to clock skew
+    [Documentation]    Verify that a registered user can start a fresh GDM login with their
+    ...    local password when optional provider token verification fails.
+
+    Login Remote User Through CLI
+    Log Out
+
+    Change Broker Configuration    force_access_check_with_provider    false
+    Set Guest Clock In Future
+    Log In With Remote User Through GDM: Local Password    ${username}    ${local_password}
+
+
+Test locked session unlock falls back to local password when token verification fails due to clock skew
+    [Documentation]    Verify that a registered user can unlock a locked session with their
+    ...    local password when optional provider token verification fails.
+
+    Log In With Remote User Through GDM: QR Code    ${username}    ${local_password}
+
+    Change Broker Configuration    force_access_check_with_provider    false
+    Set Guest Clock In Future
+
+    SSH.Execute    loginctl lock-sessions
+    Hid.Keys Combo    Return
+
+    Unlock Session With Local Password    ${local_password}


### PR DESCRIPTION
Provider access checks are best effort unless force_access_check_with_provider is enabled. 
Keep displayable errors separate from authoritative identity and configuration failures so cached local credentials are used only for non-authoritative refresh failures.

e2e-tests: force_access_check_with_provider.robot

Closes #1824 
UDENG-11281