### PR TITLE
Avoid bug reports for unknown Entra accounts

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -2276,6 +2276,11 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 // routeMFAInitError routes the AADSTS errors returned by InitiateEntraAuth
 // (the MFA init step) to appropriate broker responses.
 func (b *Broker) routeMFAInitError(mfaErr *himmelblau.MFAError, session *session) (string, isAuthenticatedDataResponse) {
+	if mfaErr.IsMFAUserNotFound() {
+		log.Noticef(context.Background(), "Login denied: user %q does not exist in %s", session.username, b.provider.DisplayName())
+		return AuthDenied, errorMessage{Message: "An account with that name does not exist."}
+	}
+
 	if mfaErr.IsMFAPasswordRequired() {
 		log.Debugf(context.Background(), "Passwordless Entra authentication for user %q requires password entry", session.username)
 		session.entraAuthPasswordRequired = true

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -4150,6 +4150,7 @@ func TestEntraAuthRoutesAADSTSErrors(t *testing.T) {
 		wantAccess    string
 		wantNextModes []string
 		wantMsg       string
+		wantReport    bool
 	}{
 		"Account_locked":                               {aadsts: 50053, wantAccess: broker.AuthDenied, wantMsg: "locked"},
 		"Password_expired":                             {aadsts: 50055, wantAccess: broker.AuthDenied, wantMsg: "expired"},
@@ -4162,9 +4163,10 @@ func TestEntraAuthRoutesAADSTSErrors(t *testing.T) {
 		"MFA_enrollment_alt_to_device":                 {aadsts: 50079, wantAccess: broker.AuthNext, wantNextModes: []string{authmodes.Device, authmodes.DeviceQr}, wantMsg: "MFA registration required"},
 		"Authenticator_registration_to_device":         {aadsts: 50203, wantAccess: broker.AuthNext, wantNextModes: []string{authmodes.Device, authmodes.DeviceQr}, wantMsg: "MFA registration required"},
 		"MFA_enrollment_denied_when_device_disabled":   {aadsts: 50072, deviceAuthDisabled: true, wantAccess: broker.AuthDenied, wantMsg: "disabled"},
+		"User_not_found_by_aadsts_code":                {aadsts: 50034, wantAccess: broker.AuthDenied, wantMsg: "does not exist"},
 		"MFA_required_to_device":                       {category: himmelblau.MFAErrorRequired, wantAccess: broker.AuthNext, wantNextModes: []string{authmodes.Device, authmodes.DeviceQr}, wantMsg: "MFA is required"},
 		"MFA_required_denied_when_device_disabled":     {category: himmelblau.MFAErrorRequired, deviceAuthDisabled: true, wantAccess: broker.AuthDenied, wantMsg: "disabled"},
-		"Unhandled_AADSTS_denied":                      {aadsts: 99999, wantAccess: broker.AuthDenied, wantMsg: "AADSTS99999: simulated error. Please report this error"},
+		"Unhandled_AADSTS_denied":                      {aadsts: 99999, wantAccess: broker.AuthDenied, wantMsg: "AADSTS99999: simulated error. Please report this error", wantReport: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -4209,6 +4211,11 @@ func TestEntraAuthRoutesAADSTSErrors(t *testing.T) {
 			}
 			require.NoError(t, json.Unmarshal([]byte(data), &payload))
 			require.Contains(t, payload.Message, tc.wantMsg)
+			if tc.wantReport {
+				require.Contains(t, payload.Message, "Please report this error")
+			} else {
+				require.NotContains(t, payload.Message, "Please report this error")
+			}
 		})
 	}
 }

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/entrapwd.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/entrapwd.go
@@ -162,6 +162,11 @@ type MFAChallengeInfo struct {
 // it without depending on libhimmelblau-specific numeric codes.
 type MFAErrorCategory int
 
+// userNotFoundErrorCode is the standard Entra error code for an account
+// that is not present in the tenant. It must stay in this untagged file
+// because IsMFAUserNotFound is used by untagged builds.
+const userNotFoundErrorCode = 50034
+
 const (
 	// MFAErrorOther is the default category and means the error has no
 	// specific routing semantics.
@@ -231,4 +236,10 @@ func (e *MFAError) IsMFARetryableCode() bool {
 // authentication needs the password flow instead.
 func (e *MFAError) IsMFAPasswordRequired() bool {
 	return e.Category == MFAErrorPasswordRequired
+}
+
+// IsMFAUserNotFound returns true if the requested account does not exist in
+// the Entra tenant.
+func (e *MFAError) IsMFAUserNotFound() bool {
+	return e.AADSTS == userNotFoundErrorCode
 }

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/entrapwd_test.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/entrapwd_test.go
@@ -113,6 +113,25 @@ func TestMFAError_IsMFARetryableCode(t *testing.T) {
 	}
 }
 
+func TestMFAError_IsMFAUserNotFound(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err  *MFAError
+		want bool
+	}{
+		"User_not_found_AADSTS": {err: &MFAError{AADSTS: userNotFoundErrorCode}, want: true},
+		"Other":                 {err: &MFAError{Category: MFAErrorOther}, want: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.err.IsMFAUserNotFound())
+		})
+	}
+}
+
 func TestFreeMFAFlowState_NilSafe(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A typo in the username made the broker return an unexpected error asking the user to report it. Map the AADSTS50034 result that libhimmelblau now surfaces for an unknown account to a normal denial with a plain message.

UDENG-11422

<!--
E2E tests in CI

The E2E workflow runs for a pull request only when it has the `e2e-tests`
label. Copy the relevant line(s) below into the visible part of the pull
request description to override the defaults. Leave these examples commented
to use the defaults:

- both brokers (`authd-google` and `authd-msentraid`)
- the complete test suite
- the `authd-edge` PPA

e2e-brokers: google
e2e-tests: allowed_users.robot login_gdm.robot
e2e-ppa: authd-dev

The `e2e-ppa: authd-dev` marker sets the workflow's `authd-ppa` input to
`ubuntu-enterprise-desktop/authd-dev` instead of `authd-edge` for resolving
authd package dependencies.
-->