### PR TITLE
Fix packaging change detection

### DIFF
--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -259,7 +259,9 @@ jobs:
       - name: Check whether the packaging files changed
         id: diff
         run: |
-          if git diff --quiet -- Cargo.lock debian/control debian/copyright; then
+          # Compare the worktree with the index directly. This avoids Git
+          # interpreting the paths as a no-index comparison.
+          if git diff-files --quiet -- Cargo.lock debian/control debian/copyright; then
             echo "Nothing to commit."
             echo "changed=false" >> "${GITHUB_OUTPUT}"
           else


### PR DESCRIPTION
The `git diff` command failed, causing the workflow to always enter the `else` branch and marking the files as changed.

Use `git diff-files` to compare the worktree with the checkout index explicitly, so the workflow correctly detects changes.