### PR TITLE
e2e-tests: keep recordings distinct per test case

### DIFF
--- a/e2e-tests/resources/Browser.py
+++ b/e2e-tests/resources/Browser.py
@@ -6,6 +6,8 @@ import threading
 from robot.api.deco import keyword, library  # type: ignore
 from robot.api import logger
 
+from RecordingUtils import current_test_name_for_filename
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 BROWSER_LOGIN_DIR = os.path.join(SCRIPT_DIR, "browser_login")
 
@@ -52,7 +54,14 @@ class Browser:
                 f"Known brokers: {sorted(_BROKER_LOGIN_SCRIPTS.keys())}"
             )
 
-        command = [script, usercode, "--output-dir", output_dir]
+        command = [
+            script,
+            usercode,
+            "--output-dir",
+            output_dir,
+            "--recording-name",
+            f"Webview_Recording_{current_test_name_for_filename()}",
+        ]
         if not os.getenv("SHOW_WEBVIEW"):
             command = ["/usr/bin/env", "GDK_BACKEND=x11", "xvfb-run", "-a", "--"] + command
 

--- a/e2e-tests/resources/RecordingUtils.py
+++ b/e2e-tests/resources/RecordingUtils.py
@@ -1,0 +1,21 @@
+import re
+
+from robot.libraries.BuiltIn import BuiltIn
+
+
+def current_test_name_for_filename() -> str:
+    """Return the current test name in a form that is safe for file names."""
+    test_name = BuiltIn().get_variable_value("${TEST_NAME}")
+    if not test_name:
+        raise RuntimeError("TEST_NAME is not available while recording a test")
+
+    safe_name = re.sub(r"[^A-Za-z0-9.-]+", "_", str(test_name)).strip("._-")
+    return safe_name or "test"
+
+
+def current_test_recording_suffix() -> str:
+    return f"{current_test_name_for_filename()}.mp4"
+
+
+def recording_filename(prefix: str) -> str:
+    return f"{prefix}_{current_test_recording_suffix()}"

--- a/e2e-tests/resources/VNCRecorder.py
+++ b/e2e-tests/resources/VNCRecorder.py
@@ -8,6 +8,8 @@ from robot.api.deco import library, keyword
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 
+from RecordingUtils import recording_filename
+
 PR_SET_PDEATHSIG = 1
 SIGTERM = 15
 
@@ -69,7 +71,9 @@ class VNCRecorder:
         """Start recording the VNC session to a video file."""
         port = os.getenv('VNC_PORT', 5901)
         output_dir = str(BuiltIn().get_variable_value('${SUITE_OUTPUT_DIR}'))
-        output_path = os.path.join(output_dir, 'VM_Recording.mp4')
+        output_path = os.path.join(
+            output_dir, recording_filename('VM_Recording')
+        )
 
         display_num = find_unused_display()
         display = f':{display_num}'

--- a/e2e-tests/resources/VideoLogger.py
+++ b/e2e-tests/resources/VideoLogger.py
@@ -1,9 +1,9 @@
-from robot.api import logger
 from robot.api.deco import keyword, library  # type: ignore
 from robot.libraries.BuiltIn import BuiltIn
 import glob
 import os
-import base64
+
+from RecordingUtils import current_test_recording_suffix
 
 @library
 class VideoLogger:
@@ -12,8 +12,12 @@ class VideoLogger:
     @keyword
     def log_videos(self):
         output_dir = str(BuiltIn().get_variable_value('${SUITE_OUTPUT_DIR}'))
-        pattern = os.path.join(output_dir, '*.mp4')
-        videos = sorted(glob.glob(pattern))
+        test_video_suffix = current_test_recording_suffix()
+        patterns = (
+            os.path.join(output_dir, f'VM_Recording_{test_video_suffix}'),
+            os.path.join(output_dir, f'Webview_Recording_{test_video_suffix}'),
+        )
+        videos = sorted(path for pattern in patterns for path in glob.glob(pattern))
         for path in videos:
             title = os.path.basename(path).removesuffix('.mp4').replace('_', ' ')
             relpath = os.path.relpath(path, os.path.dirname(output_dir))

--- a/e2e-tests/resources/browser_login/base.py
+++ b/e2e-tests/resources/browser_login/base.py
@@ -53,6 +53,7 @@ def run_browser_login(login_func: LoginFunc) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("device_code")
     parser.add_argument("--output-dir", required=False, default=os.path.realpath(os.curdir))
+    parser.add_argument("--recording-name", required=False, default="Webview_Recording")
     parser.add_argument("--show-webview", action="store_true")
     args = parser.parse_args()
 
@@ -96,5 +97,7 @@ def run_browser_login(login_func: LoginFunc) -> None:
             if browser.get_mapped():
                 browser.capture_snapshot(screenshot_dir, "failure")
             logger.info("Stopping recording and closing browser")
-            browser.stop_recording(os.path.join(args.output_dir, "Webview_Recording.mp4"))
+            browser.stop_recording(
+                os.path.join(args.output_dir, f"{args.recording_name}.mp4")
+            )
             browser.destroy()


### PR DESCRIPTION
Suite-level recording paths were reused by every test in a Robot suite, so the last test replaced the video linked from earlier test results. Add the sanitized test name to VM and browser recording paths and only log the current test's recordings.

Closes #1903
UDENG-11481

e2e-brokers: msentraid
e2e-tests: polkit_pkexec.robot
