### PR TITLE
debian: Fix Noble GNOME Shell version

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ include /usr/share/dpkg/pkg-info.mk
 include /usr/share/rustc/architecture.mk
 
 ifeq ($(DEB_DISTRIBUTION),noble)
-GNOME_SHELL_PATCHED_VERSION := 46.3.1-1ubuntu1+authd1~24.04.1
+GNOME_SHELL_PATCHED_VERSION := 46.3.1-1ubuntu1~24.04.1authd11
 else ifeq ($(DEB_DISTRIBUTION),resolute)
 GNOME_SHELL_PATCHED_VERSION := 50.1-0ubuntu1.2+authd1~26.04.1
 else ifeq ($(DEB_DISTRIBUTION),stonking)

--- a/debian/rules
+++ b/debian/rules
@@ -15,11 +15,16 @@ $(error Unsupported distribution "$(DEB_DISTRIBUTION)" for gnome-shell dependenc
 endif
 
 # Keep gnome-shell optional for server installations. Newer versions are
-# accepted on stonking because the integration patch landed upstream there.
+# accepted on stonking because the patch that fixes
+# https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/2160622 landed
+# upstream there.
 ifeq ($(DEB_DISTRIBUTION),stonking)
 GNOME_SHELL_BREAKS := gnome-shell (<< $(GNOME_SHELL_PATCHED_VERSION))
 else
-# On older releases, reject versions other than the patched build.
+# On older releases, reject versions other than the patched one from the authd PPA,
+# because they would cause https://github.com/canonical/authd/issues/1424 to
+# occur almost every time.
+# TODO: Accept newer versions for resolute once the fix was SRUed there.
 GNOME_SHELL_BREAKS := gnome-shell (<< $(GNOME_SHELL_PATCHED_VERSION)), gnome-shell (>> $(GNOME_SHELL_PATCHED_VERSION))
 endif
 


### PR DESCRIPTION
The gnome-shell version `46.3.1-1ubuntu1+authd1~24.04.1` was deleted from the authd-edge PPA and a new `46.3.1-1ubuntu1~24.04.1authd11` version published instead.

Since authd has an exact `Breaks` contstraint on the gnome-shell version, systems using the authd-edge PPA could not install authd without removing gnome-shell.

Update the `Breaks` constraint to the new version.

Closes #1858
UDENG-11399

e2e-brokers: msentraid
e2e-tests: allowed_users.robot
