### PR TITLE
Preserve non-ASCII copyright holders

### DIFF
--- a/scripts/generate-vendored-copyright
+++ b/scripts/generate-vendored-copyright
@@ -354,6 +354,7 @@ class VendorLicenseScanner:
                 ],
                 capture_output=True,
                 text=True,
+                encoding='utf-8',
                 check=True  # Raises CalledProcessError on non-zero exit
             )
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Decode licensecheck output as UTF-8 so copyright names remain intact regardless of the process locale.
