### PR TITLE
e2e-tests: downgrade rapidocr version to 3.7.0

### DIFF
--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -221,7 +221,7 @@ jobs:
       - name: Checkout YARF repo
         uses: actions/checkout@v7
         with:
-          repository: adombeck/yarf
+          repository: OrazioLucioTerranova/yarf
           path: ${{ env.E2E_TESTS_DIR }}/.yarf
 
       - name: Install APT dependencies for running the E2E tests


### PR DESCRIPTION
Downgrade rapidocr to 3.7.0 to test if OCR is less error prone (as discussed in https://github.com/canonical/authd/issues/1826) 

e2e-brokers: authd-msentraid

