### PR TITLE
Require confirmation before replacing local passwords

### DIFF
--- a/authd-oidc-brokers/internal/broker/authmodes/consts.go
+++ b/authd-oidc-brokers/internal/broker/authmodes/consts.go
@@ -32,19 +32,25 @@ const (
 	// EntraAuthFidoPin is the ID of the security-key PIN entry mode, chained
 	// before EntraAuthFido when the connected device requires a client PIN.
 	EntraAuthFidoPin = "entra_auth_fido_pin"
+
+	// EntraAuthPasswordConfirmation is the ID of the follow-up mode used to
+	// confirm replacing an existing local password.
+	//nolint:gosec // G101: this is an authentication mode identifier, not a credential.
+	EntraAuthPasswordConfirmation = "entra_auth_password_confirmation"
 )
 
 var (
 	// Label is a map of auth mode IDs to their display labels.
 	Label = map[string]string{
-		Password:         "Local password",
-		Device:           "Device code flow",
-		DeviceQr:         "Device code flow",
-		NewPassword:      "Define your local password",
-		EntraAuth:        "Entra ID authentication",
-		EntraMFAWait:     "Waiting for MFA approval",
-		EntraMFACode:     "Enter your MFA code",
-		EntraAuthFido:    "Use your security key",
-		EntraAuthFidoPin: "Enter your security key PIN",
+		Password:                      "Local password",
+		Device:                        "Device code flow",
+		DeviceQr:                      "Device code flow",
+		NewPassword:                   "Define your local password",
+		EntraAuth:                     "Entra ID authentication",
+		EntraMFAWait:                  "Waiting for MFA approval",
+		EntraMFACode:                  "Enter your MFA code",
+		EntraAuthFido:                 "Use your security key",
+		EntraAuthFidoPin:              "Enter your security key PIN",
+		EntraAuthPasswordConfirmation: "Confirm local password replacement",
 	}
 )

--- a/authd-oidc-brokers/internal/broker/authresponses.go
+++ b/authd-oidc-brokers/internal/broker/authresponses.go
@@ -8,6 +8,13 @@ import "github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 // localized independently of authd.
 const cachedPasswordMessage = "Your local password has been set to your Entra password"
 
+const (
+	//nolint:gosec // G101: these are user-facing messages, not credentials.
+	entraPasswordMatchesMessage = "Your Entra password already matches your local password. No change was needed."
+	entraPasswordUpdatedMessage = "Your local password has been updated to your Entra password."
+	entraPasswordKeptMessage    = "Your existing local password was kept."
+)
+
 type isAuthenticatedDataResponse interface {
 	isAuthenticatedDataResponse()
 }
@@ -26,3 +33,12 @@ type errorMessage struct {
 }
 
 func (errorMessage) isAuthenticatedDataResponse() {}
+
+// authNextMessage carries internal state to the PAM adapter without displaying
+// an extra prompt to the user.
+type authNextMessage struct {
+	Message                 string `json:"message"`
+	EntraPasswordUnverified bool   `json:"entra_password_unverified,omitempty"`
+}
+
+func (authNextMessage) isAuthenticatedDataResponse() {}

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -1011,7 +1011,7 @@ func tokenExists(session session) bool {
 }
 
 func passwordFileExists(session session) bool {
-	exists, err := fileutils.FileExists(session.passwordPath)
+	exists, err := passwordFileStatus(session.passwordPath)
 	if err != nil {
 		log.Warningf(context.Background(), "Could not check if local password file exists: %v", err)
 	}
@@ -1595,6 +1595,12 @@ func (b *Broker) entraAuth(ctx context.Context, session *session, userPassword s
 	var localPasswordExists, localPasswordMatches bool
 	if passwordSubmitted {
 		localPasswordExists, localPasswordMatches, err = checkLocalPassword(userPassword, session.passwordPath)
+		if errors.Is(err, password.ErrInvalidHash) {
+			log.Warningf(context.Background(), "Local password file for user %q is invalid; treating it as unavailable", session.username)
+			localPasswordExists = false
+			localPasswordMatches = false
+			err = nil
+		}
 		if err != nil {
 			log.Errorf(context.Background(), "Could not verify the existing local password: %v", err)
 			return AuthDenied, unexpectedErrMsg("could not check local password")
@@ -2287,7 +2293,12 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 
 	var localPasswordExists bool
 	if session.entraAuthPasswordHash == "" || session.entraAuthPasswordNeedsConfirmation {
-		localPasswordExists, err = fileutils.FileExists(session.passwordPath)
+		localPasswordExists, err = passwordFileStatus(session.passwordPath)
+		if errors.Is(err, password.ErrInvalidHash) {
+			log.Warningf(context.Background(), "Local password file for user %q is invalid; treating it as unavailable", session.username)
+			localPasswordExists = false
+			err = nil
+		}
 		if err != nil {
 			log.Errorf(context.Background(), "Could not check if local password exists: %v", err)
 			return AuthDenied, unexpectedErrMsg("could not check local password")
@@ -2396,6 +2407,14 @@ func checkLocalPassword(candidate, path string) (bool, bool, error) {
 		return false, false, nil
 	}
 	return err == nil, matches, err
+}
+
+func passwordFileStatus(path string) (bool, error) {
+	err := password.ValidateHash(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 // routeMFAInitError routes the AADSTS errors returned by InitiateEntraAuth

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -112,13 +112,15 @@ type session struct {
 	tokenPath               string
 
 	// Data to pass from one request to another.
-	deviceAuthResponse        *oauth2.DeviceAuthResponse
-	authInfo                  *token.AuthCachedInfo
-	mfaFlowActive             *himmelblau.MFAFlowState
-	mfaChallengeInfo          *himmelblau.MFAChallengeInfo
-	entraAuthPasswordHash     string // pre-computed hash (not plaintext) for offline use
-	entraAuthPasswordRequired bool
-	fidoPIN                   string // security key PIN, kept in memory only while the FIDO exchange runs
+	deviceAuthResponse                 *oauth2.DeviceAuthResponse
+	authInfo                           *token.AuthCachedInfo
+	mfaFlowActive                      *himmelblau.MFAFlowState
+	mfaChallengeInfo                   *himmelblau.MFAChallengeInfo
+	entraAuthPasswordHash              string // pre-computed hash (not plaintext) for offline use
+	entraAuthPasswordMatchesLocal      bool
+	entraAuthPasswordNeedsConfirmation bool
+	entraAuthPasswordRequired          bool
+	fidoPIN                            string // security key PIN, kept in memory only while the FIDO exchange runs
 
 	isAuthenticating *isAuthenticatedCtx
 }
@@ -994,6 +996,8 @@ func (b *Broker) authModeIsAvailable(session session, authMode string) bool {
 	case authmodes.EntraMFAWait, authmodes.EntraMFACode, authmodes.EntraAuthFido, authmodes.EntraAuthFidoPin:
 		// MFA follow-up modes are always available when offered via AuthNext.
 		return true
+	case authmodes.EntraAuthPasswordConfirmation:
+		return session.entraAuthPasswordNeedsConfirmation && session.entraAuthPasswordHash != ""
 	}
 	return false
 }
@@ -1039,6 +1043,7 @@ func (b *Broker) supportedAuthModesFromLayout(layout map[string]string) []string
 		supportsWait := strings.Contains(layout["wait"], "true")
 		if slices.Contains(supportedEntries, "chars_password") {
 			modes = append(modes, authmodes.Password, authmodes.EntraAuthFidoPin)
+			modes = append(modes, authmodes.EntraAuthPasswordConfirmation)
 			// The entra_auth mode needs both entry capabilities: its initial
 			// passwordless-probe layout is a wait-only form, and its password
 			// layout is a chars_password form. Offering it to a client that
@@ -1194,6 +1199,13 @@ func (b *Broker) generateUILayout(session *session, authModeID string) (map[stri
 			"label": "Enter your security key PIN",
 		}
 
+	case authmodes.EntraAuthPasswordConfirmation:
+		uiLayout = map[string]string{
+			"type":  "form",
+			"entry": "chars_password",
+			"label": "Enter your current local password to replace it with your Entra password, or leave this blank to keep it",
+		}
+
 	case authmodes.NewPassword:
 		label := "Create a local password"
 		if session.mode == sessionmode.ChangePassword || session.mode == sessionmode.ChangePasswordOld {
@@ -1258,12 +1270,15 @@ func (b *Broker) IsAuthenticated(sessionID, authenticationData string) (string, 
 			iadResponse = errorMessage{Message: "Maximum number of authentication attempts reached"}
 			// Free any in-progress MFA flow immediately rather than waiting for
 			// EndSession — consistent with all other terminal paths.
-			session.entraAuthPasswordHash = ""
+			clearEntraAuthPasswordState(&session)
 			clearEntraAuthState(&session)
+			session.nextAuthModes = nil
 		}
 	}
 
 	if err = b.updateSession(sessionID, session); err != nil {
+		clearEntraAuthPasswordState(&session)
+		clearEntraAuthState(&session)
 		return AuthDenied, "{}", err
 	}
 
@@ -1313,6 +1328,8 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 		return b.entraAuthFidoAuth(ctx, session)
 	case authmodes.EntraAuthFidoPin:
 		return b.entraAuthFidoPinAuth(session, secret)
+	case authmodes.EntraAuthPasswordConfirmation:
+		return b.confirmEntraAuthPassword(session, secret)
 	default:
 		log.Errorf(context.Background(), "unknown authentication mode %q", session.selectedMode)
 		return AuthDenied, unexpectedErrMsg("unknown authentication mode")
@@ -1567,11 +1584,22 @@ func (b *Broker) entraAuth(ctx context.Context, session *session, userPassword s
 	if session.entraAuthPasswordRequired && !passwordSubmitted {
 		return AuthRetry, errorMessage{Message: "Please enter your Entra ID password."}
 	}
+	var err error
 
 	// A prior MFA flow may still be active if the password step is restarted
 	// (e.g. the user navigates back to re-enter the password). Release it before
 	// starting a new one so the libhimmelblau continuation it owns is not leaked.
 	clearEntraAuthState(session)
+	clearEntraAuthPasswordState(session)
+
+	var localPasswordExists, localPasswordMatches bool
+	if passwordSubmitted {
+		localPasswordExists, localPasswordMatches, err = checkLocalPassword(userPassword, session.passwordPath)
+		if err != nil {
+			log.Errorf(context.Background(), "Could not verify the existing local password: %v", err)
+			return AuthDenied, unexpectedErrMsg("could not check local password")
+		}
+	}
 
 	// Load the cached auth info once at the start of the flow and stash it on the
 	// session, so the second step (entra_mfa_wait/entra_mfa_code → finishEntraAuth)
@@ -1654,16 +1682,26 @@ func (b *Broker) entraAuth(ctx context.Context, session *session, userPassword s
 	} else if passwordSubmitted {
 		// Hash the password immediately to narrow the plaintext memory window.
 		// The hash is written to disk in finishEntraAuth after MFA succeeds.
-		passwordHash, hashErr := password.HashPassword(userPassword)
-		if hashErr != nil {
-			log.Errorf(context.Background(), "Failed to hash password: %v", hashErr)
-			clearEntraAuthState(session)
-			return AuthDenied, unexpectedErrMsg("failed to process password")
+		if localPasswordMatches {
+			session.entraAuthPasswordMatchesLocal = true
+		} else {
+			passwordHash, hashErr := password.HashPassword(userPassword)
+			if hashErr != nil {
+				log.Errorf(context.Background(), "Failed to hash password: %v", hashErr)
+				clearEntraAuthState(session)
+				clearEntraAuthPasswordState(session)
+				return AuthDenied, unexpectedErrMsg("failed to process password")
+			}
+			session.entraAuthPasswordHash = passwordHash
+			session.entraAuthPasswordNeedsConfirmation = localPasswordExists
 		}
-		session.entraAuthPasswordHash = passwordHash
 	}
 
-	return b.routeMFAChallenge(session, challengeInfo)
+	access, data := b.routeMFAChallenge(session, challengeInfo)
+	if passwordSubmitted && bypassesPasswordMethod(challengeInfo.Method) && access == AuthNext {
+		return access, authNextMessage{EntraPasswordUnverified: true}
+	}
+	return access, data
 }
 
 // routeMFAChallenge inspects the MFA challenge negotiated by the password
@@ -1707,13 +1745,19 @@ func clearEntraAuthState(session *session) {
 	session.fidoPIN = ""
 }
 
+func clearEntraAuthPasswordState(session *session) {
+	session.entraAuthPasswordHash = ""
+	session.entraAuthPasswordMatchesLocal = false
+	session.entraAuthPasswordNeedsConfirmation = false
+}
+
 // restartFromEntraAuth handles a terminal MFA-step failure: it clears the
 // now-dead MFA state (including the cached password hash) and directs the
 // client back to entra_auth so it can restart the flow rather than
 // re-entering a dead follow-up mode, showing msg to the user.
 func restartFromEntraAuth(session *session, msg string) (string, isAuthenticatedDataResponse) {
 	needsPassword := session.entraAuthPasswordRequired || session.entraAuthPasswordHash != ""
-	session.entraAuthPasswordHash = ""
+	clearEntraAuthPasswordState(session)
 	session.entraAuthPasswordRequired = needsPassword
 	clearEntraAuthState(session)
 	session.nextAuthModes = []string{authmodes.EntraAuth}
@@ -1743,7 +1787,7 @@ func replayCompletedMFA(session *session, mode string) (string, isAuthenticatedD
 // denies with data. Terminal FIDO/MFA failures use it; success paths keep the
 // hash for offline caching, so clearEntraAuthState alone must not wipe it.
 func denyAndClearMFA(session *session, data isAuthenticatedDataResponse) (string, isAuthenticatedDataResponse) {
-	session.entraAuthPasswordHash = ""
+	clearEntraAuthPasswordState(session)
 	clearEntraAuthState(session)
 	return AuthDenied, data
 }
@@ -1939,7 +1983,7 @@ func (b *Broker) routeFIDOChallenge(session *session, challengeInfo *himmelblau.
 // the device code flow (or denies when that flow is disabled). It is the
 // fallback for FIDO challenges that cannot be completed on this machine.
 func (b *Broker) redirectFIDOToDeviceAuth(session *session) (string, isAuthenticatedDataResponse) {
-	session.entraAuthPasswordHash = ""
+	clearEntraAuthPasswordState(session)
 	clearEntraAuthState(session)
 	if b.cfg.flows.DeviceAuth {
 		session.nextAuthModes = []string{authmodes.Device, authmodes.DeviceQr}
@@ -2131,8 +2175,12 @@ func (b *Broker) routeFIDOAssertionError(ctx context.Context, session *session, 
 }
 
 func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken *oauth2.Token) (string, isAuthenticatedDataResponse) {
-	// Ensure any cached password hash is cleared from memory on all exit paths.
-	defer func() { session.entraAuthPasswordHash = "" }()
+	keepPasswordPending := false
+	defer func() {
+		if !keepPasswordPending {
+			clearEntraAuthPasswordState(session)
+		}
+	}()
 
 	// AcquireTokenByMFAFlow returns (nil, nil) only on a provider contract
 	// violation, but this is the trust boundary into the generic broker: guard
@@ -2237,14 +2285,30 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 		authInfo.UserInfo.Groups = groups
 	}
 
+	var localPasswordExists bool
+	if session.entraAuthPasswordHash == "" || session.entraAuthPasswordNeedsConfirmation {
+		localPasswordExists, err = fileutils.FileExists(session.passwordPath)
+		if err != nil {
+			log.Errorf(context.Background(), "Could not check if local password exists: %v", err)
+			return AuthDenied, unexpectedErrMsg("could not check local password")
+		}
+	}
+
 	// A passwordless login has no Entra password to cache for offline
 	// authentication. When the user has no local password yet, chain into the
 	// newpassword step (like the device-auth flow does) so offline logins
 	// keep working; an existing local password stays valid, so returning
 	// users are not asked to redefine one on every login.
-	if session.entraAuthPasswordHash == "" && !passwordFileExists(*session) {
+	if session.entraAuthPasswordHash == "" && !localPasswordExists {
 		session.authInfo = authInfo
 		session.nextAuthModes = []string{authmodes.NewPassword}
+		return AuthNext, nil
+	}
+
+	if session.entraAuthPasswordNeedsConfirmation && localPasswordExists {
+		session.authInfo = authInfo
+		session.nextAuthModes = []string{authmodes.EntraAuthPasswordConfirmation}
+		keepPasswordPending = true
 		return AuthNext, nil
 	}
 
@@ -2262,15 +2326,76 @@ func (b *Broker) finishEntraAuth(ctx context.Context, session *session, mfaToken
 			log.Errorf(context.Background(), "Failed to store password hash: %v", hashErr)
 			return AuthDenied, unexpectedErrMsg("failed to store password")
 		}
-		session.entraAuthPasswordHash = ""
 
-		if msg, ok := data.(userInfoMessage); ok {
-			msg.Message = cachedPasswordMessage
-			data = msg
-		}
+		data = withUserInfoMessage(data, cachedPasswordMessage)
+	} else if session.entraAuthPasswordMatchesLocal {
+		data = withUserInfoMessage(data, entraPasswordMatchesMessage)
 	}
 
 	return access, data
+}
+
+func (b *Broker) confirmEntraAuthPassword(session *session, currentPassword string) (string, isAuthenticatedDataResponse) {
+	if session.authInfo == nil || session.entraAuthPasswordHash == "" {
+		log.Error(context.Background(), "local password replacement confirmation is missing authentication state")
+		clearEntraAuthPasswordState(session)
+		return AuthDenied, unexpectedErrMsg("local password replacement state is not set")
+	}
+
+	if currentPassword == "" {
+		access, data := b.finishAuth(session, session.authInfo)
+		if access != AuthGranted {
+			clearEntraAuthPasswordState(session)
+			return access, data
+		}
+
+		data = withUserInfoMessage(data, entraPasswordKeptMessage)
+		clearEntraAuthPasswordState(session)
+		return access, data
+	}
+
+	_, matches, err := checkLocalPassword(currentPassword, session.passwordPath)
+	if err != nil {
+		log.Errorf(context.Background(), "Could not verify the existing local password: %v", err)
+		clearEntraAuthPasswordState(session)
+		return AuthDenied, unexpectedErrMsg("could not check local password")
+	}
+	if !matches {
+		log.Noticef(context.Background(), "Authentication failure: incorrect local password for user %q", session.username)
+		return AuthRetry, errorMessage{Message: "Incorrect local password, please try again."}
+	}
+
+	access, data := b.finishAuth(session, session.authInfo)
+	if access != AuthGranted {
+		clearEntraAuthPasswordState(session)
+		return access, data
+	}
+
+	if err := password.StoreHashedPassword(session.entraAuthPasswordHash, session.passwordPath); err != nil {
+		log.Errorf(context.Background(), "Failed to store password hash: %v", err)
+		clearEntraAuthPasswordState(session)
+		return AuthDenied, unexpectedErrMsg("failed to store password")
+	}
+
+	data = withUserInfoMessage(data, entraPasswordUpdatedMessage)
+	clearEntraAuthPasswordState(session)
+	return access, data
+}
+
+func withUserInfoMessage(data isAuthenticatedDataResponse, message string) isAuthenticatedDataResponse {
+	if msg, ok := data.(userInfoMessage); ok {
+		msg.Message = message
+		return msg
+	}
+	return data
+}
+
+func checkLocalPassword(candidate, path string) (bool, bool, error) {
+	matches, err := password.CheckPassword(candidate, path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, false, nil
+	}
+	return err == nil, matches, err
 }
 
 // routeMFAInitError routes the AADSTS errors returned by InitiateEntraAuth
@@ -2580,6 +2705,7 @@ func (b *Broker) EndSession(sessionID string) error {
 	} else {
 		himmelblau.FreeMFAFlowState(session.mfaFlowActive)
 	}
+	clearEntraAuthPasswordState(&session)
 
 	b.currentSessionsMu.Lock()
 	defer b.currentSessionsMu.Unlock()

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -2450,11 +2450,13 @@ func TestEntraAuthAccessPassDoesNotCacheUnverifiedPassword(t *testing.T) {
 	require.NoError(t, err)
 
 	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
-	access, _, err = b.IsAuthenticated(sessionID, passwordAuthData)
+	access, data, err := b.IsAuthenticated(sessionID, passwordAuthData)
 	require.NoError(t, err)
 	require.Equal(t, broker.AuthNext, access)
 	require.Equal(t, []string{authmodes.EntraMFACode}, b.GetNextAuthModes(sessionID),
 		"a TAP challenge should route to code entry")
+	require.Contains(t, data, "entra_password_unverified",
+		"the PAM adapter must be told not to reuse the unverified password")
 
 	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraMFACode))
 	_, err = b.SelectAuthenticationMode(sessionID, authmodes.EntraMFACode)
@@ -2677,13 +2679,217 @@ func TestIsAuthenticatedEntraMFAWaitStartsPollingAtOne(t *testing.T) {
 	require.NoError(t, err, "Entra MFA completion should cache the refreshed token")
 }
 
+func newEntraMFAWaitTestBroker(t *testing.T) *broker.Broker {
+	t.Helper()
+
+	username := "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{},
+		flowState:    &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message:           "Approve the sign-in request in Microsoft Authenticator",
+			Method:            "PhoneAppNotification",
+			PollingIntervalMs: 1,
+			MaxPollAttempts:   1,
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+	return b
+}
+
+func TestEntraAuthKeepsExistingPasswordUntilConfirmed(t *testing.T) {
+	t.Parallel()
+
+	b := newEntraMFAWaitTestBroker(t)
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	require.NoError(t, password.HashAndStorePassword("local-password", b.PasswordFilepathForSession(sessionID)))
+
+	advanceToEntraMFAWaitWithPassword(t, b, sessionID, key, "entra-password")
+
+	access, data, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, "{}", data)
+	require.Equal(t, []string{authmodes.EntraAuthPasswordConfirmation}, b.GetNextAuthModes(sessionID))
+	require.True(t, passwordMatches(t, "local-password", b.PasswordFilepathForSession(sessionID)))
+	require.False(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+
+	modes, err := b.GetAuthenticationModes(sessionID, []map[string]string{supportedUILayouts["form"]})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{{
+		"id":    authmodes.EntraAuthPasswordConfirmation,
+		"label": authmodes.Label[authmodes.EntraAuthPasswordConfirmation],
+	}}, modes)
+
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuthPasswordConfirmation)
+	layout, err := b.SelectAuthenticationMode(sessionID, authmodes.EntraAuthPasswordConfirmation)
+	require.NoError(t, err)
+	require.Equal(t, "chars_password", layout["entry"])
+	require.Contains(t, layout["label"], "leave this blank to keep it")
+
+	access, data, err = b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Contains(t, data, broker.EntraPasswordKeptMessage)
+	require.True(t, passwordMatches(t, "local-password", b.PasswordFilepathForSession(sessionID)))
+	require.False(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+}
+
+func TestEntraAuthReplacesExistingPasswordAfterConfirmation(t *testing.T) {
+	t.Parallel()
+
+	b := newEntraMFAWaitTestBroker(t)
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	require.NoError(t, password.HashAndStorePassword("local-password", b.PasswordFilepathForSession(sessionID)))
+
+	advanceToEntraMFAWaitWithPassword(t, b, sessionID, key, "entra-password")
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuthPasswordConfirmation)
+
+	wrongPassword := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "wrong-password", key))
+	access, _, err = b.IsAuthenticated(sessionID, wrongPassword)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthRetry, access)
+	require.True(t, passwordMatches(t, "local-password", b.PasswordFilepathForSession(sessionID)))
+	require.False(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+
+	localPassword := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "local-password", key))
+	access, data, err := b.IsAuthenticated(sessionID, localPassword)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Contains(t, data, broker.EntraPasswordUpdatedMessage)
+	require.False(t, passwordMatches(t, "local-password", b.PasswordFilepathForSession(sessionID)))
+	require.True(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+}
+
+func TestEntraAuthCodeFlowConfirmsExistingPasswordReplacement(t *testing.T) {
+	t.Parallel()
+
+	username := "test-user@email.com"
+	mfaAuthInfo := generateCachedInfo(t, tokenOptions{username: username, issuer: defaultIssuerURL})
+	provider := &mockEntraAuthProvider{
+		MockProvider: &testutils.MockProvider{},
+		flowState:    &himmelblau.MFAFlowState{},
+		challengeInfo: &himmelblau.MFAChallengeInfo{
+			Message: "Enter the code from your authenticator app",
+			Method:  "PhoneAppOTP",
+		},
+		mfaTokenResult: newMFATokenResult(mfaAuthInfo.Token),
+	}
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:          true,
+		firstUserBecomesOwner: true,
+		provider:              provider,
+		issuerURL:             defaultIssuerURL,
+	})
+	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	require.NoError(t, password.HashAndStorePassword("local-password", b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuth)
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "entra-password", key))
+	access, _, err := b.IsAuthenticated(sessionID, passwordAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraMFACode}, b.GetNextAuthModes(sessionID))
+
+	updateAuthModes(t, b, sessionID, authmodes.EntraMFACode)
+	codeAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "123456", key))
+	access, _, err = b.IsAuthenticated(sessionID, codeAuthData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	require.Equal(t, []string{authmodes.EntraAuthPasswordConfirmation}, b.GetNextAuthModes(sessionID))
+	require.True(t, b.HasPendingEntraPassword(sessionID))
+
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuthPasswordConfirmation)
+	localPassword := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "local-password", key))
+	access, _, err = b.IsAuthenticated(sessionID, localPassword)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.False(t, b.HasPendingEntraPassword(sessionID))
+	require.True(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+}
+
+func TestEntraAuthConfirmationExhaustsAttemptsWithoutChangingPassword(t *testing.T) {
+	t.Parallel()
+
+	b := newEntraMFAWaitTestBroker(t)
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	require.NoError(t, password.HashAndStorePassword("local-password", b.PasswordFilepathForSession(sessionID)))
+	advanceToEntraMFAWaitWithPassword(t, b, sessionID, key, "entra-password")
+	access, _, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthNext, access)
+	updateAuthModes(t, b, sessionID, authmodes.EntraAuthPasswordConfirmation)
+
+	wrongPassword := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "wrong-password", key))
+	for attempt := 1; attempt <= broker.MaxAuthAttempts; attempt++ {
+		access, _, err = b.IsAuthenticated(sessionID, wrongPassword)
+		require.NoError(t, err)
+		if attempt < broker.MaxAuthAttempts {
+			require.Equal(t, broker.AuthRetry, access)
+			require.True(t, b.HasPendingEntraPassword(sessionID))
+			continue
+		}
+		require.Equal(t, broker.AuthDeniedMaxTries, access)
+	}
+
+	require.False(t, b.HasPendingEntraPassword(sessionID))
+	require.True(t, passwordMatches(t, "local-password", b.PasswordFilepathForSession(sessionID)))
+	require.False(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+}
+
+func TestEntraAuthMatchingPasswordIsNotRewritten(t *testing.T) {
+	t.Parallel()
+
+	b := newEntraMFAWaitTestBroker(t)
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	passwordPath := b.PasswordFilepathForSession(sessionID)
+	require.NoError(t, password.HashAndStorePassword("same-password", passwordPath))
+	before, err := os.ReadFile(passwordPath)
+	require.NoError(t, err)
+
+	advanceToEntraMFAWaitWithPassword(t, b, sessionID, key, "same-password")
+	access, data, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Contains(t, data, broker.EntraPasswordMatchesMessage)
+
+	after, err := os.ReadFile(passwordPath)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "matching Entra passwords must not rewrite the local password hash")
+}
+
+func passwordMatches(t *testing.T, candidate, path string) bool {
+	t.Helper()
+
+	matches, err := password.CheckPassword(candidate, path)
+	require.NoError(t, err)
+	return matches
+}
+
 // advanceToEntraMFAWait submits the Entra password for the session and selects the
 // entra_mfa_wait mode, leaving the session ready for the polling IsAuthenticated("{}").
 func advanceToEntraMFAWait(t *testing.T, b *broker.Broker, sessionID, key string) {
+	advanceToEntraMFAWaitWithPassword(t, b, sessionID, key, "password")
+}
+
+func advanceToEntraMFAWaitWithPassword(t *testing.T, b *broker.Broker, sessionID, key, userPassword string) {
 	t.Helper()
 
 	updateAuthModes(t, b, sessionID, authmodes.EntraAuth)
-	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "password", key))
+	passwordAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, userPassword, key))
 
 	access, _, err := b.IsAuthenticated(sessionID, passwordAuthData)
 	require.NoError(t, err)

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -2437,6 +2437,7 @@ func TestEntraAuthAccessPassDoesNotCacheUnverifiedPassword(t *testing.T) {
 	})
 
 	sessionID, key := newSessionForTests(t, b, username, sessionmode.Login)
+	require.NoError(t, password.StoreHashedPassword("malformed", b.PasswordFilepathForSession(sessionID)))
 	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraAuth))
 	_, err := b.SelectAuthenticationMode(sessionID, authmodes.EntraAuth)
 	require.NoError(t, err)
@@ -2465,10 +2466,10 @@ func TestEntraAuthAccessPassDoesNotCacheUnverifiedPassword(t *testing.T) {
 	codeAuthData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, "123456", key))
 	access, _, err = b.IsAuthenticated(sessionID, codeAuthData)
 	require.NoError(t, err)
-	require.NotEqual(t, broker.AuthDenied, access,
-		"a Temporary Access Pass is a valid credential, so the login itself must succeed")
-	require.NoFileExists(t, b.PasswordFilepathForSession(sessionID),
-		"the TAP answered the login, so the submitted password was never verified and must not be cached")
+	require.Equal(t, broker.AuthNext, access,
+		"a Temporary Access Pass is a valid credential, so the login should continue to local password setup")
+	require.Equal(t, []string{authmodes.NewPassword}, b.GetNextAuthModes(sessionID))
+	require.ErrorIs(t, password.ValidateHash(b.PasswordFilepathForSession(sessionID)), password.ErrInvalidHash)
 }
 
 // TestEntraAuthProbeKeepsDeviceAuthOutWhenFlowDisabled verifies that the probe
@@ -2532,6 +2533,7 @@ func TestEntraAuthPasswordlessSuccessDoesNotCacheOfflinePassword(t *testing.T) {
 	})
 
 	sessionID, _ := newSessionForTests(t, b, username, sessionmode.Login)
+	require.NoError(t, password.StoreHashedPassword("malformed", b.PasswordFilepathForSession(sessionID)))
 	require.NoError(t, b.SetAvailableMode(sessionID, authmodes.EntraAuth))
 	_, err := b.SelectAuthenticationMode(sessionID, authmodes.EntraAuth)
 	require.NoError(t, err)
@@ -2554,10 +2556,9 @@ func TestEntraAuthPasswordlessSuccessDoesNotCacheOfflinePassword(t *testing.T) {
 	require.Equal(t, broker.AuthNext, access,
 		"first-time passwordless logins should chain to local password creation")
 	require.Equal(t, []string{authmodes.NewPassword}, b.GetNextAuthModes(sessionID))
+	require.ErrorIs(t, password.ValidateHash(b.PasswordFilepathForSession(sessionID)), password.ErrInvalidHash)
 	_, err = os.Stat(b.TokenPathForSession(sessionID))
 	require.NoError(t, err, "passwordless auth should cache the token once device registration succeeds")
-	require.NoFileExists(t, b.PasswordFilepathForSession(sessionID),
-		"passwordless auth has no verified Entra password to cache for offline login")
 	require.Equal(t, 1, provider.registerDeviceCalls,
 		"passwordless auth should attempt first-time device registration after MFA succeeds")
 }
@@ -2742,6 +2743,23 @@ func TestEntraAuthKeepsExistingPasswordUntilConfirmed(t *testing.T) {
 	require.Contains(t, data, broker.EntraPasswordKeptMessage)
 	require.True(t, passwordMatches(t, "local-password", b.PasswordFilepathForSession(sessionID)))
 	require.False(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
+}
+
+func TestEntraAuthRecoversFromMalformedLocalPassword(t *testing.T) {
+	t.Parallel()
+
+	b := newEntraMFAWaitTestBroker(t)
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	passwordPath := b.PasswordFilepathForSession(sessionID)
+	require.NoError(t, password.StoreHashedPassword("malformed", passwordPath))
+
+	advanceToEntraMFAWaitWithPassword(t, b, sessionID, key, "entra-password")
+
+	access, data, err := b.IsAuthenticated(sessionID, "{}")
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access)
+	require.Contains(t, data, broker.CachedPasswordMessage)
+	require.True(t, passwordMatches(t, "entra-password", b.PasswordFilepathForSession(sessionID)))
 }
 
 func TestEntraAuthReplacesExistingPasswordAfterConfirmation(t *testing.T) {

--- a/authd-oidc-brokers/internal/broker/export_test.go
+++ b/authd-oidc-brokers/internal/broker/export_test.go
@@ -247,6 +247,16 @@ func (b *Broker) SetAttemptsPerMode(sessionID, mode string, attempts int) error 
 	return b.updateSession(sessionID, s)
 }
 
+// HasPendingEntraPassword returns whether the session retains a pending Entra
+// password candidate for a later confirmation step.
+func (b *Broker) HasPendingEntraPassword(sessionID string) bool {
+	s, err := b.getSession(sessionID)
+	if err != nil {
+		return false
+	}
+	return s.entraAuthPasswordHash != ""
+}
+
 // MaxRequestDuration exposes the broker's maxRequestDuration for tests.
 const MaxRequestDuration = maxRequestDuration
 
@@ -255,6 +265,15 @@ const MaxAuthAttempts = maxAuthAttempts
 
 // CachedPasswordMessage exposes the broker's cachedPasswordMessage for tests.
 const CachedPasswordMessage = cachedPasswordMessage
+
+// EntraPasswordMatchesMessage exposes the matching-password message for tests.
+const EntraPasswordMatchesMessage = entraPasswordMatchesMessage
+
+// EntraPasswordUpdatedMessage exposes the password-replacement message for tests.
+const EntraPasswordUpdatedMessage = entraPasswordUpdatedMessage
+
+// EntraPasswordKeptMessage exposes the keep-password message for tests.
+const EntraPasswordKeptMessage = entraPasswordKeptMessage
 
 // SetSessionMFAFlowActive lets tests set mfaFlowActive on a session without
 // going through entraAuth. The challenge info is left nil so that

--- a/authd-oidc-brokers/internal/password/password.go
+++ b/authd-oidc-brokers/internal/password/password.go
@@ -13,6 +13,9 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
+// ErrInvalidHash indicates that a password file does not contain a valid hash.
+var ErrInvalidHash = errors.New("invalid password hash")
+
 // HashAndStorePassword hashes the password and stores it in the data directory.
 func HashAndStorePassword(password, path string) error {
 	encoded, err := HashPassword(password)
@@ -50,19 +53,17 @@ func StoreHashedPassword(encoded, path string) error {
 	return nil
 }
 
+// ValidateHash checks that the password file contains a valid encoded hash.
+func ValidateHash(path string) error {
+	_, err := loadHash(path)
+	return err
+}
+
 // CheckPassword checks if the provided password matches the hash stored in the password file.
 func CheckPassword(password, path string) (bool, error) {
-	data, err := os.ReadFile(path)
+	decoded, err := loadHash(path)
 	if err != nil {
-		return false, fmt.Errorf("could not read password file: %w", err)
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(string(data))
-	if err != nil {
-		return false, fmt.Errorf("could not decode password: %w", err)
-	}
-	if len(decoded) < 16 {
-		return false, errors.New("could not decode password: invalid password hash")
+		return false, err
 	}
 
 	salt, hash := decoded[:16], decoded[16:]
@@ -71,6 +72,22 @@ func CheckPassword(password, path string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func loadHash(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read password file: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("could not decode password: %w: %w", ErrInvalidHash, err)
+	}
+	if len(decoded) != 16+32 {
+		return nil, fmt.Errorf("could not decode password: %w", ErrInvalidHash)
+	}
+	return decoded, nil
 }
 
 func hashPassword(password string, salt []byte) []byte {

--- a/authd-oidc-brokers/internal/password/password.go
+++ b/authd-oidc-brokers/internal/password/password.go
@@ -4,6 +4,7 @@ package password
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,6 +60,9 @@ func CheckPassword(password, path string) (bool, error) {
 	decoded, err := base64.StdEncoding.DecodeString(string(data))
 	if err != nil {
 		return false, fmt.Errorf("could not decode password: %w", err)
+	}
+	if len(decoded) < 16 {
+		return false, errors.New("could not decode password: invalid password hash")
 	}
 
 	salt, hash := decoded[:16], decoded[16:]

--- a/authd-oidc-brokers/internal/password/password_test.go
+++ b/authd-oidc-brokers/internal/password/password_test.go
@@ -172,5 +172,5 @@ func TestCheckPasswordRejectsShortHash(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = password.CheckPassword("test123", path)
-	require.Error(t, err)
+	require.ErrorIs(t, err, password.ErrInvalidHash)
 }

--- a/authd-oidc-brokers/internal/password/password_test.go
+++ b/authd-oidc-brokers/internal/password/password_test.go
@@ -163,3 +163,14 @@ func TestCheckPassword(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckPasswordRejectsShortHash(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "password")
+	err := os.WriteFile(path, []byte(base64.StdEncoding.EncodeToString([]byte("short"))), 0o600)
+	require.NoError(t, err)
+
+	_, err = password.CheckPassword("test123", path)
+	require.Error(t, err)
+}

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -29,6 +29,14 @@ const (
 	// delivered to the brokers, but also it's used to compute the time we should
 	// wait for the fully cancellation to have completed once delivered.
 	cancellationWait = time.Millisecond * 10
+
+	entraAuthModeID        = "entra_auth"
+	entraMFAWaitModeID     = "entra_mfa_wait"
+	entraMFACodeModeID     = "entra_mfa_code"
+	entraAuthFidoModeID    = "entra_auth_fido"
+	entraAuthFidoPinModeID = "entra_auth_fido_pin"
+	//nolint:gosec // G101: this is an authentication mode identifier, not a credential.
+	entraAuthPasswordConfirmationModeID = "entra_auth_password_confirmation"
 )
 
 var (
@@ -125,13 +133,15 @@ type authenticationModel struct {
 	clientType PamClientType
 	mode       authd.SessionMode
 
-	inProgress       bool
-	inputLocked      bool
-	currentModel     authenticationComponent
-	currentSessionID string
-	currentBrokerID  string
-	currentSecret    string
-	currentLayout    string
+	inProgress        bool
+	inputLocked       bool
+	currentModel      authenticationComponent
+	currentSessionID  string
+	currentBrokerID   string
+	currentSecret     string
+	currentLayout     string
+	currentAuthModeID string
+	entraAuthSecret   string
 
 	// authGen identifies the current challenge. It is bumped every time a
 	// challenge starts (startAuthentication), so that a stopAuthentication
@@ -199,6 +209,41 @@ func newAuthenticationModel(client authd.PAMClient, clientType PamClientType, mo
 		mode:        mode,
 		authTracker: &authTracker{},
 	}
+}
+
+func isEntraAuthContinuationMode(mode string) bool {
+	switch mode {
+	case entraMFAWaitModeID, entraMFACodeModeID, entraAuthFidoModeID,
+		entraAuthFidoPinModeID, entraAuthPasswordConfirmationModeID:
+		return true
+	}
+	return false
+}
+
+func (m *authenticationModel) setAuthMode(mode string) {
+	previousMode := m.currentAuthModeID
+	leavingEntraFlow := previousMode == entraAuthModeID ||
+		isEntraAuthContinuationMode(previousMode)
+
+	if mode == entraAuthModeID || (!isEntraAuthContinuationMode(mode) && leavingEntraFlow) {
+		m.clearSecrets()
+	} else if !isEntraAuthContinuationMode(mode) {
+		m.clearEntraSecret()
+	}
+	m.currentAuthModeID = mode
+}
+
+func (m *authenticationModel) clearEntraSecret() {
+	if m.entraAuthSecret != "" && m.currentSecret == m.entraAuthSecret {
+		m.currentSecret = ""
+	}
+	m.entraAuthSecret = ""
+}
+
+func (m *authenticationModel) clearSecrets() {
+	m.currentSecret = ""
+	m.entraAuthSecret = ""
+	m.currentAuthModeID = ""
 }
 
 // Init initializes authenticationModel.
@@ -376,13 +421,24 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 	case isAuthenticatedResultReceived:
 		safeMessageDebug(msg)
 
+		unverifiedEntraPassword := msg.access == auth.Next &&
+			m.currentAuthModeID == entraAuthModeID &&
+			msg.secret != nil &&
+			responseMarksUnverifiedEntraPassword(msg.msg)
+
 		// Resets password if the authentication wasn't successful.
 		defer func() {
 			// the returned authModel is a copy of function-level's `m` at this point!
 			m := &authModel
 			if msg.secret != nil &&
 				(msg.access == auth.Granted || msg.access == auth.Next) {
-				m.currentSecret = *msg.secret
+				if !unverifiedEntraPassword {
+					m.currentSecret = *msg.secret
+				}
+				if msg.access == auth.Next && m.currentAuthModeID == entraAuthModeID &&
+					*msg.secret != "" && !unverifiedEntraPassword {
+					m.entraAuthSecret = *msg.secret
+				}
 			}
 
 			if msg.access != auth.Next && msg.access != auth.Retry {
@@ -403,13 +459,21 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		switch msg.access {
 		case auth.Granted:
 			var secret string
-			// TODO: This will not select the correct secret in case the last authentication step uses a secret
-			// which is not the local password (e.g. OTP).
-			if msg.secret != nil {
+			var oldSecret string
+
+			switch {
+			case m.currentAuthModeID == entraAuthPasswordConfirmationModeID:
+				if msg.secret != nil && *msg.secret != "" {
+					secret = m.entraAuthSecret
+					oldSecret = *msg.secret
+				}
+			case isEntraAuthContinuationMode(m.currentAuthModeID) && m.entraAuthSecret != "":
+				secret = m.entraAuthSecret
+			case msg.secret != nil:
 				secret = *msg.secret
-			} else if m.currentSecret != "" {
+			case m.currentSecret != "":
 				secret = m.currentSecret
-			} else {
+			default:
 				log.Warningf(context.Background(), "authentication granted, but no secret is available, cannot set PAM_AUTHTOK")
 			}
 
@@ -420,17 +484,18 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 			// old password. We only do this when the old and new secrets differ and
 			// the new one came from this step (msg.secret), to avoid setting a
 			// spurious PAM_OLDAUTHTOK during plain authentication.
-			var oldSecret string
 			if m.mode == authd.SessionMode_CHANGE_PASSWORD && msg.secret != nil &&
 				m.currentSecret != "" && m.currentSecret != secret {
 				oldSecret = m.currentSecret
 			}
-			return m, sendEvent(PamSuccess{
+			success := PamSuccess{
 				BrokerID:   m.currentBrokerID,
 				AuthTok:    secret,
 				OldAuthTok: oldSecret,
 				msg:        authMsg,
-			})
+			}
+			m.clearSecrets()
+			return m, sendEvent(success)
 
 		case auth.Retry:
 			m.errorMsg = authMsg
@@ -440,12 +505,14 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 			if authMsg == "" {
 				authMsg = "Access denied"
 			}
+			m.clearSecrets()
 			return m, sendEvent(pamError{status: pam.ErrAuth, msg: authMsg})
 
 		case auth.DeniedMaxTries:
 			if authMsg == "" {
 				authMsg = "Maximum number of tries exceeded"
 			}
+			m.clearSecrets()
 			return m, sendEvent(pamError{status: pam.ErrMaxtries, msg: authMsg})
 
 		case auth.Next:
@@ -618,20 +685,30 @@ func dataToMsg(data string) (string, error) {
 	if data == "" {
 		return "", nil
 	}
-
-	v := make(map[string]string)
+	var v struct {
+		Message *string `json:"message"`
+	}
 	if err := json.Unmarshal([]byte(data), &v); err != nil {
 		return "", fmt.Errorf("invalid json data from provider: %v", err)
 	}
-	if len(v) == 0 {
-		return "", nil
+	if v.Message == nil {
+		return "", fmt.Errorf("no message entry in json data from provider: %s", data)
+	}
+	return *v.Message, nil
+}
+
+func responseMarksUnverifiedEntraPassword(data string) bool {
+	if data == "" {
+		return false
 	}
 
-	r, ok := v["message"]
-	if !ok {
-		return "", fmt.Errorf("no message entry in json data from provider: %v", v)
+	var response struct {
+		Unverified bool `json:"entra_password_unverified"`
 	}
-	return r, nil
+	if err := json.Unmarshal([]byte(data), &response); err != nil {
+		return true
+	}
+	return response.Unverified
 }
 
 // grantedTolerantMsg parses data via dataToMsg, treating a malformed or

--- a/pam/internal/adapter/authentication_test.go
+++ b/pam/internal/adapter/authentication_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"testing"
 
+	"github.com/canonical/authd/internal/brokers/auth"
 	"github.com/canonical/authd/internal/brokers/layouts"
 	"github.com/canonical/authd/internal/brokers/layouts/entries"
 	"github.com/canonical/authd/internal/proto/authd"
@@ -141,4 +142,191 @@ func TestFormModelLocksInputOnSubmission(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, updatedForm.submitting)
 	require.Equal(t, "password", entry.Value())
+}
+
+func TestFormModelSubmitsEmptyConfirmation(t *testing.T) {
+	t.Parallel()
+
+	entry := newTextInputModel(entries.CharsPassword)
+	form := formModel{focusableModels: []authenticationComponent{&entry}}
+	form.Focus()
+
+	updated, cmd := form.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updatedForm, ok := updated.(formModel)
+	require.True(t, ok)
+	require.True(t, updatedForm.submitting)
+
+	request, ok := cmd().(isAuthenticatedRequested)
+	require.True(t, ok)
+	secret, ok := request.item.(*authd.IARequest_AuthenticationData_Secret)
+	require.True(t, ok)
+	require.Empty(t, secret.Secret)
+}
+
+func TestAuthenticationModelPreservesEntraPasswordAcrossMFA(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthModeID
+	entraPassword := "entra-password"
+
+	updated, _ := model.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    "{}",
+		secret: &entraPassword,
+	})
+	require.Equal(t, entraPassword, updated.entraAuthSecret)
+
+	updated.currentAuthModeID = entraMFACodeModeID
+	mfaCode := "123456"
+	updated, cmd := updated.Update(isAuthenticatedResultReceived{
+		access: auth.Granted,
+		secret: &mfaCode,
+		msg:    "{}",
+	})
+
+	success, ok := cmd().(PamSuccess)
+	require.True(t, ok)
+	require.Equal(t, entraPassword, success.AuthTok)
+	require.Empty(t, success.OldAuthTok)
+	require.Empty(t, updated.entraAuthSecret)
+}
+
+func TestAuthenticationModelPreservesEntraPasswordAcrossFidoPIN(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthModeID
+	entraPassword := "entra-password"
+
+	updated, _ := model.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    "{}",
+		secret: &entraPassword,
+	})
+	updated.currentAuthModeID = entraAuthFidoPinModeID
+	fidoPIN := "123456"
+	updated, _ = updated.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    "{}",
+		secret: &fidoPIN,
+	})
+	require.Equal(t, entraPassword, updated.entraAuthSecret)
+
+	updated.currentAuthModeID = entraAuthFidoModeID
+	updated, cmd := updated.Update(isAuthenticatedResultReceived{
+		access: auth.Granted,
+		msg:    "{}",
+	})
+	success, ok := cmd().(PamSuccess)
+	require.True(t, ok)
+	require.Equal(t, entraPassword, success.AuthTok)
+	require.Empty(t, success.OldAuthTok)
+	require.Empty(t, updated.entraAuthSecret)
+}
+
+func TestAuthenticationModelReturnsOldTokenForEntraPasswordReplacement(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthPasswordConfirmationModeID
+	model.entraAuthSecret = "entra-password"
+
+	localPassword := "local-password"
+	updated, cmd := model.Update(isAuthenticatedResultReceived{
+		access: auth.Granted,
+		secret: &localPassword,
+		msg:    "{}",
+	})
+
+	success, ok := cmd().(PamSuccess)
+	require.True(t, ok)
+	require.Equal(t, "entra-password", success.AuthTok)
+	require.Equal(t, localPassword, success.OldAuthTok)
+	require.Empty(t, updated.entraAuthSecret)
+}
+
+func TestAuthenticationModelDoesNotReturnEntraTokenWhenKeepingLocalPassword(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthPasswordConfirmationModeID
+	model.entraAuthSecret = "entra-password"
+	emptyPassword := ""
+
+	updated, cmd := model.Update(isAuthenticatedResultReceived{
+		access: auth.Granted,
+		secret: &emptyPassword,
+		msg:    "{}",
+	})
+
+	success, ok := cmd().(PamSuccess)
+	require.True(t, ok)
+	require.Empty(t, success.AuthTok)
+	require.Empty(t, success.OldAuthTok)
+	require.Empty(t, updated.entraAuthSecret)
+}
+
+func TestAuthenticationModelDropsUnverifiedEntraPassword(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthModeID
+	entraPassword := "temporary-password"
+
+	updated, _ := model.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    `{"message":"","entra_password_unverified":true}`,
+		secret: &entraPassword,
+	})
+	require.Empty(t, updated.entraAuthSecret)
+	require.Empty(t, updated.currentSecret)
+}
+
+func TestAuthenticationModelDoesNotExposeEntraFactorsAfterFallback(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthModeID
+	entraPassword := "entra-password"
+
+	updated, _ := model.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    "{}",
+		secret: &entraPassword,
+	})
+	updated.currentAuthModeID = entraAuthFidoPinModeID
+	fidoPIN := "123456"
+	updated, _ = updated.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    "{}",
+		secret: &fidoPIN,
+	})
+	require.Equal(t, entraPassword, updated.entraAuthSecret)
+
+	updated.setAuthMode("device_auth")
+	require.Empty(t, updated.entraAuthSecret)
+	require.Empty(t, updated.currentSecret)
+}
+
+func TestAuthenticationModelClearsEntraPasswordOnDenial(t *testing.T) {
+	t.Parallel()
+
+	model := newAuthenticationModel(nil, InteractiveTerminal, authd.SessionMode_LOGIN)
+	model.currentAuthModeID = entraAuthModeID
+	entraPassword := "entra-password"
+	model, _ = model.Update(isAuthenticatedResultReceived{
+		access: auth.Next,
+		msg:    "{}",
+		secret: &entraPassword,
+	})
+
+	updated, cmd := model.Update(isAuthenticatedResultReceived{
+		access: auth.Denied,
+		msg:    `{"message":"denied"}`,
+	})
+	_, ok := cmd().(pamError)
+	require.True(t, ok)
+	require.Empty(t, updated.entraAuthSecret)
+	require.Empty(t, updated.currentSecret)
 }

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -272,12 +272,14 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case PamReturnValue:
 		safeMessageDebug(msg)
 		if m.pamReturnValue == nil {
+			m.authenticationModel.clearSecrets()
 			return m, m.quit()
 		}
 		if *m.pamReturnValue != pamNoReturnValue {
 			// Nothing to do, we're already exiting...
 			return m, nil
 		}
+		m.authenticationModel.clearSecrets()
 		*m.pamReturnValue = msg
 		return m, m.quit()
 
@@ -416,6 +418,7 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				msg:    "reselection of current auth mode without current ID",
 			})
 		}
+		m.authenticationModel.setAuthMode(msg.ID)
 		return m, tea.Sequence(
 			m.updateClientModel(msg),
 			getLayout(m.client, m.currentSession.sessionID, msg.ID),
@@ -441,6 +444,7 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		safeMessageDebug(msg)
 		m.sessionStartingForBroker = ""
 		m.currentSession = nil
+		m.authenticationModel.clearSecrets()
 		if m.clientType == Gdm {
 			m.gdmModel.pendingEchoAuthModeID = ""
 		}


### PR DESCRIPTION
> [!NOTE]
> This is still a draft
> - [ ] Add an end-to-end test 

An Entra password login could overwrite a different local password
without user consent and leave PAM without the old token needed to
re-key GNOME Keyring. Require the existing local password for
replacement, retain it when skipped, and carry both PAM tokens across
MFA.

Closes https://github.com/canonical/authd/issues/1683
UDENG-10793