### PR TITLE
Redact Entra client secrets in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -112,7 +112,7 @@ body:
           | sed -E -e 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' \
             -e 's/GOCSPX-[0-9a-zA-Z_-]+/<redacted>/g' \
             -e 's/[0-9a-zA-Z_-]+\.apps\.googleusercontent\.com/<redacted>/g' \
-            -e 's/(client_secret = )\S+.*/\1<redacted>/g')
+            -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
         \`\`\`
 
         #### authd apt history
@@ -121,25 +121,25 @@ body:
         \`\`\`
 
         #### authd broker configuration
-        $(sudo sh -c 'if ! find /etc/authd/brokers.d -name \*.conf | grep -q .; then echo ":warning: No config files in /etc/authd/brokers.d/"; else for f in /etc/authd/brokers.d/*.conf; do echo "#### $f"; echo "\`\`\`";  cat $f; echo "\`\`\`"; done; fi' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo sh -c 'if ! find /etc/authd/brokers.d -name \*.conf | grep -q .; then echo ":warning: No config files in /etc/authd/brokers.d/"; else for f in /etc/authd/brokers.d/*.conf; do echo "#### $f"; echo "\`\`\`";  cat $f; echo "\`\`\`"; done; fi' | sed -E 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
 
         #### authd-msentraid configuration
         \`\`\`
-        $(sudo cat 2>&1 /var/snap/authd-msentraid/current/broker.conf | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-msentraid/current/broker.conf | sed -E -e 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
         \`\`\`
-        $(sudo sh -c 'for f in /var/snap/authd-msentraid/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo sh -c 'for f in /var/snap/authd-msentraid/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
 
         #### authd-google configuration
         \`\`\`
-        $(sudo cat 2>&1 /var/snap/authd-google/current/broker.conf | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-google/current/broker.conf | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
         \`\`\`
-        $(sudo sh -c 'for f in /var/snap/authd-google/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo sh -c 'for f in /var/snap/authd-google/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/client_id = .*/client_id = <redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
 
         #### authd-oidc configuration
         \`\`\`
-        $(sudo cat 2>&1 /var/snap/authd-oidc/current/broker.conf | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-oidc/current/broker.conf | sed -E -e 's/client_id = .*/client_id = <redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
         \`\`\`
-        $(sudo sh -c 'for f in /var/snap/authd-oidc/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo sh -c 'for f in /var/snap/authd-oidc/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/client_id = .*/client_id = <redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
 
         EOF
         ```

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -131,15 +131,15 @@ body:
 
         #### authd-google configuration
         \`\`\`
-        $(sudo cat 2>&1 /var/snap/authd-google/current/broker.conf | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-google/current/broker.conf | sed -E -e 's/(client_id[[:space:]]*=[[:space:]]*).*/\1<redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
         \`\`\`
-        $(sudo sh -c 'for f in /var/snap/authd-google/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/client_id = .*/client_id = <redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
+        $(sudo sh -c 'for f in /var/snap/authd-google/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/(client_id[[:space:]]*=[[:space:]]*).*/\1<redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
 
         #### authd-oidc configuration
         \`\`\`
-        $(sudo cat 2>&1 /var/snap/authd-oidc/current/broker.conf | sed -E -e 's/client_id = .*/client_id = <redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-oidc/current/broker.conf | sed -E -e 's/(client_id[[:space:]]*=[[:space:]]*).*/\1<redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
         \`\`\`
-        $(sudo sh -c 'for f in /var/snap/authd-oidc/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/client_id = .*/client_id = <redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
+        $(sudo sh -c 'for f in /var/snap/authd-oidc/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E -e 's/(client_id[[:space:]]*=[[:space:]]*).*/\1<redacted>/g' -e 's/(client_secret[[:space:]]*=[[:space:]]*).*/\1<redacted>/g')
 
         EOF
         ```

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -125,9 +125,9 @@ body:
 
         #### authd-msentraid configuration
         \`\`\`
-        $(sudo cat 2>&1 /var/snap/authd-msentraid/current/broker.conf | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-msentraid/current/broker.conf | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
         \`\`\`
-        $(sudo sh -c 'for f in /var/snap/authd-msentraid/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g')
+        $(sudo sh -c 'for f in /var/snap/authd-msentraid/current/broker.conf.d/*.conf; do [ -f "$f" ] && echo "##### $f" && echo "\`\`\`" && cat "$f" && echo "\`\`\`"; done' 2>/dev/null | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
 
         #### authd-google configuration
         \`\`\`


### PR DESCRIPTION
Update the bug report template to redact OAuth configuration values safely.

- Redact Entra `client_secret` values in the main config and drop-ins.
- Match flexible INI spacing for `client_secret` in logs and broker configs, and for `client_id` in Google and OIDC configs.

UDENG-11458