### PR TITLE
docs: clarify Entra password and `libpwquality` scope

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -63,8 +63,27 @@ authentication flow.
 
 Strong passwords are critical to prevent unauthorized access.
 
-authd uses libpwquality to enforce password complexity requirements. See the
-[Configure password quality](ref::config-pwquality) section for details.
+authd uses `libpwquality` to enforce password complexity requirements for local
+passwords. See the [Configure password quality](ref::config-pwquality) section
+for details.
+
+(ref::cached-entra-passwords)=
+
+#### Cached Entra ID passwords
+
+After a successful login through the Entra authentication flow using an Entra ID
+password, authd stores a salted hash of the password for offline authentication.
+
+authd does not apply its local `libpwquality` policy to Entra ID passwords
+used in the Entra authentication flow. Changes made to
+`/etc/security/pwquality.conf` do not affect users authenticating with an Entra
+ID password through that flow.
+A weak password accepted by the tenant is cached the same way. Configure the
+tenant password policy to reject weak passwords.
+
+The local policy applies when authd creates or changes a local password,
+including after passwordless or device-code authentication.
+See [Authentication flows](/reference/authentication-flows/) for details.
 
 (ref::force-auth-security)=
 #### Force provider authentication
@@ -164,6 +183,8 @@ To avoid this risk:
 
 This section describes how authd is built to protect stored data and limit
 system exposure.
+
+(ref::stored-secrets)=
 
 ### Stored secrets
 

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -649,8 +649,15 @@ If your mobile device management (MDM) solution includes a compliance check for
 the passwords of authd users, you may also need to configure authd's password
 policy so that it matches that of the MDM.
 
-authd depends on the libpwquality library, which supports configuring password
+authd depends on the `libpwquality` library, which supports configuring password
 quality.
+
+```{note}
+This policy applies only to local passwords created or changed through authd.
+To reject weak Entra ID passwords, configure the tenant password policy. See
+[Cached Entra ID passwords](ref::cached-entra-passwords) in the security
+overview.
+```
 
 To configure the local password policy for authd, create a drop file in
 `/etc/security/pwquality.conf.d/`.

--- a/docs/reference/authentication-flows.md
+++ b/docs/reference/authentication-flows.md
@@ -23,7 +23,8 @@ Microsoft Entra ID supports the following authentication flows:
   method, or with their Entra ID password followed by an MFA challenge.
   On success, authd caches the access tokens and user information locally.
   For offline login, it stores only a salted hash of the Entra ID or local
-  password. See [Stored secrets](/explanation/security.md#stored-secrets).
+  password. See [Stored secrets](ref::stored-secrets) and
+  [Cached Entra ID passwords](ref::cached-entra-passwords).
 
 The device code flow is enabled by default. If `entra_auth` is omitted, its
 default follows `register_device`: it is enabled when device registration is


### PR DESCRIPTION
Explain that `libpwquality` validates local passwords only. A password accepted by Microsoft Entra ID can still be cached as a salted hash for offline login, so weak Entra passwords must be rejected by the tenant password policy.

UDENG-11483