### PR TITLE
broker: prevent AADSTS700025 on Entra device-code refresh

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -278,16 +278,14 @@ func New(cfg Config, apiVersion uint, args ...Option) (b *Broker, err error) {
 	}
 
 	clientID := cfg.clientID
-	if _, ok := providers.ProviderAs[providers.DeviceRegisterer](opts.provider); ok && cfg.registerDevice {
-		clientID = consts.MicrosoftBrokerAppID
-	}
-
-	// The Microsoft Broker App is a public client and must never send a secret,
-	// even when client_secret is configured (for Graph API fallback). Resolve
-	// this once so that NewSession never needs to re-derive it from the client ID.
 	oidcClientSecret := cfg.clientSecret
-	if clientID == consts.MicrosoftBrokerAppID {
+	if _, ok := providers.ProviderAs[providers.DeviceRegisterer](opts.provider); ok {
+		// Entra device-code authentication uses a public OIDC client. The
+		// secret is reserved for the provider's app-only Graph fallback.
 		oidcClientSecret = ""
+		if cfg.registerDevice {
+			clientID = consts.MicrosoftBrokerAppID
+		}
 	}
 
 	b = &Broker{

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -4284,6 +4284,67 @@ func TestIsAuthenticatedPasswordDeviceRegistrationRefreshDoesNotSendClientSecret
 		"the Microsoft Broker App is a public client, so refresh must not send the configured OIDC client secret")
 }
 
+func TestIsAuthenticatedPasswordEntraDeviceCodeRefreshDoesNotSendClientSecret(t *testing.T) {
+	t.Parallel()
+
+	const correctPassword = "password"
+	const listenAddress = "127.0.0.1:31318"
+	const serverURL = "http://" + listenAddress
+
+	var sawRefresh bool
+	var refreshClientSecret string
+	baseTokenHandler := testutils.TokenHandler(serverURL, &testutils.TokenHandlerOptions{
+		IDTokenClaims: []map[string]interface{}{
+			{"aud": "test-client-id"},
+		},
+	})
+
+	b := newBrokerForTests(t, &brokerForTestConfig{
+		Config:                     broker.Config{DataDir: t.TempDir()},
+		ownerAllowed:               true,
+		firstUserBecomesOwner:      true,
+		clientSecret:               "test-client-secret",
+		supportsDeviceRegistration: true,
+		listenAddress:              listenAddress,
+		customHandlers: map[string]testutils.EndpointHandler{
+			"/token": func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				if r.FormValue("grant_type") == "refresh_token" {
+					sawRefresh = true
+					refreshClientSecret = r.FormValue("client_secret")
+					if refreshClientSecret == "" {
+						if _, password, ok := r.BasicAuth(); ok {
+							refreshClientSecret = password
+						}
+					}
+					if refreshClientSecret != "" {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"AADSTS700025: Client is public so neither 'client_assertion' nor 'client_secret' should be presented."}`))
+						return
+					}
+				}
+				baseTokenHandler(w, r)
+			},
+		},
+	})
+
+	sessionID, key := newSessionForTests(t, b, "test-user@email.com", sessionmode.Login)
+	generateAndStoreCachedInfo(t, tokenOptions{}, b.TokenPathForSession(sessionID))
+	require.NoError(t, password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID)))
+
+	updateAuthModes(t, b, sessionID, authmodes.Password)
+	authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, encryptSecret(t, correctPassword, key))
+
+	access, _, err := b.IsAuthenticated(sessionID, authData)
+	require.NoError(t, err)
+	require.Equal(t, broker.AuthGranted, access,
+		"Entra device-code tokens must refresh as a public client when a Graph fallback secret is configured")
+	require.True(t, sawRefresh, "the returning login must exercise the OIDC refresh path")
+	require.Empty(t, refreshClientSecret,
+		"the configured Graph fallback secret must not be sent to the public OIDC client")
+}
+
 // TestEntraAuthInvalidatesCachedCredentialsOnRemotePasswordChange verifies
 // that an AADSTS50173 (grant revoked by a remote password change) wipes the
 // cached token and password files and offers re-authentication.

--- a/docs/reference/group-management.md
+++ b/docs/reference/group-management.md
@@ -51,11 +51,12 @@ scope, so the groups are resolved in one of two ways:
 - **With device registration** (`register_device = true`): the device's primary
   refresh token is exchanged for a Graph-scoped access token. No extra
   configuration is required.
-- **Without device registration** (`register_device = false`): a `client_secret`
-  must be configured in the `[oidc]` section. authd then uses the OIDC app's
-  client credentials to obtain an application-level Graph token. This requires
-  the app registration to hold the `GroupMember.Read.All` **Application**
-  permission with tenant admin consent.
+- **Without device registration** (`register_device = false`) for the
+  **Entra authentication** flow: a `client_secret` must be configured in the
+  `[oidc]` section. authd then uses the OIDC app's client credentials to obtain
+  an application-level Graph token. This requires the app registration to hold
+  the `GroupMember.Read.All` **Application** permission with tenant admin
+  consent.
 
 If neither device registration nor a client secret is available while the
 **Entra authentication** flow is enabled, the broker fails to start because


### PR DESCRIPTION
Normal Entra device-code authentication uses a public OIDC client. The configured secret is only for the app-only Graph fallback when Entra authentication is enabled without device registration. Sending it to the public refresh endpoint causes AADSTS700025.

Keep the public OAuth client separate from the Graph credentials so both refresh paths work correctly.

Closes #1881
UDENG-11453