### PR TITLE
e2e: support configuring archive package source in test VMs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,11 +12,13 @@ to use the defaults:
 - the complete test suite
 - all test cases in the selected suites
 - the `authd-edge` PPA
+- an optional Ubuntu archive suite for the matching release
 
 e2e-brokers: google
 e2e-tests: allowed_users.robot login_gdm.robot
 e2e-test-case: Test login with GDM
 e2e-ppa: authd-dev
+e2e-apt-source: resolute-proposed
 
 The `e2e-ppa: authd-dev` marker sets the workflow's `authd-ppa` input to
 `ubuntu-enterprise-desktop/authd-dev` instead of `authd-edge` for resolving
@@ -24,4 +26,9 @@ authd package dependencies.
 
 The `e2e-test-case` marker selects the exact Robot test case name. Repeat the
 marker to select more than one test case.
+
+The `e2e-apt-source` marker installs and updates packages from the named Ubuntu
+archive suite in the matching release matrix job, instead of installing the
+branch-built authd package. The broker is still built from the branch and
+installed in the matching job.
 -->

--- a/.github/scripts/parse-e2e-options.sh
+++ b/.github/scripts/parse-e2e-options.sh
@@ -77,6 +77,23 @@ while IFS= read -r ppa; do
     esac
 done < <(marker_values e2e-ppa)
 
+apt_source=
+while IFS= read -r selected_apt_source; do
+    [[ -n "${selected_apt_source}" ]] || continue
+
+    if [[ ! "${selected_apt_source}" =~ ^[a-z0-9][a-z0-9+.-]*$ ]]; then
+        echo "::warning::Ignoring invalid APT source '${selected_apt_source}' in e2e-apt-source marker"
+        continue
+    fi
+
+    if [[ -n "${apt_source}" ]]; then
+        echo "::warning::Ignoring additional APT source '${selected_apt_source}' in e2e-apt-source marker"
+        continue
+    fi
+
+    apt_source="${selected_apt_source}"
+done < <(marker_values e2e-apt-source)
+
 json_array() {
     if (($# == 0)); then
         printf '[]'
@@ -90,4 +107,5 @@ json_array() {
     printf 'tests=%s\n' "$(json_array "${tests[@]}")"
     printf 'test_cases=%s\n' "$(json_array "${test_cases[@]}")"
     printf 'authd_ppa=%s\n' "${authd_ppa}"
+    printf 'apt_source=%s\n' "${apt_source}"
 } >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -25,6 +25,11 @@ on:
         type: string
         required: false
         default: ''
+      apt-source:
+        description: 'If set, install and update packages from this Ubuntu archive suite'
+        type: string
+        required: false
+        default: ''
       brokers:
         description: 'JSON array of brokers to test'
         type: string
@@ -184,6 +189,14 @@ jobs:
       broker: ${{ matrix.broker }}
       broker-snap-channel: ${{ inputs.broker-snap-channel }}
       authd-ppa: ${{ inputs.authd-ppa }}
+      apt-source: >-
+        ${{
+          startsWith(
+            inputs.apt-source,
+            format('{0}-', inputs.ubuntu-version)
+          ) &&
+          inputs.apt-source || ''
+        }}
       e2e-tests: ${{ inputs.e2e-tests }}
       e2e-test-cases: ${{ inputs.e2e-test-cases }}
     secrets: inherit

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -169,6 +169,7 @@ jobs:
           )
 
   build-deb:
+    if: ${{ inputs.apt-source == '' }}
     uses: ./.github/workflows/debian-build.yaml
     with:
       files-hash: ${{ inputs.files-hash }}
@@ -179,6 +180,14 @@ jobs:
     needs:
       - provision-vm
       - build-deb
+    # An archive-source E2E run does not need the branch-built authd package.
+    # Keep the test job running when build-deb is skipped for that case.
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.provision-vm.result == 'success' &&
+        (needs.build-deb.result == 'success' || needs.build-deb.result == 'skipped')
+      }}
     strategy:
       matrix:
         broker: ${{ fromJSON(inputs.brokers) }}

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: ''
+      apt-source:
+        description: 'If set, install and update packages from this Ubuntu archive suite'
+        required: false
+        type: string
+        default: ''
       e2e-tests:
         description: 'JSON array of test suite filenames; an empty array runs the full suite'
         required: false
@@ -136,6 +141,7 @@ jobs:
 
       - name: Download the authd deb
         id: download-authd-deb
+        if: inputs.apt-source == ''
         env:
           OCI_REPO: ghcr.io/${{ github.repository }}/authd-deb-${{ inputs.ubuntu-version }}
           OCI_TAG: ${{ github.sha }}
@@ -219,8 +225,9 @@ jobs:
           # Provision the VM (reads RELEASE, BROKER, VM_NAME_BASE, ARTIFACTS_DIR, and
           # broker credentials from the environment)
           ${{ env.E2E_TESTS_DIR }}/vm/provision-authd.sh \
-            --authd-deb "${{ steps.download-authd-deb.outputs.deb }}" \
+            ${{ inputs.apt-source == '' && format('--authd-deb "{0}"', steps.download-authd-deb.outputs.deb) || '' }} \
             ${{ inputs.authd-ppa && format('--authd-ppa {0}', inputs.authd-ppa) || '' }} \
+            ${{ inputs.apt-source && format('--apt-source {0}', inputs.apt-source) || '' }} \
             --broker-snap "${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}"
 
       - name: Checkout YARF repo
@@ -244,6 +251,7 @@ jobs:
           E2E_TEST_CASES: ${{ inputs.e2e-test-cases }}
           AUTHD_DEB: ${{ steps.download-authd-deb.outputs.deb }}
           AUTHD_PPA: ${{ inputs.authd-ppa }}
+          APT_SOURCE: ${{ inputs.apt-source }}
           BROKER_SNAP: ${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}
         run: |
           set -eux

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -82,6 +82,11 @@ on:
         required: false
         default: ''
         type: string
+      e2e-apt-source:
+        description: 'e2e-apt-source: Optional Ubuntu archive suite, such as resolute-proposed'
+        required: false
+        default: ''
+        type: string
   schedule:
     - cron: '0 0 * * 1' # Runs every Monday at midnight
 
@@ -115,6 +120,7 @@ jobs:
       tests: ${{ steps.parse_e2e_options.outputs.tests }}
       test_cases: ${{ steps.parse_e2e_options.outputs.test_cases }}
       authd_ppa: ${{ steps.parse_e2e_options.outputs.authd_ppa }}
+      apt_source: ${{ steps.parse_e2e_options.outputs.apt_source }}
     steps:
       - uses: actions/checkout@v7
       - name: Compute hash of build-relevant files
@@ -132,6 +138,7 @@ jobs:
           E2E_TESTS: ${{ inputs.e2e-tests || '' }}
           E2E_TEST_CASE: ${{ inputs.e2e-test-case || '' }}
           E2E_PPA: ${{ inputs.e2e-ppa || '' }}
+          E2E_APT_SOURCE: ${{ inputs.e2e-apt-source || '' }}
         run: |
           set -euo pipefail
 
@@ -142,8 +149,9 @@ jobs:
             )
           else
             E2E_TESTS_DESCRIPTION=$(
-              printf 'e2e-brokers: %s\ne2e-tests: %s\ne2e-test-case: %s\ne2e-ppa: %s\n' \
-                "${E2E_BROKERS}" "${E2E_TESTS}" "${E2E_TEST_CASE}" "${E2E_PPA}"
+              printf 'e2e-brokers: %s\ne2e-tests: %s\ne2e-test-case: %s\ne2e-ppa: %s\ne2e-apt-source: %s\n' \
+                "${E2E_BROKERS}" "${E2E_TESTS}" "${E2E_TEST_CASE}" "${E2E_PPA}" \
+                "${E2E_APT_SOURCE}"
             )
           fi
 
@@ -166,8 +174,10 @@ jobs:
       files-hash: ${{ needs.prepare-e2e.outputs.files-hash }}
       force-fresh-image: ${{ github.event_name == 'schedule' }}
       broker-snap-channel: ${{ inputs.broker-snap-channel || '' }}
-      # PRs opt in by adding "e2e-ppa: authd-dev" to their description.
+      # PRs opt in by adding e2e-ppa or e2e-apt-source to their description.
       authd-ppa: ${{ needs.prepare-e2e.outputs.authd_ppa }}
+      # Apply an archive source only to the matrix job for its matching Ubuntu release.
+      apt-source: ${{ needs.prepare-e2e.outputs.apt_source }}
       brokers: ${{ needs.prepare-e2e.outputs.brokers }}
       e2e-test-cases: ${{ needs.prepare-e2e.outputs.test_cases }}
       e2e-tests: ${{ needs.prepare-e2e.outputs.tests }}

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -54,11 +54,28 @@ ssh-add /path/to/key
 This sets up a libvirt VM with Ubuntu, installs authd and the broker, and
 creates the snapshots required by the tests. By default, authd is installed
 from the [authd-edge PPA][authd-edge-ppa] and the broker from the edge channel
-snap. Use `--authd-deb` to install a locally built authd package, `--authd-ppa
-<ppa>` to select a different PPA for authd and its dependencies, or
-`--broker-snap` to install a locally built broker snap. Run
+snap. Use `--authd-deb` to install a locally built authd package,
+`--authd-ppa <ppa>` to select a different PPA for authd and its dependencies,
+or `--broker-snap` to install a locally built broker snap. Run
 `./e2e-tests/vm/provision.sh --help` for all available options, including
 `--force` to reprovision.
+
+To install authd from an Ubuntu archive suite instead of a PPA, pass the suite
+explicitly. For example, this provisions the package from `resolute-updates`:
+
+```bash
+./e2e-tests/vm/provision.sh \
+  --release resolute \
+  --broker authd-google \
+  --apt-source resolute-updates \
+  --force
+```
+
+The archive-suite option is mutually exclusive with `--authd-deb`. It adds the
+suite to the VM's Ubuntu archive sources when needed, installs `authd` from
+that suite, and updates all installed packages to the target suite. It does
+not add the default authd PPA. Use `--authd-ppa` as well only when a specific
+dependency PPA is required.
 
 ### 4. Set up YARF
 
@@ -101,19 +118,32 @@ authd and broker releases before installing the branch-built package or snap.
 To use locally built packages in those suites, set `AUTHD_DEB` and
 `BROKER_SNAP` to their host paths when running `run-tests.sh`. Set `AUTHD_PPA`
 as well when the authd package dependencies should come from a different PPA.
+When a migration suite updates packages from an archive suite, set `APT_SOURCE`
+to the same suite used during provisioning.
 
 The E2E workflow runs for a pull request only when it has the `e2e-tests` label.
 The pull request template contains commented examples for selecting brokers,
-test suites, test cases, and the authd PPA. Copy the relevant line into the
-visible part of the pull request description to enable it; leave it commented
-to use the default.
+test suites, test cases, the authd PPA, and an Ubuntu archive suite. Copy the
+relevant line into the visible part of the pull request description to enable
+it; leave it commented to use the default.
 
 To resolve authd package dependencies from the [authd-dev PPA][authd-dev-ppa]
 instead, add `e2e-ppa: authd-dev` to the pull request description.
 
-To run only selected end-to-end test suites, add one or more `e2e-tests:` lines
-to the pull request description. Each line can contain a space- or
-comma-separated list of suite filenames:
+To install and update packages from an Ubuntu archive suite, add an
+`e2e-apt-source:` line with the full suite name. For example:
+
+```text
+e2e-apt-source: resolute-proposed
+```
+
+The archive source is used only by the matrix job whose Ubuntu release matches
+the suite prefix. That job installs and updates packages from the selected
+suite; the other release jobs keep using the branch-built package.
+
+To run only selected end-to-end test suites, add an `e2e-tests:` line to the
+pull request description, followed by a space- or comma-separated list of suite
+filenames. Repeat the marker to select more than one suite:
 
 ```text
 e2e-tests: login_gdm.robot
@@ -137,11 +167,12 @@ e2e-brokers: google
 ```
 
 Editing the pull request description does not automatically re-run the
-workflow. If you change an `e2e-tests:`, `e2e-test-case:`, `e2e-brokers:`, or
-`e2e-ppa:` line after the workflow has already run, re-run the workflow. It
-fetches the current pull request description from GitHub. If you start the
-workflow with `workflow_dispatch`, use its separate `e2e-brokers`, `e2e-tests`,
-`e2e-test-case`, and `e2e-ppa` inputs instead.
+workflow. If you change an `e2e-tests:`, `e2e-test-case:`, `e2e-brokers:`,
+`e2e-ppa:`, or `e2e-apt-source:` line after the workflow has already run,
+re-run the workflow. It fetches the current pull request description from
+GitHub. If you start the workflow with `workflow_dispatch`, use its separate
+`e2e-brokers`, `e2e-tests`, `e2e-test-case`, `e2e-ppa`, and `e2e-apt-source`
+inputs instead.
 
 [yarf]: https://github.com/canonical/yarf
 [authd-edge-ppa]: https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -231,7 +231,19 @@ Cancel Operation
 
 
 Update Authd
+    ${apt_source}=    Get Environment Variable    APT_SOURCE    ${EMPTY}
     ${authd_ppa}=    Get Environment Variable    AUTHD_PPA    ${EMPTY}
+    IF    $apt_source != ''
+        SSH.Execute
+        ...    if ! grep -RqsF -- '${apt_source}' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then printf '%s\n' 'deb http://archive.ubuntu.com/ubuntu/ ${apt_source} main restricted universe multiverse' > /etc/apt/sources.list.d/e2e-tests-apt-source.list; fi
+        IF    $authd_ppa != ''
+            SSH.Execute    add-apt-repository ppa:${authd_ppa} -y    timeout=300
+        END
+        SSH.Execute    apt-get update    timeout=300
+        SSH.Execute    apt-get install -y -t ${apt_source} authd    timeout=120
+        SSH.Execute    apt-get full-upgrade -y -t ${apt_source}    timeout=300
+        RETURN
+    END
     IF    $authd_ppa == ''
         ${authd_ppa}=    Set Variable    ubuntu-enterprise-desktop/authd-edge
     END

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -27,6 +27,7 @@ Prerequisites:
 Optional environment variables:
   AUTHD_DEB           Host path to the authd package for migration tests
   AUTHD_PPA           PPA to use for authd dependencies in migration tests
+  APT_SOURCE          APT source suite to use for package updates in migration tests
   BROKER_SNAP         Host path to the broker snap for migration tests
 
 Options:
@@ -151,6 +152,17 @@ if [ -z "${E2E_USER:-}" ] || [ -z "${E2E_PASSWORD:-}" ] || [ -z "${BROKER:-}" ] 
     exit 1
 fi
 
+if [ -n "${APT_SOURCE:-}" ]; then
+    if [[ ! "${APT_SOURCE}" =~ ^[a-z0-9][a-z0-9+.-]*$ ]]; then
+        echo >&2 "Invalid APT source suite '${APT_SOURCE}'."
+        exit 1
+    fi
+    if [ -n "${AUTHD_DEB:-}" ]; then
+        echo >&2 "APT_SOURCE cannot be used together with AUTHD_DEB."
+        exit 1
+    fi
+fi
+
 VM_NAME=${VM_NAME:-"e2e-runner-${RELEASE}"}
 
 if [ ${#TESTS_TO_RUN[@]} -eq 0 ]; then
@@ -234,6 +246,7 @@ env \
     VM_NAME="$VM_NAME" \
     AUTHD_DEB="${AUTHD_DEB:-}" \
     AUTHD_PPA="${AUTHD_PPA:-}" \
+    APT_SOURCE="${APT_SOURCE:-}" \
     BROKER_SNAP="${BROKER_SNAP:-}" \
     VNC_PORT="$VNC_PORT" \
     SYSTEMD_SUPPORTS_VSOCK="${SYSTEMD_SUPPORTS_VSOCK:-}" \

--- a/e2e-tests/vm/config.env.template
+++ b/e2e-tests/vm/config.env.template
@@ -12,3 +12,9 @@ VM_NAME_BASE=e2e-runner
 # Default Ubuntu release codename to provision (e.g. noble, resolute).
 # Can be overridden per-invocation with --release.
 RELEASE=resolute
+
+# Optional APT suite from which to install and update packages instead of the
+# authd PPA
+# (e.g. resolute-updates). Can be overridden per-invocation with
+# --apt-source.
+# APT_SOURCE=resolute-updates

--- a/e2e-tests/vm/provision-authd.sh
+++ b/e2e-tests/vm/provision-authd.sh
@@ -10,7 +10,7 @@ DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/authd-e2e-tests"
 
 usage(){
     cat << EOF
-Usage: $0 [--config-file <file>] [--release <release>] [--authd-deb <deb>] [--authd-ppa <ppa>] [--broker-snap <snap>]
+Usage: $0 [--config-file <file>] [--release <release>] [--authd-deb <deb>] [--authd-ppa <ppa>] [--apt-source <source>] [--broker-snap <snap>]
 
 Options:
    --config-file <file>  Path to the configuration file (default: config.env)
@@ -21,6 +21,10 @@ Options:
    --authd-deb <deb>    Path to the authd deb file to install (default: install from the edge PPA)
    --authd-ppa <ppa>    PPA to use instead of authd-edge when installing authd
                         and its dependencies
+   --apt-source <source>
+                        APT source suite to use for package installation and
+                        updates (for example, resolute-updates); adds the
+                        suite if needed and skips the default authd PPA
    --broker-snap <snap> Path to the broker snap file to install (default: install from the edge channel)
   -h, --help             Show this help message and exit
 
@@ -52,6 +56,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --authd-ppa)
             AUTHD_PPA="$2"
+            shift 2
+            ;;
+        --apt-source)
+            APT_SOURCE_ARG="$2"
             shift 2
             ;;
         --broker-snap)
@@ -138,8 +146,20 @@ if [ -n "${BROKER:-}" ]; then
     unset _env_file _git_common_dir
 fi
 
-# CLI --release overrides the config file value
+# CLI options override config file values
 RELEASE="${RELEASE_ARG:-${RELEASE:-}}"
+APT_SOURCE="${APT_SOURCE_ARG:-${APT_SOURCE:-}}"
+
+if [ -n "${APT_SOURCE:-}" ]; then
+    if [[ ! "${APT_SOURCE}" =~ ^[a-z0-9][a-z0-9+.-]*$ ]]; then
+        echo "Invalid APT source suite '${APT_SOURCE}'." >&2
+        exit 1
+    fi
+    if [ -n "${AUTHD_DEB:-}" ]; then
+        echo "--apt-source cannot be used together with --authd-deb." >&2
+        exit 1
+    fi
+fi
 
 VM_NAME_BASE="${VM_NAME_BASE:-e2e-runner}"
 
@@ -286,10 +306,29 @@ fi
 # Revert to the pre-authd setup snapshot before installing the version to test
 restore_snapshot_and_sync_time "$PRE_AUTHD_SNAPSHOT"
 
-# Add the PPA needed to resolve dependencies for the authd package under test.
-# authd-edge remains the default for local and normal CI runs.
-PPA="${AUTHD_PPA:-ubuntu-enterprise-desktop/authd-edge}"
-$SSH "add-apt-repository -y ppa:${PPA}"
+# Add the selected Ubuntu archive suite if it is not already configured.
+if [ -n "${APT_SOURCE:-}" ]; then
+    $SSH bash -euo pipefail -s <<-EOF
+        if ! grep -RqsF -- "${APT_SOURCE}" \
+            /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+            printf '%s\n' \
+                'deb http://archive.ubuntu.com/ubuntu/ ${APT_SOURCE} main restricted universe multiverse' \
+                > /etc/apt/sources.list.d/e2e-tests-apt-source.list
+        fi
+EOF
+fi
+
+# Add the optional PPA needed to resolve dependencies for the authd package.
+# When an archive suite is selected, do not add authd-edge: the package itself
+# must be selected from that suite.
+if [ -n "${APT_SOURCE:-}" ]; then
+    if [ -n "${AUTHD_PPA:-}" ]; then
+        $SSH "add-apt-repository -y ppa:${AUTHD_PPA}"
+    fi
+else
+    PPA="${AUTHD_PPA:-ubuntu-enterprise-desktop/authd-edge}"
+    $SSH "add-apt-repository -y ppa:${PPA}"
+fi
 
 # Configure authd to be verbose. We do this before installing authd to avoid
 # having to restart the service after installation (just a simple optimization).
@@ -302,8 +341,12 @@ $SSH bash -euo pipefail -s <<-EOF
 	UNIT
 EOF
 
-# Install the version of authd to test
-if [ -n "${AUTHD_DEB:-}" ]; then
+# Install authd and update all packages from the selected archive suite.
+if [ -n "${APT_SOURCE:-}" ]; then
+    $SSH apt-get update
+    $SSH "apt-get install -y -t '${APT_SOURCE}' authd"
+    $SSH "apt-get full-upgrade -y -t '${APT_SOURCE}'"
+elif [ -n "${AUTHD_DEB:-}" ]; then
     "${SCP}" "${AUTHD_DEB}" "/home/ubuntu/$(basename "${AUTHD_DEB}")"
     $SSH apt-get install -y "/home/ubuntu/$(basename "${AUTHD_DEB}")"
 else

--- a/e2e-tests/vm/provision.sh
+++ b/e2e-tests/vm/provision.sh
@@ -7,7 +7,7 @@ CONFIG_FILE="${SCRIPT_DIR}/config.env"
 
 usage(){
     cat << EOF
-Usage: $0 [--config-file <config file>] [--release <release>] [--broker <broker>] [--authd-deb <deb>] [--authd-ppa <ppa>] [--broker-snap <snap>] [--force]
+Usage: $0 [--config-file <config file>] [--release <release>] [--broker <broker>] [--authd-deb <deb>] [--authd-ppa <ppa>] [--apt-source <source>] [--broker-snap <snap>] [--force]
 
 Options:
   --config-file <config file>  Path to the configuration file (default: config.env)
@@ -15,6 +15,7 @@ Options:
   --broker <broker>            The broker to install ("authd-google", "authd-msentraid", ...)
   --authd-deb <deb>            Path to the authd deb file to install (default: install from the edge PPA)
   --authd-ppa <ppa>            PPA to use instead of authd-edge when installing authd and its dependencies
+  --apt-source <source>       APT source suite to use for package installation and updates (for example, resolute-updates); adds it if needed
   --broker-snap <snap>         Path to the broker snap file to install (default: install from the edge channel)
   --force                      Force provisioning: remove existing VM and artifacts and create a fresh VM
   -h, --help                   Show this help message and exit
@@ -48,6 +49,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --authd-ppa)
             AUTHD_PPA="$2"
+            shift 2
+            ;;
+        --apt-source)
+            APT_SOURCE="$2"
             shift 2
             ;;
         --broker-snap)
@@ -84,5 +89,6 @@ set -x
   ${BROKER:+--broker "${BROKER}"} \
   ${AUTHD_DEB:+--authd-deb "${AUTHD_DEB}"} \
   ${AUTHD_PPA:+--authd-ppa "${AUTHD_PPA}"} \
+  ${APT_SOURCE:+--apt-source "${APT_SOURCE}"} \
   ${BROKER_SNAP:+--broker-snap "${BROKER_SNAP}"} \
   ${FORCE:+--force}


### PR DESCRIPTION
SRU verification needs E2E tests to run with packages from the -proposed pocket. Add an archive-source marker for PR descriptions, apply it to the matching Ubuntu release job, and update the VM's installed packages from that suite.

Closes #1920
UDENG-11503

e2e-tests: allowed_users.robot
e2e-apt-source: resolute-proposed
