### PR TITLE
Prevent E2E teardown from hanging on socat

### DIFF
--- a/e2e-tests/resources/Journal.py
+++ b/e2e-tests/resources/Journal.py
@@ -53,7 +53,12 @@ class Journal:
         if self.socat_process:
             logger.info("Terminating socat")
             self.socat_process.terminate()
-            self.socat_process.wait()
+            try:
+                self.socat_process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                logger.error("socat did not exit after termination, killing it")
+                self.socat_process.kill()
+                self.socat_process.wait()
             socat_stderr = self.socat_process.stderr.read().decode()
             socat_stderr_filtered = _filter_socat_stderr(socat_stderr)
             logger.info("socat stderr:\n" + socat_stderr_filtered)


### PR DESCRIPTION
Journal teardown could wait forever after asking the TCP journal forwarder to stop, leaving the test job stuck with orphaned processes. Bound the graceful wait and kill socat when it does not exit.

Closes #1865 
UDENG-11406

e2e-brokers: msentraid
e2e-tests: allowed_users.robot