### PR TITLE
Ensure cargo-c update commits are verified

### DIFF
--- a/.github/workflows/update-cargo-c.yaml
+++ b/.github/workflows/update-cargo-c.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           branch: auto-update-cargo-c
           delete-branch: true
+          sign-commits: true
           commit-message: "deps(snap): update cargo-c to v${{ steps.update.outputs.version }}"
           title: "deps(snap): update cargo-c to v${{ steps.update.outputs.version }}"
           body: |


### PR DESCRIPTION
Enable verified commits for automated cargo-c update PRs (an example would be #1839) by setting [`sign-commits: true`](https://github.com/peter-evans/create-pull-request/blob/main/README.md?plain=1#L66).