### PR TITLE
e2e: Test unlocking lock screen with password

### DIFF
--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -74,6 +74,29 @@ Log Out
     SSH.Execute    loginctl terminate-seat seat0
 
 
+Lock Screen
+    ${session_id} =    SSH.Execute    loginctl show-seat seat0 -p ActiveSession --value
+    Should Not Be Empty    ${session_id}
+    SSH.Execute    loginctl lock-session ${session_id}
+    Wait Until Keyword Succeeds    30s    1s    Check Session Is Locked    ${session_id}
+
+
+Check Session Is Locked
+    [Arguments]    ${session_id}
+    ${locked} =    SSH.Execute    loginctl show-session ${session_id} -p LockedHint --value
+    Should Be Equal    ${locked}    yes
+
+
+Unlock Screen With Password
+    [Arguments]    ${password}
+    # Locking the session can leave the display asleep until it receives input.
+    Hid.Keys Combo    Return
+    Match Text    Password    30
+    Hid.Type String    ${password}
+    Hid.Keys Combo    Return
+    Wait Until Desktop Ready
+
+
 Wait Until GDM Login Screen Ready
     Match Text    Not listed    180
     # Sometimes the "Not listed" is shown for a brief moment before the other

--- a/e2e-tests/tests/lockscreen.robot
+++ b/e2e-tests/tests/lockscreen.robot
@@ -1,0 +1,24 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+
+
+*** Test Cases ***
+Test remote user can unlock the lock screen with a local password
+    [Documentation]    Verify that a remote user can unlock a locked desktop
+    ...    session with the local password created during device authentication.
+
+    Log In With Remote User Through GDM: QR Code    ${username}    ${local_password}
+    Lock Screen
+    Unlock Screen With Password    ${local_password}
+    Log Out
+


### PR DESCRIPTION
Add a test that checks that a locked GDM session can be unlocked with the local password.

UDENG-11497

e2e-tests: lockscreen.robot
