### PR TITLE
e2e: enforce GDM password quality

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -352,6 +352,35 @@ Continue Log In With Remote User Through GDM: Define Local Password
     Wait Until Desktop Ready
 
 
+Continue Log In With Remote User Through GDM: Define Local Password With Quality Checks
+    [Arguments]    ${short_password}    ${dictionary_password}    ${local_password}
+    Match Text    Create a local password    120
+
+    Hid.Type String    ${short_password}
+    Hid.Keys Combo    Return
+    Match Text    Please, type the new passphrase again    30
+    Hid.Type String    ${short_password}
+    Hid.Keys Combo    Return
+    Match Text    The password is shorter than 8 characters    30
+
+    Match Text    Create a local password    30
+    Hid.Type String    ${dictionary_password}
+    Hid.Keys Combo    Return
+    Match Text    Please, type the new passphrase again    30
+    Hid.Type String    ${dictionary_password}
+    Hid.Keys Combo    Return
+    Match Text    The password fails the dictionary check    30
+
+    Match Text    Create a local password    30
+    Hid.Type String    ${local_password}
+    Hid.Keys Combo    Return
+    Match Text    Please, type the new passphrase again    120
+    Hid.Type String    ${local_password}
+    Hid.Keys Combo    Return
+
+    Wait Until Desktop Ready
+
+
 Log In With Remote User Through GDM: Entra Password
     [Arguments]    ${username}
     Start Log In With Remote User Through GDM    ${username}

--- a/e2e-tests/tests/login_gdm.robot
+++ b/e2e-tests/tests/login_gdm.robot
@@ -14,6 +14,8 @@ Test Teardown   utils.Test Teardown
 ${snapshot}    %{BROKER}-installed
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
+${short_password}    1234
+${dictionary_password}    password
 
 
 *** Test Cases ***
@@ -21,7 +23,11 @@ Test login with GDM
     [Documentation]    Test login via GDM with device code flow and local password.
 
     # Log in with remote user with device code flow via GDM
-    Log In With Remote User Through GDM: QR Code    ${username}    ${local_password}
+    Start Log In With Remote User Through GDM    ${username}
+    Select Broker Through GDM
+    Continue Log In With Remote User: Authenticate In External Browser
+    Continue Log In With Remote User Through GDM: Define Local Password With Quality Checks
+    ...    ${short_password}    ${dictionary_password}    ${local_password}
     Check that GNOME keyring is unlocked
 
     # Check remote user is properly added to the system


### PR DESCRIPTION
Reject short and dictionary passwords before accepting a local password on the first GDM login.

UDENG-11495

e2e-tests: login_gdm.robot
