### PR TITLE
Avoid warning for unrelated D-Bus interfaces

### DIFF
--- a/internal/brokers/dbusbroker.go
+++ b/internal/brokers/dbusbroker.go
@@ -141,8 +141,12 @@ func getInterface(obj dbus.BusObject) (dbusInterface, error) {
 
 	var supportedInterfaces []dbusInterface
 	for _, iface := range node.Interfaces {
-		// Ignore interfaces that do not satisfy the expected format, as they are not relevant for selecting the broker
-		// interface version.
+		if !strings.HasPrefix(iface.Name, DbusBaseInterface) {
+			continue
+		}
+
+		// Only authd broker interfaces are relevant for selecting the broker interface version.
+		// Warn when one of those interfaces does not satisfy the expected format.
 		// The expected format is com.ubuntu.authd.BrokerX, where X is the version number (or empty for the first
 		// version).
 		version, err := interfaceVersion(iface.Name)

--- a/internal/brokers/dbusbroker_test.go
+++ b/internal/brokers/dbusbroker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/canonical/authd/internal/services/errmessages"
+	"github.com/canonical/authd/log"
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/stretchr/testify/require"
@@ -126,6 +127,26 @@ func TestGetInterface(t *testing.T) {
 			require.Equal(t, tc.wantInterface, got, "getInterface returned unexpected interface")
 		})
 	}
+}
+
+func TestGetInterfaceIgnoresUnrelatedInterfacesWithoutWarning(t *testing.T) {
+	var warnings []string
+	log.SetLevelHandler(log.WarnLevel, func(_ context.Context, _ log.Level, format string, args ...interface{}) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	t.Cleanup(func() { log.SetLevelHandler(log.WarnLevel, nil) })
+
+	mock := &mockBusObject{
+		introspectXML: introspectionXML(
+			"com.ubuntu.authd.Broker2",
+			"org.freedesktop.DBus.Introspectable",
+		),
+	}
+
+	got, err := getInterface(mock)
+	require.NoError(t, err)
+	require.Equal(t, dbusInterface{name: "com.ubuntu.authd.Broker2", version: 2}, got)
+	require.Empty(t, warnings, "unrelated interfaces should not produce warnings")
 }
 
 func TestDbusBrokerCallUsesInterface(t *testing.T) {


### PR DESCRIPTION
Broker introspection includes standard D-Bus interfaces such as `org.freedesktop.DBus.Introspectable`. Only parse interfaces in the authd broker namespace so these interfaces do not look like malformed broker APIs and emit warnings.

Closes #1906
UDENG-11482

e2e-brokers: msentraid
e2e-tests: allowed_users.robot