### PR TITLE
Avoid Tokio panic during late NSS lookups

### DIFF
--- a/nss/src/group/mod.rs
+++ b/nss/src/group/mod.rs
@@ -2,7 +2,6 @@ use crate::{info, REQUEST_TIMEOUT};
 use libc::gid_t;
 use libnss::group::{Group, GroupHooks};
 use libnss::interop::Response;
-use tokio::runtime::Builder;
 use tonic::Request;
 
 use crate::client::{self, authd};
@@ -28,10 +27,9 @@ impl GroupHooks for AuthdGroupHooks {
 
 /// get_all_entries connects to the grpc server and asks for all group entries.
 fn get_all_entries() -> Response<Vec<Group>> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };
@@ -59,10 +57,9 @@ fn get_all_entries() -> Response<Vec<Group>> {
 
 /// get_entry_by_gid connects to the grpc server and asks for the group entry with the given gid.
 fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };
@@ -90,10 +87,9 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
 
 /// get_entry_by_name connects to the grpc server and asks for the group entry with the given name.
 fn get_entry_by_name(name: String) -> Response<Group> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };

--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 // used by libnss_*_hooks macros
 use libnss::{interop::Response, libnss_group_hooks, libnss_passwd_hooks, libnss_shadow_hooks};
+use tokio::runtime::{Builder, Handle, Runtime};
 
 mod passwd;
 use passwd::AuthdPasswdHooks;
@@ -31,6 +32,29 @@ const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const DEFAULT_SOCKET_PATH: &str = "/run/authd.sock";
+
+/// build_runtime creates a current-thread runtime unless the calling process is already
+/// destroying its thread-local state.
+fn build_runtime() -> Option<Runtime> {
+    // glibc runs TLS destructors before atexit callbacks. NSS can therefore be called after
+    // Tokio's context has been destroyed.
+    if let Err(err) = Handle::try_current() {
+        if err.is_thread_local_destroyed() {
+            info!(
+                "could not create runtime for NSS: Tokio context thread-local has been destroyed"
+            );
+            return None;
+        }
+    }
+
+    match Builder::new_current_thread().enable_all().build() {
+        Ok(rt) => Some(rt),
+        Err(err) => {
+            info!("could not create runtime for NSS: {}", err);
+            None
+        }
+    }
+}
 
 /// socket_path returns the socket path to connect to the gRPC server.
 ///

--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -88,6 +88,51 @@ fn init_logger() {
     logs::init_logger();
 }
 
+#[cfg(test)]
+mod tests {
+    use super::passwd::AuthdPasswdHooks;
+    use libnss::passwd::PasswdHooks;
+    use std::panic::AssertUnwindSafe;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static LOOKUP_COMPLETED: AtomicBool = AtomicBool::new(false);
+
+    struct RunDuringThreadTeardown;
+
+    impl Drop for RunDuringThreadTeardown {
+        fn drop(&mut self) {
+            let lookup_completed = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                <AuthdPasswdHooks as PasswdHooks>::get_entry_by_name("late-lookup".to_owned());
+            }))
+            .is_ok();
+            LOOKUP_COMPLETED.store(lookup_completed, Ordering::SeqCst);
+        }
+    }
+
+    thread_local! {
+        static RUN_DURING_THREAD_TEARDOWN: RunDuringThreadTeardown = RunDuringThreadTeardown;
+    }
+
+    #[test]
+    fn nss_lookup_during_thread_teardown_does_not_panic() {
+        LOOKUP_COMPLETED.store(false, Ordering::SeqCst);
+
+        std::thread::spawn(|| {
+            RUN_DURING_THREAD_TEARDOWN.with(|_| {});
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime should be available");
+            rt.block_on(async {});
+        })
+        .join()
+        .expect("test thread should exit cleanly");
+
+        assert!(LOOKUP_COMPLETED.load(Ordering::SeqCst));
+    }
+}
+
 #[cfg(feature = "integration_tests")]
 #[ctor::ctor]
 /// register_local_aad_nss_service_for_tests executes the C API to override the NSS lookup.

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -3,7 +3,6 @@ use libc::uid_t;
 use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
 use std::path::PathBuf;
-use tokio::runtime::Builder;
 use tonic::Request;
 
 use crate::client::{self, authd};
@@ -29,10 +28,9 @@ impl PasswdHooks for AuthdPasswdHooks {
 
 /// get_all_entries connects to the grpc server and asks for all passwd entries.
 fn get_all_entries() -> Response<Vec<Passwd>> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };
@@ -60,10 +58,9 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
 
 /// get_entry_by_uid connects to the grpc server and asks for the passwd entry with the given uid.
 fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };
@@ -91,10 +88,9 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
 
 /// get_entry_by_name connects to the grpc server and asks for the passwd entry with the given name.
 fn get_entry_by_name(name: String) -> Response<Passwd> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };

--- a/nss/src/shadow/mod.rs
+++ b/nss/src/shadow/mod.rs
@@ -1,7 +1,6 @@
 use crate::{info, REQUEST_TIMEOUT};
 use libnss::interop::Response;
 use libnss::shadow::{Shadow, ShadowHooks};
-use tokio::runtime::Builder;
 use tonic::Request;
 
 use crate::client::{self, authd};
@@ -23,10 +22,9 @@ impl ShadowHooks for AuthdShadowHooks {
 
 /// get_all_entries connects to the grpc server and asks for all shadow entries.
 fn get_all_entries() -> Response<Vec<Shadow>> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };
@@ -54,10 +52,9 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
 
 /// get_entry_by_name connects to the grpc server and asks for the shadow entry with the given name.
 fn get_entry_by_name(name: String) -> Response<Shadow> {
-    let rt = match Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt,
-        Err(e) => {
-            info!("could not create runtime for NSS: {}", e);
+    let rt = match super::build_runtime() {
+        Some(rt) => rt,
+        None => {
             return Response::Unavail;
         }
     };


### PR DESCRIPTION
glibc destroys thread-local state before running atexit handlers. A late NSS lookup from a caller such as Squid can therefore reach Tokio after its context has been destroyed and abort the process. Detect that condition before creating the runtime and return NSS_UNAVAIL instead.

Closes #1504
UDENG-11400