### PR TITLE
ci: pin staticcheck to v0.7.0

### DIFF
--- a/.github/workflows/tics-run.yaml
+++ b/.github/workflows/tics-run.yaml
@@ -36,7 +36,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ env.build_dependencies }}
 
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          # We need to pin staticcheck to v0.7.0 while we are in Go 1.25 since newer versions require Go 1.26 or later.
+          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
       - name: Update Rust version
         run: |


### PR DESCRIPTION
Newer staticcheck versions [require Go >= 1.26](https://github.com/canonical/authd/actions/runs/33345908055/job/99349869529#step:6:425). Since we are bound to Go 1.25 due to archive availability, we need to pin the dependency version to the latest one that still supports Go 1.25.