### PR TITLE
Preserve UTF-8 copyright holders in packaging CI

### DIFF
--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -71,6 +71,7 @@ jobs:
       IS_CARGO_PR: ${{ startsWith(github.event.pull_request.head.ref, 'dependabot/cargo/') }}
 
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       # The container image does not include git, which checkout needs.
       - name: Install git
         run: |
@@ -174,6 +175,7 @@ jobs:
       changed: ${{ steps.diff.outputs.changed }}
 
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       # The container image does not include git, which checkout and setup-go
       # need.
       - name: Install git

--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -218,7 +218,6 @@ jobs:
 
       - name: Install cargo and cargo-vendor-filterer
         run: |
-          apt-get update -y
           apt-get install -y --no-install-recommends \
             build-essential \
             cargo \

--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -164,6 +164,8 @@ jobs:
 
   generate-copyright:
     name: Regenerate debian/copyright
+    # This job consumes the Cargo.lock and debian/control artifact from
+    # generate-cargo to recreate the Rust vendor tree consistently.
     needs: generate-cargo
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/update-packaging-on-dependabot-pr.yaml
+++ b/.github/workflows/update-packaging-on-dependabot-pr.yaml
@@ -248,12 +248,17 @@ jobs:
       - name: Install licensecheck and python3-anytree
         run: |
           apt-get update -y
+          # Enable licensecheck's RE2 regex engine. Without it, ubuntu:devel
+          # double-encodes non-ASCII copyright holders.
           apt-get install -y --no-install-recommends \
             licensecheck \
+            libre-engine-re2-perl \
             python3-anytree
 
       - name: Regenerate debian/copyright
         run: |
+          # licensecheck uses the process locale when writing its output.
+          export LC_ALL=C.UTF-8
           # Pass both trees because the script rewrites all vendored Files:
           # stanzas. Use relative paths because they are written verbatim to
           # debian/copyright.


### PR DESCRIPTION
Run copyright generation in a UTF-8 locale and install the RE2 Perl engine. Without these settings, ubuntu:devel double-encodes non-ASCII copyright holders.

UDENG-11407