### PR TITLE
e2e: check GDM user shell

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -410,6 +410,12 @@ Check Home Directory
     Should Be Equal    ${ownership}    ${username}:${username}
 
 
+Check User Shell
+    [Arguments]    ${username}
+    ${shell} =    SSH.Execute    getent passwd ${username} | cut -d: -f7
+    Should Be Equal    ${shell}    /usr/bin/bash
+
+
 Check That Remote User Is Not Allowed To Log In
     Match Text    authentication failure: user not allowed in broker configuration    120
 

--- a/e2e-tests/tests/login_gdm.robot
+++ b/e2e-tests/tests/login_gdm.robot
@@ -27,6 +27,7 @@ Test login with GDM
     # Check remote user is properly added to the system
     Check If User Was Added Properly    ${username}
     Check Home Directory    ${username}
+    Check User Shell    ${username}
     Log Out
 
     # Log in with remote user with local password via GDM


### PR DESCRIPTION
Check the created user's shell after the first GDM login.

UDENG-11496

e2e-tests: login_gdm.robot
