### PR TITLE
e2e: allow selecting individual Robot test cases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,13 +10,18 @@ to use the defaults:
 
 - both brokers (`authd-google` and `authd-msentraid`)
 - the complete test suite
+- all test cases in the selected suites
 - the `authd-edge` PPA
 
 e2e-brokers: google
 e2e-tests: allowed_users.robot login_gdm.robot
+e2e-test-case: Test login with GDM
 e2e-ppa: authd-dev
 
 The `e2e-ppa: authd-dev` marker sets the workflow's `authd-ppa` input to
 `ubuntu-enterprise-desktop/authd-dev` instead of `authd-edge` for resolving
 authd package dependencies.
+
+The `e2e-test-case` marker selects the exact Robot test case name. Repeat the
+marker to select more than one test case.
 -->

--- a/.github/scripts/parse-e2e-options.sh
+++ b/.github/scripts/parse-e2e-options.sh
@@ -9,13 +9,17 @@ body_without_comments=$(
         perl -0pe 's/<!--.*?(?:-->|$)//gs'
 )
 
-marker_values() {
+marker_lines() {
     local marker="$1"
 
     sed -nE \
-        "s/^[[:space:]]*${marker}:[[:space:]]*(.+)[[:space:]]*$/\1/p" \
+        "s/^[[:space:]]*${marker}:[[:space:]]*(.+)$/\1/p" \
         <<<"${body_without_comments}" |
-        tr -s ' \t,' '\n'
+        sed -E 's/[[:space:]]+$//'
+}
+
+marker_values() {
+    marker_lines "$1" | tr -s ' \t,' '\n'
 }
 
 brokers=()
@@ -52,6 +56,12 @@ while IFS= read -r test; do
     tests+=("${test}")
 done < <(marker_values e2e-tests)
 
+test_cases=()
+while IFS= read -r test_case; do
+    [[ -n "${test_case}" ]] || continue
+    test_cases+=("${test_case}")
+done < <(marker_lines e2e-test-case)
+
 authd_ppa=
 while IFS= read -r ppa; do
     case "${ppa}" in
@@ -78,5 +88,6 @@ json_array() {
 {
     printf 'brokers=%s\n' "$(json_array "${brokers[@]}")"
     printf 'tests=%s\n' "$(json_array "${tests[@]}")"
+    printf 'test_cases=%s\n' "$(json_array "${test_cases[@]}")"
     printf 'authd_ppa=%s\n' "${authd_ppa}"
 } >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -35,6 +35,11 @@ on:
         type: string
         required: false
         default: '[]'
+      e2e-test-cases:
+        description: 'JSON array of exact Robot test case names; an empty array runs all cases in the selected suites'
+        type: string
+        required: false
+        default: '[]'
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -180,4 +185,5 @@ jobs:
       broker-snap-channel: ${{ inputs.broker-snap-channel }}
       authd-ppa: ${{ inputs.authd-ppa }}
       e2e-tests: ${{ inputs.e2e-tests }}
+      e2e-test-cases: ${{ inputs.e2e-test-cases }}
     secrets: inherit

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: '[]'
+      e2e-test-cases:
+        description: 'JSON array of exact Robot test case names; an empty array runs all cases in the selected suites'
+        required: false
+        type: string
+        default: '[]'
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -236,6 +241,7 @@ jobs:
           RELEASE: ${{ inputs.ubuntu-version }}
           BROKER: ${{ inputs.broker }}
           E2E_TESTS: ${{ inputs.e2e-tests }}
+          E2E_TEST_CASES: ${{ inputs.e2e-test-cases }}
           AUTHD_DEB: ${{ steps.download-authd-deb.outputs.deb }}
           AUTHD_PPA: ${{ inputs.authd-ppa }}
           BROKER_SNAP: ${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}
@@ -265,8 +271,20 @@ jobs:
           fi
           mapfile -t e2e_tests < <(jq -r '.[]' <<< "${E2E_TESTS}")
 
+          if ! jq -e 'type == "array" and all(.[]; type == "string")' \
+              <<< "${E2E_TEST_CASES}" >/dev/null; then
+            echo "Invalid e2e-test-cases JSON input" >&2
+            exit 1
+          fi
+          mapfile -t e2e_test_cases < <(jq -r '.[]' <<< "${E2E_TEST_CASES}")
+          test_case_args=()
+          for test_case in "${e2e_test_cases[@]}"; do
+            test_case_args+=(--test "${test_case}")
+          done
+
           ${{ env.E2E_TESTS_DIR }}/run-tests.sh \
             --output-dir "${{ env.OUTPUT_DIR }}" \
+            "${test_case_args[@]}" \
             -- "${e2e_tests[@]}" \
             || exit_code=$?
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -72,6 +72,11 @@ on:
         required: false
         default: ''
         type: string
+      e2e-test-case:
+        description: 'e2e-test-case: Optional exact Robot test case name'
+        required: false
+        default: ''
+        type: string
       e2e-ppa:
         description: 'e2e-ppa: Optional PPA name, such as authd-dev; empty uses authd-edge'
         required: false
@@ -108,6 +113,7 @@ jobs:
       files-hash: ${{ steps.hash.outputs.hash }}
       brokers: ${{ steps.parse_e2e_options.outputs.brokers }}
       tests: ${{ steps.parse_e2e_options.outputs.tests }}
+      test_cases: ${{ steps.parse_e2e_options.outputs.test_cases }}
       authd_ppa: ${{ steps.parse_e2e_options.outputs.authd_ppa }}
     steps:
       - uses: actions/checkout@v7
@@ -124,6 +130,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           E2E_BROKERS: ${{ inputs.e2e-brokers || '' }}
           E2E_TESTS: ${{ inputs.e2e-tests || '' }}
+          E2E_TEST_CASE: ${{ inputs.e2e-test-case || '' }}
           E2E_PPA: ${{ inputs.e2e-ppa || '' }}
         run: |
           set -euo pipefail
@@ -135,8 +142,8 @@ jobs:
             )
           else
             E2E_TESTS_DESCRIPTION=$(
-              printf 'e2e-brokers: %s\ne2e-tests: %s\ne2e-ppa: %s\n' \
-                "${E2E_BROKERS}" "${E2E_TESTS}" "${E2E_PPA}"
+              printf 'e2e-brokers: %s\ne2e-tests: %s\ne2e-test-case: %s\ne2e-ppa: %s\n' \
+                "${E2E_BROKERS}" "${E2E_TESTS}" "${E2E_TEST_CASE}" "${E2E_PPA}"
             )
           fi
 
@@ -162,5 +169,6 @@ jobs:
       # PRs opt in by adding "e2e-ppa: authd-dev" to their description.
       authd-ppa: ${{ needs.prepare-e2e.outputs.authd_ppa }}
       brokers: ${{ needs.prepare-e2e.outputs.brokers }}
+      e2e-test-cases: ${{ needs.prepare-e2e.outputs.test_cases }}
       e2e-tests: ${{ needs.prepare-e2e.outputs.tests }}
     secrets: inherit

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -104,9 +104,9 @@ as well when the authd package dependencies should come from a different PPA.
 
 The E2E workflow runs for a pull request only when it has the `e2e-tests` label.
 The pull request template contains commented examples for selecting brokers,
-test suites, and the authd PPA. Copy the relevant line into the visible part of
-the pull request description to enable it; leave it commented to use the
-default.
+test suites, test cases, and the authd PPA. Copy the relevant line into the
+visible part of the pull request description to enable it; leave it commented
+to use the default.
 
 To resolve authd package dependencies from the [authd-dev PPA][authd-dev-ppa]
 instead, add `e2e-ppa: authd-dev` to the pull request description.
@@ -119,6 +119,14 @@ filenames:
 e2e-tests: login_gdm.robot login.robot
 ```
 
+To run only selected test cases from the selected suites, add one or more
+`e2e-test-case:` lines with the exact Robot test case names:
+
+```text
+e2e-tests: force_access_check_with_provider.robot
+e2e-test-case: Test second login succeeds with force_access_check_with_provider enabled
+```
+
 To run the tests against only selected brokers, add an `e2e-brokers:` line to
 the pull request description, followed by a space- or comma-separated list of
 `google`/`authd-google` and/or `msentraid`/`authd-msentraid`:
@@ -128,11 +136,11 @@ e2e-brokers: google
 ```
 
 Editing the pull request description does not automatically re-run the
-workflow. If you change an `e2e-tests:`, `e2e-brokers:`, or `e2e-ppa:` line
-after the workflow has already run, re-run the workflow. It fetches the current
-pull request description from GitHub. If you start the workflow with
-`workflow_dispatch`, use its separate `e2e-brokers`, `e2e-tests`, and `e2e-ppa`
-inputs instead.
+workflow. If you change an `e2e-tests:`, `e2e-test-case:`, `e2e-brokers:`, or
+`e2e-ppa:` line after the workflow has already run, re-run the workflow. It
+fetches the current pull request description from GitHub. If you start the
+workflow with `workflow_dispatch`, use its separate `e2e-brokers`, `e2e-tests`,
+`e2e-test-case`, and `e2e-ppa` inputs instead.
 
 [yarf]: https://github.com/canonical/yarf
 [authd-edge-ppa]: https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -111,12 +111,13 @@ to use the default.
 To resolve authd package dependencies from the [authd-dev PPA][authd-dev-ppa]
 instead, add `e2e-ppa: authd-dev` to the pull request description.
 
-To run only selected end-to-end test suites, add an `e2e-tests:` line to the
-pull request description, followed by a space- or comma-separated list of suite
-filenames:
+To run only selected end-to-end test suites, add one or more `e2e-tests:` lines
+to the pull request description. Each line can contain a space- or
+comma-separated list of suite filenames:
 
 ```text
-e2e-tests: login_gdm.robot login.robot
+e2e-tests: login_gdm.robot
+e2e-tests: login.robot
 ```
 
 To run only selected test cases from the selected suites, add one or more

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -77,8 +77,18 @@ environment.
 
 `run-tests.sh` automatically loads the broker's `.env` file (e.g.
 `e2e-tests-google.env` for `authd-google`). Omit the test file argument to run
-the full suite. Run `./e2e-tests/run-tests.sh --help` for all available options,
-including `--rerunfailed` and `--output-dir`.
+the full suite. To run one test case from a suite, pass its exact name with
+`--test`:
+
+```bash
+./e2e-tests/run-tests.sh \
+    --broker authd-google --release noble \
+    --test "Test second login succeeds with force_access_check_with_provider enabled" \
+    e2e-tests/tests/force_access_check_with_provider.robot
+```
+
+Run `./e2e-tests/run-tests.sh --help` for all available options, including
+`--rerunfailed` and `--output-dir`.
 
 ## Running in GitHub CI
 

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -36,6 +36,7 @@ Options:
   -b, --broker <broker>        Broker to test (can also be set via BROKER environment variable)
   -r, --release <release>      Ubuntu release to test (e.g., 'resolute', can also be set via RELEASE environment variable)
   -o, --output-dir DIR         Directory to store test outputs (default: temporary directory)
+  -t, --test <name>            Run only the named test case (can be repeated)
   -h, --help                   Show this help message and exit
       --rerunfailed            Re-run only the tests that failed in the previous run
 EOF
@@ -78,6 +79,7 @@ unset _scan_broker _scan_args _env_file _git_common_dir
 
 # Parse command line arguments
 TESTS_TO_RUN=()
+TEST_CASES_TO_RUN=()
 while [[ $# -gt 0 ]]; do
     key="$1"
 
@@ -108,6 +110,15 @@ while [[ $# -gt 0 ]]; do
             ;;
         --output-dir|-o)
             OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --test|-t)
+            if [[ $# -lt 2 ]]; then
+                echo >&2 "Error: $1 requires an argument"
+                usage
+                exit 1
+            fi
+            TEST_CASES_TO_RUN+=("$2")
             shift 2
             ;;
         -h|--help)
@@ -159,6 +170,9 @@ if dpkg --compare-versions "$systemd_ver" "ge" "256" && [ -z "${FORCE_JOURNAL_TC
 fi
 
 ROBOT_ARGS=()
+for test_case in "${TEST_CASES_TO_RUN[@]}"; do
+    ROBOT_ARGS+=(--test "$test_case")
+done
 if [ -n "${RERUNFAILED:-}" ]; then
     echo "Rerunning failed tests from previous run in ${PREVIOUS_TEST_RUN_DIR}"
     ROBOT_ARGS+=(--rerunfailed "${PREVIOUS_TEST_RUN_DIR}/output.xml")


### PR DESCRIPTION
Running a suite file should not require executing every test in it. Add a repeatable test-name option so we can select which test cases should be executed by an e2e run.

Closes #1909
UDENG-11489

e2e-brokers: msentraid
e2e-tests: force_access_check_with_provider.robot
e2e-test-case: Test second login succeeds with force_access_check_with_provider enabled
