### PR TITLE
ci: Fix packaging regeneration workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -24,7 +24,8 @@ on:
 
 env:
   # Keep this aligned with update-packaging-on-dependabot-pr.yaml.
-  CARGO_VENDOR_FILTERER_VERSION: 0.5.16
+  # Noble's Rust 1.75 supports cargo-vendor-filterer only up to 0.5.16.
+  CARGO_VENDOR_FILTERER_NOBLE_VERSION: 0.5.16
 
 jobs:
   build-deb:
@@ -190,7 +191,7 @@ jobs:
           extra-source-build-script: |
             if [ "${{ inputs.ubuntu-version }}" == noble ]; then
               cargo install --locked --root=/usr \
-                cargo-vendor-filterer@${{ env.CARGO_VENDOR_FILTERER_VERSION }}
+                cargo-vendor-filterer@${{ env.CARGO_VENDOR_FILTERER_NOBLE_VERSION }}
               command -v cargo-vendor-filterer
             fi
           allow-sudo: true

--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -39,8 +39,11 @@ permissions:
   contents: read
 
 env:
-  # Keep this aligned with debian-build.yaml.
-  CARGO_VENDOR_FILTERER_VERSION: 0.5.16
+  # Keep these aligned with debian-build.yaml.
+  # Noble's Rust 1.75 supports cargo-vendor-filterer only up to 0.5.16.
+  CARGO_VENDOR_FILTERER_NOBLE_VERSION: 0.5.16
+  # The ubuntu:devel image provides OpenSSL 4, which requires 0.5.18.
+  CARGO_VENDOR_FILTERER_DEVEL_VERSION: 0.5.18
 
 defaults:
   run:
@@ -119,7 +122,7 @@ jobs:
           cargo --version
 
           cargo install --locked --root=/usr \
-            cargo-vendor-filterer@"${CARGO_VENDOR_FILTERER_VERSION}"
+            cargo-vendor-filterer@"${CARGO_VENDOR_FILTERER_NOBLE_VERSION}"
 
           cargo generate-lockfile
 
@@ -220,7 +223,7 @@ jobs:
             pkg-config
 
           cargo install --locked --root=/usr \
-            cargo-vendor-filterer@"${CARGO_VENDOR_FILTERER_VERSION}"
+            cargo-vendor-filterer@"${CARGO_VENDOR_FILTERER_DEVEL_VERSION}"
 
       - name: Vendor the Rust dependencies
         run: |

--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -178,6 +178,7 @@ jobs:
         run: |
           apt-get update -y
           apt-get install -y --no-install-recommends ca-certificates git
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Checkout the PR branch
         uses: actions/checkout@v7
@@ -203,13 +204,15 @@ jobs:
 
           # go mod vendor may change go.mod/go.sum. This workflow does not
           # upload those files, so fail instead of dropping the changes.
-          if ! git diff --quiet HEAD -- go.mod go.sum; then
+          # Compare the worktree with the index directly. This avoids Git
+          # interpreting a revision and pathspec as a no-index comparison.
+          if ! git diff-files --quiet -- go.mod go.sum; then
             echo "go mod vendor modified go.mod/go.sum; this workflow only" >&2
             echo "regenerates Cargo.lock, debian/control and" >&2
             echo "debian/copyright, so this change would be silently lost." >&2
             echo "Please update go.mod/go.sum manually (e.g. by running" >&2
             echo "'go mod tidy') and push the fix to the PR branch." >&2
-            git --no-pager diff HEAD -- go.mod go.sum >&2
+            git --no-pager diff-files -- go.mod go.sum >&2
             exit 1
           fi
 


### PR DESCRIPTION
Fix issues in the packaging regeneration workflow for Dependabot PRs:

* Upgrade `cargo-vendor-filterer` from `0.5.16` to `0.5.18` in both packaging workflows.
* Fix the `go.mod`/`go.sum` change check for Git 2.55.
* Mark the GitHub Actions workspace as a safe Git directory for container jobs.
