### PR TITLE
e2e: test migrations with branch packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,5 +17,6 @@ e2e-tests: allowed_users.robot login_gdm.robot
 e2e-ppa: authd-dev
 
 The `e2e-ppa: authd-dev` marker sets the workflow's `authd-ppa` input to
-`ubuntu-enterprise-desktop/authd-dev` instead of `authd-edge`.
+`ubuntu-enterprise-desktop/authd-dev` instead of `authd-edge` for resolving
+authd package dependencies.
 -->

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -237,6 +237,7 @@ jobs:
           BROKER: ${{ inputs.broker }}
           E2E_TESTS: ${{ inputs.e2e-tests }}
           AUTHD_DEB: ${{ steps.download-authd-deb.outputs.deb }}
+          AUTHD_PPA: ${{ inputs.authd-ppa }}
           BROKER_SNAP: ${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}
         run: |
           set -eux

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -236,6 +236,8 @@ jobs:
           RELEASE: ${{ inputs.ubuntu-version }}
           BROKER: ${{ inputs.broker }}
           E2E_TESTS: ${{ inputs.e2e-tests }}
+          AUTHD_DEB: ${{ steps.download-authd-deb.outputs.deb }}
+          BROKER_SNAP: ${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}
         run: |
           set -eux
           export PATH="$(realpath "${{ env.E2E_TESTS_DIR }}/vm/helpers"):${PATH}"

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -83,8 +83,13 @@ including `--rerunfailed` and `--output-dir`.
 ## Running in GitHub CI
 
 By default, GitHub CI runs the end-to-end tests against both `authd-google` and
-`authd-msentraid`, using the complete test suite and packages from the
-[authd-edge PPA][authd-edge-ppa].
+`authd-msentraid`, using the complete test suite and the authd package and
+broker snap built from the current branch. The authd package dependencies
+(gnome-shell) are resolved from the [authd-edge PPA][authd-edge-ppa].
+Migration suites start with the last stable authd and broker releases before
+installing the branch-built package or snap.
+To use locally built packages in those suites, set `AUTHD_DEB` and
+`BROKER_SNAP` to their host paths when running `run-tests.sh`.
 
 The E2E workflow runs for a pull request only when it has the `e2e-tests` label.
 The pull request template contains commented examples for selecting brokers,
@@ -92,7 +97,7 @@ test suites, and the authd PPA. Copy the relevant line into the visible part of
 the pull request description to enable it; leave it commented to use the
 default.
 
-To install authd and its dependencies from the [authd-dev PPA][authd-dev-ppa]
+To resolve authd package dependencies from the [authd-dev PPA][authd-dev-ppa]
 instead, add `e2e-ppa: authd-dev` to the pull request description.
 
 To run only selected end-to-end test suites, add an `e2e-tests:` line to the

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -85,11 +85,12 @@ including `--rerunfailed` and `--output-dir`.
 By default, GitHub CI runs the end-to-end tests against both `authd-google` and
 `authd-msentraid`, using the complete test suite and the authd package and
 broker snap built from the current branch. The authd package dependencies
-(gnome-shell) are resolved from the [authd-edge PPA][authd-edge-ppa].
-Migration suites start with the last stable authd and broker releases before
-installing the branch-built package or snap.
+(gnome-shell) are resolved from the [authd-edge PPA][authd-edge-ppa], or from
+the PPA selected with `AUTHD_PPA`. Migration suites start with the last stable
+authd and broker releases before installing the branch-built package or snap.
 To use locally built packages in those suites, set `AUTHD_DEB` and
-`BROKER_SNAP` to their host paths when running `run-tests.sh`.
+`BROKER_SNAP` to their host paths when running `run-tests.sh`. Set `AUTHD_PPA`
+as well when the authd package dependencies should come from a different PPA.
 
 The E2E workflow runs for a pull request only when it has the `e2e-tests` label.
 The pull request template contains commented examples for selecting brokers,

--- a/e2e-tests/resources/SSH.py
+++ b/e2e-tests/resources/SSH.py
@@ -7,6 +7,7 @@ import ExecUtils
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SSH_SCRIPT = os.path.abspath(os.path.join(SCRIPT_DIR, "ssh.sh"))
+SCP_SCRIPT = os.path.abspath(os.path.join(SCRIPT_DIR, "../vm/scp.sh"))
 
 @library
 class SSH:
@@ -44,6 +45,22 @@ class SSH:
             logger.debug(f"stderr: {stderr}")
 
         return stdout
+
+    @keyword
+    async def copy_to_vm(self, local_path: str, remote_path: str) -> None:
+        """
+        Copy a local file to the VM over its VSOCK SSH connection.
+
+        Args:
+            local_path: Path to the local file.
+            remote_path: Destination path in the VM.
+        """
+        ExecUtils.run(
+            [SCP_SCRIPT, local_path, remote_path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
     @keyword
     async def execute_as_user(self, user:str, command: str, timeout: int|None = 30) -> str:

--- a/e2e-tests/resources/authd.resource
+++ b/e2e-tests/resources/authd.resource
@@ -10,10 +10,6 @@ ${local_password}    qwer1234
 
 
 *** Keywords ***
-Enable Edge Repository For Authd
-    SSH.Execute    add-apt-repository ppa:ubuntu-enterprise-desktop/authd-edge -y  timeout=300
-
-
 Disable Authd Socket And Service
     SSH.Execute    systemctl mask --now authd.socket
     SSH.Execute    systemctl mask --now authd.service

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -18,8 +18,17 @@ Variables           ./broker_vars.py
 
 
 *** Keywords ***
-Enable Edge Broker
-    SSH.Execute    snap refresh ${BROKER_SNAP_NAME} --edge
+Update Broker
+    [Documentation]    Install the broker snap built from the current branch
+    ...                when one was provided for the test run. Otherwise
+    ...                refresh the broker from the edge channel.
+    ${broker_snap}=    Get Environment Variable    BROKER_SNAP    ${EMPTY}
+    IF    $broker_snap != ''
+        SSH.Copy To VM    ${broker_snap}    /home/ubuntu/broker-under-test.snap
+        SSH.Execute    snap install --dangerous /home/ubuntu/broker-under-test.snap
+    ELSE
+        SSH.Execute    snap refresh ${BROKER_SNAP_NAME} --edge
+    END
 
 
 Disable Broker And Purge Config
@@ -125,7 +134,7 @@ Wait For Shell Prompt After Login
     # The shell prompt did not appear. Only attribute the failure to #1642 if we are
     # running one of the migration tests (where the stable, unfixed authd is active)
     # and the journal shows login failing with a PAM "System error".
-    IF    '${TEST NAME}' == 'Test login after updating authd to edge version' or '${TEST NAME}' == 'Test login after upgrading authd and broker to edge channel'
+    IF    '${TEST NAME}' == 'Test login after updating authd to the version under test' or '${TEST NAME}' == 'Test login after upgrading authd and broker'
         ${system_error} =    SSH.Execute
         ...    sudo journalctl --no-pager --since "10 minutes ago" | grep "FAILED LOGIN" | grep "System error" || true
         IF    $system_error != ''

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -231,7 +231,13 @@ Cancel Operation
 
 
 Update Authd
-    SSH.Execute    apt-get install -y authd    timeout=120
+    ${authd_deb}=    Get Environment Variable    AUTHD_DEB    ${EMPTY}
+    IF    $authd_deb != ''
+        SSH.Copy To VM    ${authd_deb}    /home/ubuntu/authd-under-test.deb
+        SSH.Execute    apt-get install -y /home/ubuntu/authd-under-test.deb    timeout=120
+    ELSE
+        SSH.Execute    apt-get install -y authd    timeout=120
+    END
 
 
 Sync System Time

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -231,6 +231,11 @@ Cancel Operation
 
 
 Update Authd
+    ${authd_ppa}=    Get Environment Variable    AUTHD_PPA    ${EMPTY}
+    IF    $authd_ppa == ''
+        ${authd_ppa}=    Set Variable    ubuntu-enterprise-desktop/authd-edge
+    END
+    SSH.Execute    add-apt-repository ppa:${authd_ppa} -y    timeout=300
     ${authd_deb}=    Get Environment Variable    AUTHD_DEB    ${EMPTY}
     IF    $authd_deb != ''
         SSH.Copy To VM    ${authd_deb}    /home/ubuntu/authd-under-test.deb

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -24,6 +24,10 @@ Prerequisites:
 
   - YARF must be installed via the setup_yarf.sh script
 
+Optional environment variables:
+  AUTHD_DEB           Host path to the authd package for migration tests
+  BROKER_SNAP         Host path to the broker snap for migration tests
+
 Options:
   -u, --user <name>            Username for the tests (can also be set via E2E_USER environment variable)
   -p, --password <password>    Password for the tests (can also be set via E2E_PASSWORD environment variable)
@@ -212,6 +216,9 @@ env \
     TOTP_SECRET="$TOTP_SECRET" \
     BROKER="$BROKER" \
     RELEASE="$RELEASE" \
+    VM_NAME="$VM_NAME" \
+    AUTHD_DEB="${AUTHD_DEB:-}" \
+    BROKER_SNAP="${BROKER_SNAP:-}" \
     VNC_PORT="$VNC_PORT" \
     SYSTEMD_SUPPORTS_VSOCK="${SYSTEMD_SUPPORTS_VSOCK:-}" \
     YARF_LOG_VIDEO="${YARF_LOG_VIDEO}" \

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -26,6 +26,7 @@ Prerequisites:
 
 Optional environment variables:
   AUTHD_DEB           Host path to the authd package for migration tests
+  AUTHD_PPA           PPA to use for authd dependencies in migration tests
   BROKER_SNAP         Host path to the broker snap for migration tests
 
 Options:
@@ -218,6 +219,7 @@ env \
     RELEASE="$RELEASE" \
     VM_NAME="$VM_NAME" \
     AUTHD_DEB="${AUTHD_DEB:-}" \
+    AUTHD_PPA="${AUTHD_PPA:-}" \
     BROKER_SNAP="${BROKER_SNAP:-}" \
     VNC_PORT="$VNC_PORT" \
     SYSTEMD_SUPPORTS_VSOCK="${SYSTEMD_SUPPORTS_VSOCK:-}" \

--- a/e2e-tests/tests/migration_authd.robot
+++ b/e2e-tests/tests/migration_authd.robot
@@ -16,8 +16,9 @@ ${local_password}    qwer1234
 
 
 *** Test Cases ***
-Test login after updating authd to edge version
-    [Documentation]    Test login via CLI with device code flow and local password after switching to the edge PPA for authd.
+Test login after updating authd to the version under test
+    [Documentation]    Test login via CLI with device code flow and local password
+    ...                after updating authd to the version under test.
 
     # Log in with local user
     Log In
@@ -36,7 +37,7 @@ Test login after updating authd to edge version
     Log Out From su Session
     Close Focused Window
 
-    # Switch to the edge PPA for authd
+    # Add the edge PPA to provide dependencies for the authd package under test.
     Enable Edge Repository For Authd
     Update Authd
 

--- a/e2e-tests/tests/migration_authd.robot
+++ b/e2e-tests/tests/migration_authd.robot
@@ -37,8 +37,6 @@ Test login after updating authd to the version under test
     Log Out From su Session
     Close Focused Window
 
-    # Add the edge PPA to provide dependencies for the authd package under test.
-    Enable Edge Repository For Authd
     Update Authd
 
     # Log in with remote user with local password after upgrading

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -41,8 +41,6 @@ Test login after upgrading authd and broker
     Log Out From su Session
     Close Focused Window
 
-    # Add the edge PPA to provide dependencies for the authd package under test.
-    Enable Edge Repository For Authd
     Update Broker
     Update Authd
 

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -16,8 +16,13 @@ ${local_password}    qwer1234
 
 
 *** Test Cases ***
-Test login after upgrading authd and broker to edge channel
-    [Documentation]    This test verifies that after upgrading both authd and the broker to the edge channel, remote users can still log in using device code flow and local password, and their accounts are properly set up on the system.
+Test login after upgrading authd and broker
+    [Documentation]    This test verifies that after upgrading authd to the
+    ...                version under test and the broker to the version under
+    ...                test,
+    ...                remote users can still log in using device code flow and
+    ...                local password, and their accounts are properly set up
+    ...                on the system.
 
     # Log in with local user
     Log In
@@ -36,9 +41,9 @@ Test login after upgrading authd and broker to edge channel
     Log Out From su Session
     Close Focused Window
 
-    # Switch to the edge channel for the broker snap and the edge PPA for authd
+    # Add the edge PPA to provide dependencies for the authd package under test.
     Enable Edge Repository For Authd
-    Enable Edge Broker
+    Update Broker
     Update Authd
 
     # Log in with remote user with local password after upgrading

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -16,8 +16,10 @@ ${local_password}    qwer1234
 
 
 *** Test Cases ***
-Test login with broker on edge channel
-    [Documentation]    Test login with broker on edge channel with device code flow and local password, before and after upgrading authd and broker to edge channel.
+Test login with broker version under test
+    [Documentation]    Test login with the broker version under test with
+    ...                device code flow and local password, before and after
+    ...                upgrading the broker.
 
     # Log in with local user
     Log In
@@ -36,8 +38,8 @@ Test login with broker on edge channel
     Log Out From su Session
     Close Focused Window
 
-    # Switch to edge channel for the broker snap
-    Enable Edge Broker
+    # Install the broker version under test.
+    Update Broker
 
     # Log in with remote user with local password after upgrading
     Open Terminal

--- a/e2e-tests/vm/provision-authd.sh
+++ b/e2e-tests/vm/provision-authd.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 LIB_DIR="${SCRIPT_DIR}/lib"
 SSH="${SCRIPT_DIR}/ssh.sh"
+SCP="${SCRIPT_DIR}/scp.sh"
 DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/authd-e2e-tests"
 
 usage(){
@@ -208,7 +209,7 @@ function install_broker() {
         # Copy the local snap to the VM and install it
         local remote_snap
         remote_snap="/home/ubuntu/$(basename "${snap_file}")"
-        scp_to_vm "${snap_file}" "${remote_snap}"
+        "${SCP}" "${snap_file}" "${remote_snap}"
         $SSH snap install --dangerous "${remote_snap}"
     else
         # Install the snap from the specified channel
@@ -233,20 +234,6 @@ function install_broker() {
     # Reboot VM and wait until it's back
     virsh reboot "${VM_NAME}"
     wait_for_system_running
-}
-
-function scp_to_vm() {
-    local local_path="$1"
-    local remote_path="$2"
-    local cid
-    cid=$(virsh dumpxml "${VM_NAME}" | \
-          xmllint --xpath 'string(//vsock/cid/@address)' -)
-    scp \
-      -o ProxyCommand="socat - VSOCK-CONNECT:${cid}:22" \
-      -o UserKnownHostsFile=/dev/null \
-      -o StrictHostKeyChecking=no \
-      -o LogLevel=ERROR \
-      "${local_path}" "root@localhost:${remote_path}"
 }
 
 # Print executed commands to ease debugging
@@ -317,7 +304,7 @@ EOF
 
 # Install the version of authd to test
 if [ -n "${AUTHD_DEB:-}" ]; then
-    scp_to_vm "${AUTHD_DEB}" "/home/ubuntu/$(basename "${AUTHD_DEB}")"
+    "${SCP}" "${AUTHD_DEB}" "/home/ubuntu/$(basename "${AUTHD_DEB}")"
     $SSH apt-get install -y "/home/ubuntu/$(basename "${AUTHD_DEB}")"
 else
     $SSH "apt-get install -y authd"

--- a/e2e-tests/vm/scp.sh
+++ b/e2e-tests/vm/scp.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z "${VM_NAME:-}" ] && [ -z "${RELEASE:-}" ]; then
+    echo >&2 "Error: Missing VM_NAME or RELEASE"
+    exit 1
+fi
+
+if [ "$#" -ne 2 ]; then
+    echo >&2 "Usage: $0 <local_path> <remote_path>"
+    exit 1
+fi
+
+VM_NAME=${VM_NAME:-"e2e-runner-${RELEASE}"}
+
+CID=$(virsh dumpxml "${VM_NAME}" | \
+      xmllint --xpath 'string(//vsock/cid/@address)' -)
+
+exec scp \
+  -o ProxyCommand="socat - VSOCK-CONNECT:${CID}:22" \
+  -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=no \
+  -o LogLevel=ERROR \
+  "$1" "root@localhost:$2"


### PR DESCRIPTION
In CI, the migration e2e-tests should exercise upgrades from the latest stable authd and broker releases to artifacts built from the current branch. Pass the branch-built Debian package and broker snap into the VM and install them during the update step. For local runs which don't specify packages via the AUTHD_DEB and BROKER_SNAP environment variables, we keep falling back to the edge version.

e2e-brokers: msentraid
e2e-tests: e2e-tests/tests/migration_authd.robot e2e-tests/tests/migration_authd_broker.robot e2e-tests/tests/migration_broker.robot

UDENG-11344
Closes #1842