### PR TITLE
ci(e2e): stop running Google broker by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ label. Copy the relevant line(s) below into the visible part of the pull
 request description to override the defaults. Leave these examples commented
 to use the defaults:
 
-- both brokers (`authd-google` and `authd-msentraid`)
+- the `authd-msentraid` broker
 - the complete test suite
 - the `authd-edge` PPA
 

--- a/.github/scripts/parse-e2e-options.sh
+++ b/.github/scripts/parse-e2e-options.sh
@@ -43,7 +43,7 @@ while IFS= read -r selected; do
 done < <(marker_values e2e-brokers)
 
 if ((${#brokers[@]} == 0)); then
-    brokers=(authd-msentraid authd-google)
+    brokers=(authd-msentraid)
 fi
 
 tests=()

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -29,7 +29,7 @@ on:
         description: 'JSON array of brokers to test'
         type: string
         required: false
-        default: '["authd-msentraid","authd-google"]'
+        default: '["authd-msentraid"]'
       e2e-tests:
         description: 'JSON array of test suite filenames; an empty array runs the full suite'
         type: string

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -63,7 +63,7 @@ on:
         default: ''
         type: string
       e2e-brokers:
-        description: 'e2e-brokers: Optional comma- or space-separated broker list; empty runs both brokers'
+        description: 'e2e-brokers: Optional comma- or space-separated broker list; empty runs authd-msentraid'
         required: false
         default: ''
         type: string

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -82,9 +82,9 @@ including `--rerunfailed` and `--output-dir`.
 
 ## Running in GitHub CI
 
-By default, GitHub CI runs the end-to-end tests against both `authd-google` and
-`authd-msentraid`, using the complete test suite and the authd package and
-broker snap built from the current branch. The authd package dependencies
+By default, GitHub CI runs the end-to-end tests against `authd-msentraid`, using
+the complete test suite and the authd package and broker snap built from the
+current branch. The authd package dependencies
 (gnome-shell) are resolved from the [authd-edge PPA][authd-edge-ppa], or from
 the PPA selected with `AUTHD_PPA`. Migration suites start with the last stable
 authd and broker releases before installing the branch-built package or snap.


### PR DESCRIPTION
Google browser logins now hit a CAPTCHA on every attempt (#1870), so the authd-google end-to-end jobs fail consistently. Until that's fixed, run the e2e tests in CI only with authd-msentraid.

UDENG-11487

e2e-tests: allowed_users.robot
