### PR TITLE
pam/gdm: work around PAM_MAXTRIES until GNOME Shell is fixed

### DIFF
--- a/pam/integration-tests/gdm-module-handler_test.go
+++ b/pam/integration-tests/gdm-module-handler_test.go
@@ -325,7 +325,7 @@ func (gh *gdmTestModuleHandler) RespondPAM(style pam.Style, prompt string) (stri
 		gh.pamInfoMessages = append(gh.pamInfoMessages, prompt)
 	case pam.ErrorMsg:
 		gh.t.Logf("GDM PAM Error Message: %s", prompt)
-		gh.pamErrorMessages = append(gh.pamInfoMessages, prompt)
+		gh.pamErrorMessages = append(gh.pamErrorMessages, prompt)
 	default:
 		return "", fmt.Errorf("PAM style %d not implemented", style)
 	}

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -867,9 +867,6 @@ func TestGdmModule(t *testing.T) {
 					Msg:    "invalid password 'not yet goodpass', should be 'goodpass'",
 				},
 			},
-			wantPamErrorMessages: []string{
-				"Maximum number of authentication attempts reached",
-			},
 			wantError: pam.ErrMaxtries,
 		},
 		"Error_on_authenticating_unknown_user": {
@@ -882,16 +879,7 @@ func TestGdmModule(t *testing.T) {
 				},
 			},
 			wantAuthModeIDs: []string{passwordAuthID},
-			wantPamErrorMessages: []string{
-				"user not found",
-			},
-			wantAuthResponses: []*authd.IAResponse{
-				{
-					Access: auth.Denied,
-					Msg:    "user not found",
-				},
-			},
-			wantError: pam.ErrAuth,
+			wantError:       pam.ErrAuth,
 		},
 		"Error_on_invalid_fido_ack": {
 			pamUserPrefix:   examplebroker.UserIntegrationMfaPrefix,
@@ -904,19 +892,12 @@ func TestGdmModule(t *testing.T) {
 					gdm_test.IsAuthenticatedEvent(&authd.IARequest_AuthenticationData_Wait{}),
 				},
 			},
-			wantPamErrorMessages: []string{
-				fido1AuthID + " should have wait set to true",
-			},
 			wantUILayouts: []*authd.UILayout{
 				&testPasswordUILayout,
 				&testFidoDeviceUILayout,
 			},
 			wantAuthResponses: []*authd.IAResponse{
 				{Access: auth.Next},
-				{
-					Access: auth.Denied,
-					Msg:    fido1AuthID + " should have wait set to true",
-				},
 			},
 			wantError: pam.ErrAuth,
 		},

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -866,10 +866,6 @@ func TestGdmModule(t *testing.T) {
 					Access: auth.Retry,
 					Msg:    "invalid password 'not yet goodpass', should be 'goodpass'",
 				},
-				{
-					Access: auth.DeniedMaxTries,
-					Msg:    "Maximum number of authentication attempts reached",
-				},
 			},
 			wantPamErrorMessages: []string{
 				"Maximum number of authentication attempts reached",

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -866,8 +866,12 @@ func TestGdmModule(t *testing.T) {
 					Access: auth.Retry,
 					Msg:    "invalid password 'not yet goodpass', should be 'goodpass'",
 				},
+				{
+					Access: auth.Denied,
+					Msg:    "Maximum number of authentication attempts reached",
+				},
 			},
-			wantError: pam.ErrMaxtries,
+			wantError: pam.ErrAuth,
 		},
 		"Error_on_authenticating_unknown_user": {
 			pamUser: ptrValue("user-unknown"),

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -374,6 +374,11 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		return m, m.cancelIsAuthenticated()
 
 	case isAuthenticatedResultReceived:
+		if m.clientType == Gdm && msg.access == auth.DeniedMaxTries {
+			// GDM treats PAM_MAXTRIES as service unavailable until GNOME Shell
+			// handles the result correctly. Use its normal auth failure path.
+			msg.access = auth.Denied
+		}
 		safeMessageDebug(msg)
 
 		// Resets password if the authentication wasn't successful.

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -49,8 +48,6 @@ type gdmPollResponse struct {
 }
 
 type gdmPollDone struct{}
-
-type gdmIsAuthenticatedResultReceived isAuthenticatedResultReceived
 
 type gdmStopConversations struct{}
 
@@ -301,44 +298,42 @@ func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
 		m.waitingAuth = false
 
 	case isAuthenticatedResultReceived:
-		return m, sendEvent(gdmIsAuthenticatedResultReceived(msg))
-
-	case gdmIsAuthenticatedResultReceived:
 		access := msg.access
 		authMsg, err := grantedTolerantMsg(access, msg.msg)
 		if err != nil {
 			return m, sendEvent(pamError{status: pam.ErrSystem, msg: err.Error()})
 		}
 
+		event := &gdm.EventData_AuthEvent{
+			AuthEvent: &gdm.Events_AuthEvent{Response: &authd.IAResponse{
+				Access: access,
+				Msg:    authMsg,
+			}},
+		}
+
 		switch access {
 		case auth.Granted:
 		case auth.Denied:
 		case auth.DeniedMaxTries:
+			// PAM handles the terminal result; do not send the same message to GDM again.
+			return m, nil
 		case auth.Cancelled:
 		case auth.Retry:
 		case auth.Next:
 		default:
 			errMsg := fmt.Sprintf("Access %q is not valid", access)
-			accessJSON, _ := json.Marshal(errMsg)
-			return m, tea.Sequence(
-				sendEvent(gdmIsAuthenticatedResultReceived{
-					access: auth.Denied,
-					msg:    fmt.Sprintf(`{"message": %s}`, accessJSON),
-				}),
-				sendEvent(pamError{status: pam.ErrAuth, msg: errMsg}),
-			)
+			event.AuthEvent.Response.Access = auth.Denied
+			event.AuthEvent.Response.Msg = errMsg
+			return m, sendEvent(m.emitEventSync(event))
 		}
 
-		if access == auth.DeniedMaxTries {
-			// PAM handles the terminal result; do not send the same message to GDM again.
+		if access == auth.Denied {
+			// Let GDM's normal PAM failure path count this attempt and retry
+			// the selected user. An authd denied event tells the authd Shell
+			// service that retries are exhausted and sends the user to the list.
 			return m, nil
 		}
-		return m, m.emitEvent(&gdm.EventData_AuthEvent{
-			AuthEvent: &gdm.Events_AuthEvent{Response: &authd.IAResponse{
-				Access: access,
-				Msg:    authMsg,
-			}},
-		})
+		return m, m.emitEvent(event)
 
 	case gdmStopConversations:
 		m.stopConversations()

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -329,6 +329,10 @@ func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
 			)
 		}
 
+		if access == auth.DeniedMaxTries {
+			// PAM handles the terminal result; do not send the same message to GDM again.
+			return m, nil
+		}
 		return m, m.emitEvent(&gdm.EventData_AuthEvent{
 			AuthEvent: &gdm.Events_AuthEvent{Response: &authd.IAResponse{
 				Access: access,

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -315,8 +315,13 @@ func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
 		case auth.Granted:
 		case auth.Denied:
 		case auth.DeniedMaxTries:
-			// PAM handles the terminal result; do not send the same message to GDM again.
-			return m, nil
+			// GNOME Shell does not handle denied-max-tries. Send the supported
+			// denied result so it completes the authentication.
+			event.AuthEvent.Response.Access = auth.Denied
+			if event.AuthEvent.Response.Msg == "" {
+				event.AuthEvent.Response.Msg = "Maximum number of tries exceeded"
+			}
+			return m, sendEvent(m.emitEventSync(event))
 		case auth.Cancelled:
 		case auth.Retry:
 		case auth.Next:
@@ -328,9 +333,7 @@ func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
 		}
 
 		if access == auth.Denied {
-			// Let GDM's normal PAM failure path count this attempt and retry
-			// the selected user. An authd denied event tells the authd Shell
-			// service that retries are exhausted and sends the user to the list.
+			// Let GDM's normal PAM failure path handle authentication failures.
 			return m, nil
 		}
 		return m, m.emitEvent(event)

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2274,10 +2274,14 @@ func TestGdmModel(t *testing.T) {
 				gdm.RequestType_changeStage, // -> authMode Selection
 				gdm.RequestType_changeStage, // -> password
 			},
-			wantNoGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
-			wantStage:       gdmTestIgnoreStage,
+			wantGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
+			wantGdmAuthRes: []*authd.IAResponse{{
+				Access: auth.Denied,
+				Msg:    "Maximum number of authentication attempts reached",
+			}},
+			wantStage: gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
-				status: pam.ErrMaxtries,
+				status: pam.ErrAuth,
 				msg:    "Maximum number of authentication attempts reached",
 			},
 		},
@@ -2286,7 +2290,7 @@ func TestGdmModel(t *testing.T) {
 				pam_test.WithGetBrokerReturn(firstBrokerInfo.Id, nil),
 				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
 					Access: auth.DeniedMaxTries,
-					Msg:    `{"message":"Maximum number of authentication attempts reached"}`,
+					Msg:    "",
 				}, nil),
 			),
 			pamUser: "pam-preset-user-and-daemon-selected-broker-with-wrong-pass",
@@ -2308,11 +2312,15 @@ func TestGdmModel(t *testing.T) {
 				gdm.RequestType_changeStage, // -> authMode Selection
 				gdm.RequestType_changeStage, // -> password
 			},
-			wantNoGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
-			wantStage:       gdmTestIgnoreStage,
+			wantGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
+			wantGdmAuthRes: []*authd.IAResponse{{
+				Access: auth.Denied,
+				Msg:    "Maximum number of tries exceeded",
+			}},
+			wantStage: gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
-				status: pam.ErrMaxtries,
-				msg:    "Maximum number of authentication attempts reached",
+				status: pam.ErrAuth,
+				msg:    "Access denied",
 			},
 		},
 		"Error_on_authentication_client_because_of_empty_auth_data_access": {

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -959,47 +959,7 @@ func TestGdmModel(t *testing.T) {
 			wantStage:          proto.Stage_challenge,
 			wantPAMReturnValue: PamSuccess{BrokerID: firstBrokerInfo.Id, AuthTok: "gdm-good-password"},
 		},
-		"Authenticated_after_client_side_user_and_broker_and_authMode_selection": {
-			clientOptions: append(slices.Clone(multiBrokerClientOptions),
-				pam_test.WithIsAuthenticatedWantSecret("gdm-good-password"),
-			),
-			gdmEvents: []*gdm.EventData{
-				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
-			},
-			messages: []tea.Msg{
-				gdmTestWaitForStage{
-					stage: proto.Stage_brokerSelection,
-					events: []*gdm.EventData{
-						gdm_test.SelectBrokerEvent(secondBrokerInfo.Id),
-					},
-					commands: []tea.Cmd{
-						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Secret{
-							Secret: "gdm-good-password",
-						}}),
-					},
-				},
-			},
-			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
-			wantSelectedBroker: secondBrokerInfo.Id,
-			wantGdmRequests: []gdm.RequestType{
-				gdm.RequestType_uiLayoutCapabilities,
-				gdm.RequestType_changeStage, // -> broker Selection
-				gdm.RequestType_changeStage, // -> authMode Selection
-				gdm.RequestType_changeStage, // -> password
-			},
-			wantGdmEvents: []gdm.EventType{
-				gdm.EventType_userSelected,
-				gdm.EventType_brokersReceived,
-				gdm.EventType_brokerSelected,
-				gdm.EventType_authModeSelected,
-				gdm.EventType_uiLayoutReceived,
-				gdm.EventType_startAuthentication,
-				gdm.EventType_authEvent,
-			},
-			wantStage:          proto.Stage_challenge,
-			wantGdmAuthRes:     []*authd.IAResponse{{Access: auth.Granted}},
-			wantPAMReturnValue: PamSuccess{BrokerID: secondBrokerInfo.Id, AuthTok: "gdm-good-password"},
-		},
+
 		"Authenticated_after_client_side_user_and_broker_and_authMode_selection_and_after_various_retries": {
 			clientOptions: append(slices.Clone(singleBrokerClientOptions),
 				pam_test.WithIsAuthenticatedWantSecret("gdm-good-password"),
@@ -1062,6 +1022,47 @@ func TestGdmModel(t *testing.T) {
 			},
 			wantStage:          proto.Stage_challenge,
 			wantPAMReturnValue: PamSuccess{BrokerID: firstBrokerInfo.Id, AuthTok: "gdm-good-password"},
+		},
+		"Authenticated_after_client_side_user_and_broker_and_authMode_selection": {
+			clientOptions: append(slices.Clone(multiBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantSecret("gdm-good-password"),
+			),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(secondBrokerInfo.Id),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Secret{
+							Secret: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: secondBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> password
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:          proto.Stage_challenge,
+			wantGdmAuthRes:     []*authd.IAResponse{{Access: auth.Granted}},
+			wantPAMReturnValue: PamSuccess{BrokerID: secondBrokerInfo.Id, AuthTok: "gdm-good-password"},
 		},
 		"Cancelled_auth_after_client_side_user_and_broker_and_authMode_selection": {
 			clientOptions: append(slices.Clone(singleBrokerClientOptions),
@@ -1225,8 +1226,10 @@ func TestGdmModel(t *testing.T) {
 				gdm.EventType_brokerSelected,
 				gdm.EventType_authModeSelected,
 			},
+			wantGdmEventsCount: map[gdm.EventType]int{
+				gdm.EventType_startAuthentication: 1,
+			},
 			wantNoGdmEvents: []gdm.EventType{
-				gdm.EventType_startAuthentication,
 				gdm.EventType_authEvent,
 			},
 			wantStage:          proto.Stage_authModeSelection,
@@ -1827,7 +1830,6 @@ func TestGdmModel(t *testing.T) {
 				gdm.RequestType_uiLayoutCapabilities,
 			},
 			wantNoGdmEvents: []gdm.EventType{
-				gdm.EventType_brokersReceived,
 				gdm.EventType_userSelected,
 			},
 			wantPAMReturnValue: pamError{
@@ -2195,13 +2197,9 @@ func TestGdmModel(t *testing.T) {
 				gdm.EventType_authModesReceived,
 				gdm.EventType_authModeSelected,
 				gdm.EventType_uiLayoutReceived,
-				gdm.EventType_authEvent,
 			},
-			wantStage: gdmTestIgnoreStage,
-			wantGdmAuthRes: []*authd.IAResponse{{
-				Access: auth.Denied,
-				Msg:    "you're not allowed!",
-			}},
+			wantNoGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
+			wantStage:       gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
 				status: pam.ErrAuth,
 				msg:    "you're not allowed!",
@@ -2242,38 +2240,30 @@ func TestGdmModel(t *testing.T) {
 				gdm.EventType_authModesReceived,
 				gdm.EventType_authModeSelected,
 				gdm.EventType_uiLayoutReceived,
-				gdm.EventType_authEvent,
 			},
-			wantStage:      gdmTestIgnoreStage,
-			wantGdmAuthRes: []*authd.IAResponse{{Access: auth.Denied}},
+			wantNoGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
+			wantStage:       gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
 				status: pam.ErrAuth,
 				msg:    "Access denied",
 			},
 		},
-		"Error_on_authentication_client_denied_because_of_wrong_password_after_retry": {
+		"Error_on_broker_max_tries_with_password": {
 			clientOptions: append(slices.Clone(singleBrokerClientOptions),
 				pam_test.WithGetBrokerReturn(firstBrokerInfo.Id, nil),
-				pam_test.WithIsAuthenticatedWantSecret("gdm-good-password"),
-				pam_test.WithIsAuthenticatedMaxRetries(1),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: auth.DeniedMaxTries,
+					Msg:    `{"message":"Maximum number of authentication attempts reached"}`,
+				}, nil),
 			),
 			pamUser: "pam-preset-user-and-daemon-selected-broker-with-wrong-pass",
 			messages: []tea.Msg{
 				gdmTestWaitForStage{
 					stage: proto.Stage_challenge,
 					commands: []tea.Cmd{
-						sendEvent(gdmTestSendAuthDataWhenReadyFull{
-							authData: &authd.IARequest_AuthenticationData_Secret{
-								Secret: "gdm-wrong-password",
-							},
-							commands: []tea.Cmd{
-								sendEvent(gdmTestSendAuthDataWhenReady{
-									&authd.IARequest_AuthenticationData_Secret{
-										Secret: "gdm-another-wrong-password",
-									},
-								}),
-							},
-						}),
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Secret{
+							Secret: "gdm-good-password",
+						}}),
 					},
 				},
 			},
@@ -2284,24 +2274,45 @@ func TestGdmModel(t *testing.T) {
 				gdm.RequestType_changeStage, // -> authMode Selection
 				gdm.RequestType_changeStage, // -> password
 			},
-			wantGdmEvents: []gdm.EventType{
-				gdm.EventType_userSelected,
-				gdm.EventType_brokersReceived,
-				gdm.EventType_brokerSelected,
-				gdm.EventType_authModesReceived,
-				gdm.EventType_authModeSelected,
-				gdm.EventType_uiLayoutReceived,
-				gdm.EventType_authEvent, // retry
-				gdm.EventType_authEvent, // denied
-			},
-			wantStage: gdmTestIgnoreStage,
-			wantGdmAuthRes: []*authd.IAResponse{
-				{Access: auth.Retry},
-				{Access: auth.Denied},
-			},
+			wantNoGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
+			wantStage:       gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
-				status: pam.ErrAuth,
-				msg:    "Access denied",
+				status: pam.ErrMaxtries,
+				msg:    "Maximum number of authentication attempts reached",
+			},
+		},
+		"Error_on_broker_max_tries": {
+			clientOptions: append(slices.Clone(singleBrokerNewPasswordClientOptions),
+				pam_test.WithGetBrokerReturn(firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: auth.DeniedMaxTries,
+					Msg:    `{"message":"Maximum number of authentication attempts reached"}`,
+				}, nil),
+			),
+			pamUser: "pam-preset-user-and-daemon-selected-broker-with-wrong-pass",
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Secret{
+							Secret: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			supportedLayouts:   []*authd.UILayout{pam_test.NewPasswordUILayout()},
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> password
+			},
+			wantNoGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
+			wantStage:       gdmTestIgnoreStage,
+			wantPAMReturnValue: pamError{
+				status: pam.ErrMaxtries,
+				msg:    "Maximum number of authentication attempts reached",
 			},
 		},
 		"Error_on_authentication_client_because_of_empty_auth_data_access": {
@@ -2327,20 +2338,12 @@ func TestGdmModel(t *testing.T) {
 				gdm.RequestType_changeStage, // -> authMode Selection
 				gdm.RequestType_changeStage, // -> password
 			},
-			wantGdmEvents: []gdm.EventType{
-				gdm.EventType_userSelected,
-				gdm.EventType_brokersReceived,
-				gdm.EventType_brokerSelected,
-				gdm.EventType_authModesReceived,
-				gdm.EventType_authModeSelected,
-				gdm.EventType_uiLayoutReceived,
-				gdm.EventType_authEvent, // denied
-			},
-			wantStage: gdmTestIgnoreStage,
+			wantGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
 			wantGdmAuthRes: []*authd.IAResponse{{
 				Access: auth.Denied,
 				Msg:    `Access "" is not valid`,
 			}},
+			wantStage: gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
 				status: pam.ErrSystem,
 				msg:    `Unknown authentication access: ""`,
@@ -2372,20 +2375,12 @@ func TestGdmModel(t *testing.T) {
 				gdm.RequestType_changeStage, // -> authMode Selection
 				gdm.RequestType_changeStage, // -> password
 			},
-			wantGdmEvents: []gdm.EventType{
-				gdm.EventType_userSelected,
-				gdm.EventType_brokersReceived,
-				gdm.EventType_brokerSelected,
-				gdm.EventType_authModesReceived,
-				gdm.EventType_authModeSelected,
-				gdm.EventType_uiLayoutReceived,
-				gdm.EventType_authEvent, // denied
-			},
-			wantStage: gdmTestIgnoreStage,
+			wantGdmEvents: []gdm.EventType{gdm.EventType_authEvent},
 			wantGdmAuthRes: []*authd.IAResponse{{
 				Access: auth.Denied,
 				Msg:    `Access "no way you get here!" is not valid`,
 			}},
+			wantStage: gdmTestIgnoreStage,
 			wantPAMReturnValue: pamError{
 				status: pam.ErrSystem,
 				msg:    `Unknown authentication access: "no way you get here!"`,
@@ -2516,9 +2511,6 @@ func TestGdmModel(t *testing.T) {
 				userSelected{"another-selected-user"},
 			},
 			wantNoGdmEvents: []gdm.EventType{
-				gdm.EventType_brokerSelected,
-				gdm.EventType_authModesReceived,
-				gdm.EventType_authModeSelected,
 				gdm.EventType_authEvent,
 			},
 			wantStage: proto.Stage_userSelection,
@@ -2753,6 +2745,12 @@ func TestGdmModel(t *testing.T) {
 			for _, e := range gdmHandler.receivedEvents {
 				receivedEventTypes = append(receivedEventTypes, e.Type)
 			}
+			for _, evType := range tc.wantNoGdmEvents {
+				require.NotContains(t, receivedEventTypes, evType,
+					"GDM received unexpected event %q in %v",
+					evType, stringifySlice(receivedEventTypes))
+			}
+
 			require.True(t, isSupersetOf(receivedEventTypes, tc.wantGdmEvents),
 				"Required events have not been received: %v vs %v",
 				stringifySlice(tc.wantGdmEvents), stringifySlice(receivedEventTypes))

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -106,7 +106,7 @@ func showPamMessage(mTx pam.ModuleTransaction, style pam.Style, msg string) erro
 	return nil
 }
 
-func sendReturnMessageToPam(mTx pam.ModuleTransaction, retStatus adapter.PamReturnValue) {
+func sendReturnMessageToPam(mTx pam.ModuleTransaction, clientType adapter.PamClientType, retStatus adapter.PamReturnValue) {
 	msg := retStatus.Message()
 	if msg == "" {
 		return
@@ -122,21 +122,32 @@ func sendReturnMessageToPam(mTx pam.ModuleTransaction, retStatus adapter.PamRetu
 		}
 	}
 
+	if !shouldSendPamMessage(style, clientType, retStatus) {
+		return
+	}
+
 	if err := showPamMessage(mTx, style, msg); err != nil {
 		log.Warningf(context.TODO(), "Impossible to send PAM message: %v", err)
 	}
 }
 
-func shouldSendAuthMessage(clientType adapter.PamClientType, msg string, isSuccess bool) bool {
-	if msg == "" {
-		return false
+func shouldSendPamMessage(style pam.Style, clientType adapter.PamClientType, retStatus adapter.PamReturnValue) bool {
+	if style == pam.TextInfo {
+		// Native clients already display successful authentication messages via
+		// the native model. Keep informational PAM errors, such as PAM_IGNORE,
+		// visible to the caller.
+		if _, ok := retStatus.(adapter.PamSuccess); ok {
+			return clientType != adapter.Native
+		}
+		return true
 	}
 
-	if isSuccess {
-		// Native clients (SSH, non-TTY) already display the success message
-		// via the native model's sendInfo path; skip the PAM-conversation echo
-		// to avoid printing it twice.
-		return clientType != adapter.Native
+	if style == pam.ErrorMsg && clientType == adapter.Gdm {
+		// GDM renders authentication failures itself. Preserve messages for
+		// service and system errors because GDM does not own those details.
+		if rs, ok := retStatus.(adapter.PamReturnError); ok {
+			return rs.Status() != pam.ErrAuth && rs.Status() != pam.ErrMaxtries
+		}
 	}
 
 	return true
@@ -357,8 +368,8 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 
 	conn, closeConn, err := newClientConnection(parsedArgs)
 	if err != nil {
-		if err := showPamMessage(mTx, pam.ErrorMsg, err.Error()); err != nil {
-			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", err)
+		if msgErr := showPamMessage(mTx, pam.ErrorMsg, err.Error()); msgErr != nil {
+			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", msgErr)
 		}
 		return fmt.Errorf("%w: %w", pam.ErrAuthinfoUnavail, err)
 	}
@@ -375,9 +386,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 
 	switch returnValue := pamReturnValue.(type) {
 	case adapter.PamSuccess:
-		if shouldSendAuthMessage(pamClientType, returnValue.Message(), true) {
-			sendReturnMessageToPam(mTx, returnValue)
-		}
+		sendReturnMessageToPam(mTx, pamClientType, returnValue)
 		if returnValue.AuthTok != "" {
 			if err := mTx.SetItem(pam.Authtok, returnValue.AuthTok); err != nil {
 				return err
@@ -393,15 +402,13 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		return nil
 
 	case adapter.PamReturnError:
-		if shouldSendAuthMessage(pamClientType, returnValue.Message(), false) {
-			sendReturnMessageToPam(mTx, returnValue)
-		}
+		sendReturnMessageToPam(mTx, pamClientType, returnValue)
 		return fmt.Errorf("%w: %s", returnValue.Status(), returnValue.Message())
 
 	default:
 		// Preserve the previous behavior of showing any message associated with
 		// unexpected exit statuses before returning the system error.
-		sendReturnMessageToPam(mTx, returnValue)
+		sendReturnMessageToPam(mTx, pamClientType, returnValue)
 		return fmt.Errorf("%w: unknown exit code: %#v", pam.ErrSystem, returnValue)
 	}
 }

--- a/pam/pam_session_test.go
+++ b/pam/pam_session_test.go
@@ -4,48 +4,80 @@ import (
 	"testing"
 
 	"github.com/canonical/authd/pam/internal/adapter"
+	"github.com/msteinert/pam/v2"
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldSendAuthMessage(t *testing.T) {
+type testPamReturnError struct {
+	status pam.Error
+}
+
+func (e testPamReturnError) Message() string   { return "message" }
+func (e testPamReturnError) Status() pam.Error { return e.status }
+
+func TestShouldSendPamMessage(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
+		style      pam.Style
 		clientType adapter.PamClientType
-		msg        string
-		isSuccess  bool
+		retStatus  adapter.PamReturnValue
 
 		want bool
 	}{
-		"Does_not_send_native_success_messages_again": {
+		"Does_not_send_native_success_info_messages_again": {
+			style:      pam.TextInfo,
 			clientType: adapter.Native,
-			msg:        "cached",
-			isSuccess:  true,
+			retStatus:  adapter.PamSuccess{},
 			want:       false,
 		},
-		"Sends_gdm_success_messages_via_pam_conversation": {
+		"Sends_gdm_success_info_messages_via_pam_conversation": {
+			style:      pam.TextInfo,
 			clientType: adapter.Gdm,
-			msg:        "cached",
-			isSuccess:  true,
+			retStatus:  adapter.PamSuccess{},
 			want:       true,
 		},
-		"Sends_interactive_terminal_success_messages": {
+		"Sends_interactive_terminal_success_info_messages": {
+			style:      pam.TextInfo,
 			clientType: adapter.InteractiveTerminal,
-			msg:        "cached",
-			isSuccess:  true,
+			retStatus:  adapter.PamSuccess{},
 			want:       true,
 		},
-		"Sends_error_messages": {
-			clientType: adapter.Native,
-			msg:        "denied",
-			isSuccess:  false,
-			want:       true,
-		},
-		"Ignores_empty_messages": {
-			clientType: adapter.Native,
-			msg:        "",
-			isSuccess:  true,
+		"Does_not_send_gdm_auth_error_messages": {
+			style:      pam.ErrorMsg,
+			clientType: adapter.Gdm,
+			retStatus:  testPamReturnError{status: pam.ErrAuth},
 			want:       false,
+		},
+		"Does_not_send_gdm_maxtries_error_messages": {
+			style:      pam.ErrorMsg,
+			clientType: adapter.Gdm,
+			retStatus:  testPamReturnError{status: pam.ErrMaxtries},
+			want:       false,
+		},
+		"Sends_gdm_system_error_messages": {
+			style:      pam.ErrorMsg,
+			clientType: adapter.Gdm,
+			retStatus:  testPamReturnError{status: pam.ErrSystem},
+			want:       true,
+		},
+		"Sends_native_ignore_info_messages": {
+			style:      pam.TextInfo,
+			clientType: adapter.Native,
+			retStatus:  testPamReturnError{status: pam.ErrIgnore},
+			want:       true,
+		},
+		"Sends_native_error_messages": {
+			style:      pam.ErrorMsg,
+			clientType: adapter.Native,
+			retStatus:  testPamReturnError{status: pam.ErrAuth},
+			want:       true,
+		},
+		"Sends_interactive_terminal_error_messages": {
+			style:      pam.ErrorMsg,
+			clientType: adapter.InteractiveTerminal,
+			retStatus:  testPamReturnError{status: pam.ErrAuth},
+			want:       true,
 		},
 	}
 
@@ -53,7 +85,8 @@ func TestShouldSendAuthMessage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, tc.want, shouldSendAuthMessage(tc.clientType, tc.msg, tc.isSuccess))
+			require.Equal(t, tc.want,
+				shouldSendPamMessage(tc.style, tc.clientType, tc.retStatus))
 		})
 	}
 }


### PR DESCRIPTION
GDM treats `PAM_MAXTRIES` as service unavailable and leaves the password
prompt spinning **forever** after authd reaches its retry limit.

Until GNOME Shell handles this result correctly, return `PAM_AUTH_ERR` and
send the existing denied result for GDM only. `PAM_MAXTRIES` remains
unchanged for other clients, preserving the fixes for #1425 and #1342.

The earlier commits also remove the duplicate GDM/PAM failure message.

Launchpad bug report: [#2166922](https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/2166922)

Closes #1893
UDENG-11472