### PR TITLE
fix(pam/integration-tests): fix flaky QR code CLI authentication tests

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -236,14 +236,6 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `6\. Use a QR code`)
 				c.Send(t, "6")
-				c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
-				// The QR view exceeds the PTY read buffer and arrives in
-				// several reads. A WaitFor poll can land between the chunk
-				// carrying "Scan the qrcode" and the one carrying "Code:",
-				// snapshotting a half-drawn QR matrix. Discard that
-				// intermediate frame; the "Code:" frame is a complete
-				// superset that captures the same screen.
-				c.DiscardLastSnapshot()
 				c.WaitFor(t, `Code:\s*1337`)
 				c.Send(t, "	")
 				c.Send(t, strings.Repeat("\r", 100))
@@ -931,14 +923,6 @@ func cliAuthenticateWithQRCode(t *testing.T, c *ptytest.Console, signalFn func(s
 	c.WaitFor(t, `Select the authentication flow:`)
 	c.WaitFor(t, `6\. Use a QR code`)
 	c.Send(t, "6")
-	c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
-	// The QR view (label, QR matrix, URL, Code) is emitted as a single render,
-	// but in a TTY it exceeds the PTY read buffer and arrives in several reads.
-	// A WaitFor poll can therefore land between the chunk carrying the "Scan the
-	// qrcode" label (top of the view) and the one carrying "Code:" (bottom),
-	// snapshotting a half-drawn QR matrix. Discard that intermediate frame; the
-	// "Code:" frame below is a complete superset that captures the same screen.
-	c.DiscardLastSnapshot()
 	c.WaitFor(t, `Code:\s*1337`)
 	// The Regenerate button has a 500ms reselectionWaitTime guard to
 	// prevent accidental double-clicks right after mode selection.


### PR DESCRIPTION
### Summary
Fixes intermittent golden snapshot test failures in `TestCLIAuthenticate/Authenticate_user_with_qr_code` and `TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY` caused by timing races during QR code rendering in the PTY

### Key Changes
* **Direct Frame Synchronization:** Removed the intermediate `WaitFor` on `"Scan the qrcode or enter the code in the login page"` and the subsequent `DiscardLastSnapshot()` call in `cliAuthenticateWithQRCode` and `Authenticate_user_with_qr_code_after_many_regenerations`.
* **Deterministic Snapshot Capture:** Synchronized directly on `WaitFor(t, "Code:\\s*1337")`, ensuring the complete QR matrix and prompt are fully rendered in the terminal buffer before taking a snapshot.

### Related Issues
* Closes #1624

I've tested the tests locally and they're passing.
Take a look at this when you get time @adombeck @nooreldeenmansour.